### PR TITLE
Feat/add count to GQL queries

### DIFF
--- a/src/api/entities/Proposal/__tests__/index.ts
+++ b/src/api/entities/Proposal/__tests__/index.ts
@@ -128,7 +128,9 @@ describe('Proposal class', () => {
 
       const result = await proposal.getVotes();
 
-      expect(result).toEqual(fakeResult);
+      expect(result.data).toEqual(fakeResult);
+      expect(result.next).toBeNull();
+      expect(result.count).toBeUndefined();
     });
 
     test('should throw if the middleware query fails', async () => {

--- a/src/api/entities/Proposal/index.ts
+++ b/src/api/entities/Proposal/index.ts
@@ -6,7 +6,7 @@ import { Entity, PolymeshError } from '~/base';
 import { Context } from '~/context';
 import { eventByIndexedArgs, proposalVotes } from '~/middleware/queries';
 import { EventIdEnum, ModuleIdEnum, Query } from '~/middleware/types';
-import { Ensured, ErrorCode, ProposalVotesOrderByInput } from '~/types';
+import { Ensured, ErrorCode, ProposalVotesOrderByInput, ResultSet } from '~/types';
 import { valueToDid } from '~/utils';
 
 import { ProposalVote } from './types';
@@ -107,7 +107,7 @@ export class Proposal extends Entity<UniqueIdentifiers> {
       size?: number;
       start?: number;
     } = {}
-  ): Promise<ProposalVote[]> {
+  ): Promise<ResultSet<ProposalVote>> {
     const {
       context: { middlewareApi },
       pipId,
@@ -134,12 +134,18 @@ export class Proposal extends Entity<UniqueIdentifiers> {
       });
     }
 
-    return result.data.proposalVotes.map(({ account: did, vote: proposalVote, weight }) => {
+    const data = result.data.proposalVotes.map(({ account: did, vote: proposalVote, weight }) => {
       return {
         identity: new Identity({ did }, context),
         vote: proposalVote,
         weight: new BigNumber(weight),
       };
     });
+
+    return {
+      data,
+      // TODO: replace by proper calculation once the query returns totalCount
+      next: null,
+    };
   }
 }

--- a/src/api/procedures/__tests__/modifyClaims.ts
+++ b/src/api/procedures/__tests__/modifyClaims.ts
@@ -161,18 +161,22 @@ describe('modifyClaims procedure', () => {
       didsWithClaims({
         trustedClaimIssuers: [mockContext.getCurrentIdentity().did],
         dids: [someDid, otherDid],
+        count: 2,
       }),
       {
-        didsWithClaims: [
-          {
-            did: someDid,
-            claims: [cddClaim, buyLockupClaim],
-          },
-          {
-            did: otherDid,
-            claims: [cddClaim],
-          },
-        ],
+        didsWithClaims: {
+          totalCount: 2,
+          items: [
+            {
+              did: someDid,
+              claims: [cddClaim, buyLockupClaim],
+            },
+            {
+              did: otherDid,
+              claims: [cddClaim],
+            },
+          ],
+        },
       }
     );
 
@@ -193,9 +197,13 @@ describe('modifyClaims procedure', () => {
       didsWithClaims({
         trustedClaimIssuers: [mockContext.getCurrentIdentity().did],
         dids: [someDid, otherDid],
+        count: 2,
       }),
       {
-        didsWithClaims: [],
+        didsWithClaims: {
+          totalCount: 0,
+          items: [],
+        },
       }
     );
 
@@ -219,18 +227,22 @@ describe('modifyClaims procedure', () => {
       didsWithClaims({
         trustedClaimIssuers: [mockContext.getCurrentIdentity().did],
         dids: [someDid, otherDid],
+        count: 2,
       }),
       {
-        didsWithClaims: [
-          {
-            did: someDid,
-            claims: [cddClaim, buyLockupClaim],
-          },
-          {
-            did: otherDid,
-            claims: [cddClaim],
-          },
-        ],
+        didsWithClaims: {
+          totalCount: 2,
+          items: [
+            {
+              did: someDid,
+              claims: [cddClaim, buyLockupClaim],
+            },
+            {
+              did: otherDid,
+              claims: [cddClaim],
+            },
+          ],
+        },
       }
     );
 

--- a/src/api/procedures/modifyClaims.ts
+++ b/src/api/procedures/modifyClaims.ts
@@ -97,9 +97,15 @@ export async function prepareModifyClaims(
 
   if (operation !== ClaimOperation.Add) {
     const {
-      data: { didsWithClaims: currentClaims },
+      data: {
+        didsWithClaims: { items: currentClaims },
+      },
     } = await middlewareApi.query<Ensured<Query, 'didsWithClaims'>>(
-      didsWithClaims({ dids: allTargets, trustedClaimIssuers: [context.getCurrentIdentity().did] })
+      didsWithClaims({
+        dids: allTargets,
+        trustedClaimIssuers: [context.getCurrentIdentity().did],
+        count: allTargets.length,
+      })
     );
     const claimsByDid = currentClaims.reduce<Record<string, MiddlewareClaim[]>>(
       (prev, { did, claims: didClaims }) => {

--- a/src/middleware/queries.ts
+++ b/src/middleware/queries.ts
@@ -64,16 +64,19 @@ export function didsWithClaims(
         count: $count
         skip: $skip
       ) {
-        did
-        claims {
-          targetDID
-          issuer
-          issuance_date
-          last_update_date
-          expiry
-          type
-          jurisdiction
-          scope
+        totalCount
+        items {
+          did
+          claims {
+            targetDID
+            issuer
+            issuance_date
+            last_update_date
+            expiry
+            type
+            jurisdiction
+            scope
+          }
         }
       }
     }

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -47,7 +47,7 @@ export type Query = {
   /** Get all POLYX transfers sent by the given did and/or account */
   polyxTransfersSent: Array<PolyxTransfer>;
   /** Get all dids with at least one claim for a given scope and from one the given trustedClaimIssuers */
-  didsWithClaims: Array<IdentityWithClaims>;
+  didsWithClaims: IdentityWithClaimsResult;
   /** Get all tickers of tokens that were held at some point by the given did */
   tokensHeldByDid: Array<Scalars['String']>;
   /** Get all POLYX transfers (send) failed by the given account */
@@ -819,6 +819,12 @@ export type PolyxTransfer = {
   toDID: Scalars['String'];
   toAccount: Scalars['String'];
   balance: Scalars['Float'];
+};
+
+export type IdentityWithClaimsResult = {
+  __typename?: 'IdentityWithClaimsResult';
+  totalCount: Scalars['Int'];
+  items: Array<IdentityWithClaims>;
 };
 
 export type IdentityWithClaims = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -348,11 +348,12 @@ export interface PaginationOptions {
   start?: string;
 }
 
-export type NextKey = string | null;
+export type NextKey = string | number | null;
 
 export interface ResultSet<T> {
   data: T[];
   next: NextKey;
+  count?: number;
 }
 
 export interface NetworkProperties {

--- a/src/utils/__tests__/index.ts
+++ b/src/utils/__tests__/index.ts
@@ -2123,7 +2123,7 @@ describe('batchArguments', () => {
 });
 
 describe('calculateNextKey', () => {
-  test('should return NextKey null as there are less element than default page size', () => {
+  test('should return NextKey null as there are less elements than the default page size', () => {
     const totalCount = 20;
     const nextKey = calculateNextKey(totalCount);
 

--- a/src/utils/__tests__/index.ts
+++ b/src/utils/__tests__/index.ts
@@ -2130,7 +2130,7 @@ describe('calculateNextKey', () => {
     expect(nextKey).toBeNull();
   });
 
-  test('should return NextKey null as it is latest page', () => {
+  test('should return NextKey null as it is the last page', () => {
     const totalCount = 50;
     const currentPageSize = 30;
     const currentStart = 31;

--- a/src/utils/__tests__/index.ts
+++ b/src/utils/__tests__/index.ts
@@ -65,6 +65,7 @@ import {
   booleanToBool,
   boolToBoolean,
   bytesToString,
+  calculateNextKey,
   canTransferResultToTransferStatus,
   cddStatusToBoolean,
   claimToMeshClaim,
@@ -2118,5 +2119,32 @@ describe('batchArguments', () => {
     expect(() => batchArguments(elements, tag, element => `${element % 2}`)).toThrowError(
       'Batch size exceeds limit'
     );
+  });
+});
+
+describe('calculateNextKey', () => {
+  test('should return NextKey null as there are less element than default page size', () => {
+    const totalCount = 20;
+    const nextKey = calculateNextKey(totalCount);
+
+    expect(nextKey).toBeNull();
+  });
+
+  test('should return NextKey null as it is latest page', () => {
+    const totalCount = 50;
+    const currentPageSize = 30;
+    const currentStart = 31;
+    const nextKey = calculateNextKey(totalCount, currentPageSize, currentStart);
+
+    expect(nextKey).toBeNull();
+  });
+
+  test('should return NextKey', () => {
+    const totalCount = 50;
+    const currentPageSize = 30;
+    const currentStart = 0;
+    const nextKey = calculateNextKey(totalCount, currentPageSize, currentStart);
+
+    expect(nextKey).toEqual(30);
   });
 });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -23,3 +23,4 @@ export const SS58_FORMAT = 42;
 export const MAX_CONCURRENT_REQUESTS = 200;
 export const TREASURY_MODULE_ADDRESS = 'modlpm/trsry';
 export const BATCH_REGEX = RegExp('(b|s?B)atch');
+export const DEFAULT_GQL_PAGE_SIZE = 25;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -79,6 +79,7 @@ import {
 import { tuple } from '~/types/utils';
 import {
   BATCH_REGEX,
+  DEFAULT_GQL_PAGE_SIZE,
   IGNORE_CHECKSUM,
   MAX_BATCH_ELEMENTS,
   MAX_MODULE_LENGTH,
@@ -1167,4 +1168,20 @@ export function batchArguments<Args>(
   });
 
   return batches;
+}
+
+/**
+ * Calculates next page number for paginated GraphQL ResultSet.
+ * Returns null if there is no next page.
+ *
+ * @param size - page size requested
+ * @param start - start index requestd
+ * @param totalCount - total amount of elements returned by query
+ *
+ * @hidden
+ *
+ */
+export function calculateNextKey(totalCount: number, size?: number, start?: number): NextKey {
+  const next = (start ?? 0) + (size ?? DEFAULT_GQL_PAGE_SIZE);
+  return totalCount > next ? next : null;
 }


### PR DESCRIPTION
Paginated GQL queries return a ResultSet including the total amount of records for that query, the
next key if there are more pages and the data from the query.

BREAKING CHANGE: 

- getIssuedClaims and getIdentitiesWithClaims return ResultSet<IdentityWithClaims> instead of IdentityWithClaims[]