### PR TITLE
feat: add `Governance.getTransactionArguments`

### DIFF
--- a/src/Governance.ts
+++ b/src/Governance.ts
@@ -1,10 +1,11 @@
 import BigNumber from 'bignumber.js';
+import { TxTag } from 'polymesh-types/types';
 
 import { Identity, Proposal } from '~/api/entities';
 import { createProposal, CreateProposalParams } from '~/api/procedures';
 import { TransactionQueue } from '~/base';
 import { Context } from '~/context';
-import { SubCallback, UnsubCallback } from '~/types';
+import { SubCallback, TransactionArgument, UnsubCallback } from '~/types';
 import { balanceToBigNumber, identityIdToString } from '~/utils';
 
 /**
@@ -36,6 +37,15 @@ export class Governance {
     const activeMembers = await committeeMembership.activeMembers();
 
     return activeMembers.map(member => new Identity({ did: identityIdToString(member) }, context));
+  }
+
+  /**
+   * Retrieve the types of arguments that a certain transaction requires to be run
+   *
+   * @param args.tag - tag associated with the transaction that will be executed if the proposal passes
+   */
+  public getTransactionArguments(args: { tag: TxTag }): TransactionArgument[] {
+    return this.context.getTransactionArguments(args);
   }
 
   /**

--- a/src/__tests__/Governance.ts
+++ b/src/__tests__/Governance.ts
@@ -8,11 +8,12 @@ import { TransactionQueue } from '~/base';
 import { Context } from '~/context';
 import { Governance } from '~/Governance';
 import { dsMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
 import { TxTags } from '~/types';
 import * as utilsModule from '~/utils';
 
 describe('Governance class', () => {
-  let context: Context;
+  let context: Mocked<Context>;
   let governance: Governance;
   let balanceToBigNumberStub: sinon.SinonStub<[Balance], BigNumber>;
   let fakeBalance: Balance;
@@ -50,6 +51,16 @@ describe('Governance class', () => {
       const result = await governance.getGovernanceCommitteeMembers();
 
       expect(result).toEqual(expectedMembers);
+    });
+  });
+
+  describe('method: getTransactionArguments', () => {
+    test('should return the result of context.getTransactionArguments', () => {
+      context.getTransactionArguments.returns(['fakeArguments']);
+
+      expect(governance.getTransactionArguments({ tag: TxTags.asset.CreateAsset })).toEqual([
+        'fakeArguments',
+      ]);
     });
   });
 

--- a/src/api/procedures/createProposal.ts
+++ b/src/api/procedures/createProposal.ts
@@ -6,7 +6,7 @@ import { PipId, TxTag } from 'polymesh-types/types';
 import { Proposal } from '~/api/entities';
 import { PolymeshError, PostTransactionValue, Procedure } from '~/base';
 import { Context } from '~/context';
-import { ErrorCode, Role } from '~/types';
+import { ErrorCode, Role, TransactionArgumentType } from '~/types';
 import {
   balanceToBigNumber,
   findEventRecord,
@@ -54,8 +54,20 @@ export async function prepareCreateProposal(
   } = this;
   const { description, discussionUrl, bondAmount, tag, args: transactionArguments } = args;
   const [mod, transaction] = tag.split('.');
+
+  const argumentTypes = context.getTransactionArguments({ tag });
+  const convertedArguments = transactionArguments.map((arg, index) => {
+    const argType = argumentTypes[index];
+
+    if (argType.type === TransactionArgumentType.Balance) {
+      return numberToBalance(arg as number, context);
+    }
+
+    return arg;
+  });
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const call = ((tx as any)[mod][transaction](...transactionArguments) as SubmittableExtrinsic<
+  const call = ((tx as any)[mod][transaction](...convertedArguments) as SubmittableExtrinsic<
     'promise'
   >).method;
 

--- a/src/context/__tests__/index.ts
+++ b/src/context/__tests__/index.ts
@@ -6,6 +6,7 @@ import { Identity } from '~/api/entities';
 import { Context } from '~/context';
 import { dsMockUtils } from '~/testUtils/mocks';
 import { createMockAccountKey } from '~/testUtils/mocks/dataSources';
+import { TransactionArgumentType } from '~/types';
 import * as utilsModule from '~/utils';
 
 jest.mock(
@@ -717,6 +718,293 @@ describe('Context class', () => {
       expect(() => context.getCurrentPair()).toThrow(
         'There is no account associated with the current SDK instance'
       );
+    });
+  });
+
+  describe('method: getTransactionArguments', () => {
+    test('should return a representation of the arguments of a transaction', async () => {
+      const pair = {
+        address: 'someAddress1',
+        meta: {},
+        publicKey: 'publicKey',
+      };
+      dsMockUtils.configureMocks({
+        keyringOptions: {
+          addFromSeed: pair,
+        },
+      });
+      dsMockUtils.createQueryStub('identity', 'keyToIdentityIds', {
+        returnValue: dsMockUtils.createMockOption(
+          dsMockUtils.createMockLinkedKeyInfo({
+            Unique: dsMockUtils.createMockIdentityId('someDid'),
+          })
+        ),
+      });
+      dsMockUtils.createQueryStub('protocolFee', 'coefficient', {
+        returnValue: dsMockUtils.createMockPosRatio(1, 2),
+      });
+
+      const context = await Context.create({
+        polymeshApi: dsMockUtils.getApiInstance(),
+        middlewareApi: dsMockUtils.getMiddlewareApi(),
+        seed: 'Alice'.padEnd(32, ' '),
+      });
+
+      dsMockUtils.createTxStub('asset', 'registerTicker', {
+        meta: {
+          args: [
+            {
+              type: 'Ticker',
+              name: 'ticker',
+            },
+          ],
+        },
+      });
+
+      expect(context.getTransactionArguments({ tag: TxTags.asset.RegisterTicker })).toMatchObject([
+        {
+          name: 'ticker',
+          type: TransactionArgumentType.Text,
+          optional: false,
+        },
+      ]);
+
+      dsMockUtils.createTxStub('identity', 'addClaim', {
+        meta: {
+          args: [
+            {
+              type: 'IdentityId',
+              name: 'target',
+            },
+            {
+              type: 'Claim',
+              name: 'claim',
+            },
+            {
+              type: 'Option<Moment>',
+              name: 'expiry',
+            },
+          ],
+        },
+      });
+
+      expect(context.getTransactionArguments({ tag: TxTags.identity.AddClaim })).toMatchObject([
+        {
+          name: 'target',
+          type: TransactionArgumentType.Did,
+          optional: false,
+        },
+        {
+          name: 'claim',
+          type: TransactionArgumentType.RichEnum,
+          optional: false,
+          internal: [
+            {
+              name: 'Accredited',
+              type: TransactionArgumentType.Did,
+              optional: false,
+            },
+            {
+              name: 'Affiliate',
+              type: TransactionArgumentType.Did,
+              optional: false,
+            },
+            {
+              name: 'BuyLockup',
+              type: TransactionArgumentType.Did,
+              optional: false,
+            },
+            {
+              name: 'SellLockup',
+              type: TransactionArgumentType.Did,
+              optional: false,
+            },
+            {
+              name: 'CustomerDueDiligence',
+              type: TransactionArgumentType.Null,
+              optional: false,
+            },
+            {
+              name: 'KnowYourCustomer',
+              type: TransactionArgumentType.Did,
+              optional: false,
+            },
+            {
+              name: 'Jurisdiction',
+              type: TransactionArgumentType.Tuple,
+              optional: false,
+              internal: [
+                {
+                  name: '0',
+                  type: TransactionArgumentType.Text,
+                  optional: false,
+                },
+                {
+                  name: '1',
+                  type: TransactionArgumentType.Did,
+                  optional: false,
+                },
+              ],
+            },
+            {
+              name: 'Exempted',
+              type: TransactionArgumentType.Did,
+              optional: false,
+            },
+            {
+              name: 'Blocked',
+              type: TransactionArgumentType.Did,
+              optional: false,
+            },
+            {
+              name: 'NoData',
+              type: TransactionArgumentType.Null,
+              optional: false,
+            },
+          ],
+        },
+        {
+          name: 'expiry',
+          type: TransactionArgumentType.Date,
+          optional: true,
+        },
+      ]);
+
+      dsMockUtils.createTxStub('identity', 'cddRegisterDid', {
+        meta: {
+          args: [
+            {
+              type: 'Compact<Bytes>',
+              name: 'someArg',
+            },
+          ],
+        },
+      });
+
+      expect(
+        context.getTransactionArguments({ tag: TxTags.identity.CddRegisterDid })
+      ).toMatchObject([
+        {
+          type: TransactionArgumentType.Unknown,
+          name: 'someArg',
+          optional: false,
+        },
+      ]);
+
+      dsMockUtils.createTxStub('asset', 'createAsset', {
+        meta: {
+          args: [
+            {
+              type: 'Vec<IdentityId>',
+              name: 'dids',
+            },
+          ],
+        },
+      });
+
+      expect(context.getTransactionArguments({ tag: TxTags.asset.CreateAsset })).toMatchObject([
+        {
+          type: TransactionArgumentType.Array,
+          name: 'dids',
+          optional: false,
+          internal: {
+            name: '',
+            type: TransactionArgumentType.Did,
+            optional: false,
+          },
+        },
+      ]);
+
+      dsMockUtils.createTxStub('asset', 'removeDocuments', {
+        meta: {
+          args: [
+            {
+              type: '[u8;32]',
+              name: 'someArg',
+            },
+          ],
+        },
+      });
+
+      expect(context.getTransactionArguments({ tag: TxTags.asset.RemoveDocuments })).toMatchObject([
+        {
+          type: TransactionArgumentType.Text,
+          name: 'someArg',
+          optional: false,
+        },
+      ]);
+
+      dsMockUtils.createTxStub('asset', 'setFundingRound', {
+        meta: {
+          args: [
+            {
+              type: 'Permission',
+              name: 'permission',
+            },
+          ],
+        },
+      });
+
+      expect(context.getTransactionArguments({ tag: TxTags.asset.SetFundingRound })).toMatchObject([
+        {
+          type: TransactionArgumentType.SimpleEnum,
+          name: 'permission',
+          optional: false,
+          internal: ['Full', 'Admin', 'Operator', 'SpendFunds'],
+        },
+      ]);
+
+      dsMockUtils.createTxStub('asset', 'unfreeze', {
+        meta: {
+          args: [
+            {
+              type: 'Document',
+              name: 'document',
+            },
+          ],
+        },
+      });
+
+      expect(context.getTransactionArguments({ tag: TxTags.asset.Unfreeze })).toMatchObject([
+        {
+          type: TransactionArgumentType.Object,
+          name: 'document',
+          optional: false,
+          internal: [
+            {
+              name: 'name',
+              type: TransactionArgumentType.Text,
+            },
+            {
+              name: 'uri',
+              type: TransactionArgumentType.Text,
+            },
+            {
+              name: 'content_hash',
+              type: TransactionArgumentType.Text,
+            },
+          ],
+        },
+      ]);
+
+      dsMockUtils.createTxStub('asset', 'updateDocuments', {
+        meta: {
+          args: [
+            {
+              type: 'UInt<8>',
+              name: 'someArg',
+            },
+          ],
+        },
+      });
+
+      expect(context.getTransactionArguments({ tag: TxTags.asset.UpdateDocuments })).toMatchObject([
+        {
+          type: TransactionArgumentType.Unknown,
+          name: 'someArg',
+          optional: false,
+        },
+      ]);
     });
   });
 });

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -35,6 +35,7 @@ import {
   txTagToProtocolOp,
   valueToDid,
 } from '~/utils';
+import { ROOT_TYPES } from '~/utils/constants';
 
 interface SignerData {
   currentPair: KeyringPair;
@@ -376,64 +377,6 @@ export class Context {
     } = this;
     const { types } = polymesh;
 
-    const didTypes = ['IdentityId'];
-
-    const addressTypes = [
-      'AccountId',
-      'AccountIdOf',
-      'LookupTarget',
-      'Address',
-      'AuthorityId',
-      'SessionKey',
-      'ValidatorId',
-      'AuthorityId',
-      'KeyType',
-      'SessionKey',
-    ];
-
-    const balanceTypes = ['Amount', 'AssetOf', 'Balance', 'BalanceOf'];
-
-    const numberTypes = ['u8', 'u16', 'u32', 'u64', 'u128', 'u256', 'U256', 'BlockNumber'];
-
-    const textTypes = ['String', 'Text', 'Ticker'];
-
-    const booleanTypes = ['bool'];
-
-    const dateTypes = ['Moment'];
-
-    const rootTypes: Record<
-      string,
-      | TransactionArgumentType.Did
-      | TransactionArgumentType.Address
-      | TransactionArgumentType.Balance
-      | TransactionArgumentType.Number
-      | TransactionArgumentType.Text
-      | TransactionArgumentType.Boolean
-      | TransactionArgumentType.Date
-    > = {};
-
-    didTypes.forEach(type => {
-      rootTypes[type] = TransactionArgumentType.Did;
-    });
-    addressTypes.forEach(type => {
-      rootTypes[type] = TransactionArgumentType.Address;
-    });
-    balanceTypes.forEach(type => {
-      rootTypes[type] = TransactionArgumentType.Balance;
-    });
-    numberTypes.forEach(type => {
-      rootTypes[type] = TransactionArgumentType.Number;
-    });
-    textTypes.forEach(type => {
-      rootTypes[type] = TransactionArgumentType.Text;
-    });
-    booleanTypes.forEach(type => {
-      rootTypes[type] = TransactionArgumentType.Boolean;
-    });
-    dateTypes.forEach(type => {
-      rootTypes[type] = TransactionArgumentType.Date;
-    });
-
     const [section, method] = args.tag.split('.');
 
     const getRootType = (
@@ -443,7 +386,7 @@ export class Context {
       | ArrayTransactionArgument
       | SimpleEnumTransactionArgument
       | ComplexTransactionArgument => {
-      const rootType = rootTypes[type];
+      const rootType = ROOT_TYPES[type];
 
       if (rootType) {
         return {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 import { Keyring } from '@polkadot/api';
-import { IKeyringPair } from '@polkadot/types/types';
+import { IKeyringPair, TypeDef } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 
 import { Identity } from '~/api/entities';
@@ -371,6 +371,63 @@ export enum LinkType {
   AssetOwnership = 'AssetOwnership',
   NoData = 'NoData',
 }
+
+export enum TransactionArgumentType {
+  Did = 'Did',
+  Address = 'Address',
+  Text = 'Text',
+  Boolean = 'Boolean',
+  Number = 'Number',
+  Balance = 'Balance',
+  Date = 'Date',
+  Array = 'Array',
+  Tuple = 'Tuple',
+  SimpleEnum = 'SimpleEnum',
+  RichEnum = 'RichEnum',
+  Object = 'Object',
+  Unknown = 'Unknown',
+  Null = 'Null',
+}
+
+export interface PlainTransactionArgument {
+  type: Exclude<
+    TransactionArgumentType,
+    | TransactionArgumentType.Array
+    | TransactionArgumentType.Tuple
+    | TransactionArgumentType.SimpleEnum
+    | TransactionArgumentType.RichEnum
+    | TransactionArgumentType.Object
+  >;
+}
+
+export interface ArrayTransactionArgument {
+  type: TransactionArgumentType.Array;
+  internal: TransactionArgument;
+}
+
+export interface SimpleEnumTransactionArgument {
+  type: TransactionArgumentType.SimpleEnum;
+  internal: string[];
+}
+
+export interface ComplexTransactionArgument {
+  type:
+    | TransactionArgumentType.RichEnum
+    | TransactionArgumentType.Object
+    | TransactionArgumentType.Tuple;
+  internal: TransactionArgument[];
+}
+
+export type TransactionArgument = {
+  name: string;
+  optional: boolean;
+  _rawType: TypeDef;
+} & (
+  | PlainTransactionArgument
+  | ArrayTransactionArgument
+  | SimpleEnumTransactionArgument
+  | ComplexTransactionArgument
+);
 
 export { TxTags } from 'polymesh-types/types';
 export * from '~/api/entities/types';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,8 @@
 import BigNumber from 'bignumber.js';
 import { TxTags } from 'polymesh-types/types';
 
+import { TransactionArgumentType } from '~/types';
+
 export const MAX_DECIMALS = 6;
 export const MAX_TICKER_LENGTH = 12;
 export const MAX_MODULE_LENGTH = 32;
@@ -24,3 +26,63 @@ export const MAX_CONCURRENT_REQUESTS = 200;
 export const TREASURY_MODULE_ADDRESS = 'modlpm/trsry';
 export const BATCH_REGEX = RegExp('(b|s?B)atch');
 export const DEFAULT_GQL_PAGE_SIZE = 25;
+
+const didTypes = ['IdentityId'];
+
+const addressTypes = [
+  'AccountId',
+  'AccountIdOf',
+  'LookupTarget',
+  'Address',
+  'AuthorityId',
+  'SessionKey',
+  'ValidatorId',
+  'AuthorityId',
+  'KeyType',
+  'SessionKey',
+];
+
+const balanceTypes = ['Amount', 'AssetOf', 'Balance', 'BalanceOf'];
+
+const numberTypes = ['u8', 'u16', 'u32', 'u64', 'u128', 'u256', 'U256', 'BlockNumber'];
+
+const textTypes = ['String', 'Text', 'Ticker'];
+
+const booleanTypes = ['bool'];
+
+const dateTypes = ['Moment'];
+
+const rootTypes: Record<
+  string,
+  | TransactionArgumentType.Did
+  | TransactionArgumentType.Address
+  | TransactionArgumentType.Balance
+  | TransactionArgumentType.Number
+  | TransactionArgumentType.Text
+  | TransactionArgumentType.Boolean
+  | TransactionArgumentType.Date
+> = {};
+
+didTypes.forEach(type => {
+  rootTypes[type] = TransactionArgumentType.Did;
+});
+addressTypes.forEach(type => {
+  rootTypes[type] = TransactionArgumentType.Address;
+});
+balanceTypes.forEach(type => {
+  rootTypes[type] = TransactionArgumentType.Balance;
+});
+numberTypes.forEach(type => {
+  rootTypes[type] = TransactionArgumentType.Number;
+});
+textTypes.forEach(type => {
+  rootTypes[type] = TransactionArgumentType.Text;
+});
+booleanTypes.forEach(type => {
+  rootTypes[type] = TransactionArgumentType.Boolean;
+});
+dateTypes.forEach(type => {
+  rootTypes[type] = TransactionArgumentType.Date;
+});
+
+export const ROOT_TYPES = rootTypes;


### PR DESCRIPTION
This function receives a transaction tag and returns a list of the transaction's arguments and their
types