### PR TITLE
feat: change inputs for `addClaims`, `editClaims` and `revokeClaims`

### DIFF
--- a/src/__tests__/Polymesh.ts
+++ b/src/__tests__/Polymesh.ts
@@ -16,7 +16,7 @@ import { dsMockUtils, entityMockUtils } from '~/testUtils/mocks';
 import {
   AccountBalance,
   ClaimData,
-  ClaimTargets,
+  ClaimTarget,
   ClaimType,
   ResultSet,
   Signer,
@@ -911,9 +911,9 @@ describe('Polymesh Class', () => {
         accountUri: '//uri',
       });
 
-      const claims: ClaimTargets[] = [
+      const claims: ClaimTarget[] = [
         {
-          targets: ['someDid'],
+          target: 'someDid',
           claim: {
             type: ClaimType.Accredited,
             scope: 'someIdentityId',
@@ -949,9 +949,9 @@ describe('Polymesh Class', () => {
         accountUri: '//uri',
       });
 
-      const claims: ClaimTargets[] = [
+      const claims: ClaimTarget[] = [
         {
-          targets: ['someDid'],
+          target: 'someDid',
           claim: {
             type: ClaimType.Accredited,
             scope: 'someIdentityId',
@@ -987,9 +987,9 @@ describe('Polymesh Class', () => {
         accountUri: '//uri',
       });
 
-      const claims: ClaimTargets[] = [
+      const claims: ClaimTarget[] = [
         {
-          targets: ['someDid'],
+          target: 'someDid',
           claim: {
             type: ClaimType.Accredited,
             scope: 'someIdentityId',

--- a/src/api/procedures/__tests__/modifyClaims.ts
+++ b/src/api/procedures/__tests__/modifyClaims.ts
@@ -62,11 +62,15 @@ describe('modifyClaims procedure', () => {
     args = {
       claims: [
         {
-          targets: [someDid, otherDid],
+          target: someDid,
           claim: cddClaim,
         },
         {
-          targets: [someDid],
+          target: otherDid,
+          claim: cddClaim,
+        },
+        {
+          target: someDid,
           claim: buyLockupClaim,
           expiry,
         },
@@ -280,7 +284,7 @@ describe('getRequiredRoles', () => {
     const args = {
       claims: [
         {
-          targets: ['someDid'],
+          target: 'someDid',
           claim: { type: ClaimType.CustomerDueDiligence },
         },
       ],
@@ -293,7 +297,7 @@ describe('getRequiredRoles', () => {
     const args = {
       claims: [
         {
-          targets: ['someDid'],
+          target: 'someDid',
           claim: { type: ClaimType.Accredited, scope: 'someIdentityId' },
         },
       ],

--- a/src/base/PolymeshError.ts
+++ b/src/base/PolymeshError.ts
@@ -35,3 +35,12 @@ export class PolymeshError extends Error {
     this.data = data;
   }
 }
+
+/**
+ * @hidden
+ */
+export function isPolymeshError(err: unknown): err is PolymeshError {
+  const error = err as PolymeshError;
+
+  return typeof error.code === 'string' && typeof error.message === 'string';
+}

--- a/src/base/__tests__/PolymeshError.ts
+++ b/src/base/__tests__/PolymeshError.ts
@@ -1,6 +1,7 @@
+import { Polymesh } from '~/Polymesh';
 import { ErrorCode } from '~/types';
 
-import { PolymeshError } from '../PolymeshError';
+import { isPolymeshError,PolymeshError } from '../PolymeshError';
 
 describe('Polymesh Error class', () => {
   test('should extend error', () => {
@@ -24,5 +25,17 @@ describe('Polymesh Error class', () => {
       expect(err.code).toBe(code);
       expect(err.message).toBe(`Unknown error, code: ${code}`);
     });
+  });
+});
+
+describe('isPolymeshError', () => {
+  test('should return whether the input is a PolymeshError object', () => {
+    let result = isPolymeshError(new PolymeshError({ code: ErrorCode.FatalError }));
+
+    expect(result).toBe(true);
+
+    result = isPolymeshError('Hello');
+
+    expect(result).toBe(false);
   });
 });

--- a/src/base/__tests__/PolymeshError.ts
+++ b/src/base/__tests__/PolymeshError.ts
@@ -1,7 +1,6 @@
-import { Polymesh } from '~/Polymesh';
 import { ErrorCode } from '~/types';
 
-import { isPolymeshError,PolymeshError } from '../PolymeshError';
+import { isPolymeshError, PolymeshError } from '../PolymeshError';
 
 describe('Polymesh Error class', () => {
   test('should extend error', () => {

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -1,5 +1,16 @@
+import { PolymeshError as PolymeshErrorClass } from './PolymeshError';
 import { PolymeshTransaction as PolymeshTransactionClass } from './PolymeshTransaction';
 import { TransactionQueue as TransactionQueueClass } from './TransactionQueue';
 
 export type PolymeshTransaction = InstanceType<typeof PolymeshTransactionClass>;
 export type TransactionQueue = InstanceType<typeof TransactionQueueClass>;
+export type PolymeshError = InstanceType<typeof PolymeshErrorClass>;
+
+/**
+ * @hidden
+ */
+export function isPolymeshError(err: unknown): err is PolymeshError {
+  const error = err as PolymeshError;
+
+  return typeof error.code === 'string' && typeof error.message === 'string';
+}

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -5,12 +5,4 @@ import { TransactionQueue as TransactionQueueClass } from './TransactionQueue';
 export type PolymeshTransaction = InstanceType<typeof PolymeshTransactionClass>;
 export type TransactionQueue = InstanceType<typeof TransactionQueueClass>;
 export type PolymeshError = InstanceType<typeof PolymeshErrorClass>;
-
-/**
- * @hidden
- */
-export function isPolymeshError(err: unknown): err is PolymeshError {
-  const error = err as PolymeshError;
-
-  return typeof error.code === 'string' && typeof error.message === 'string';
-}
+export { isPolymeshError } from './PolymeshError';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -317,8 +317,8 @@ export enum TransferStatus {
   FundsLimitReached = 'FundsLimitReached', // 168
 }
 
-export interface ClaimTargets {
-  targets: (string | Identity)[];
+export interface ClaimTarget {
+  target: string | Identity;
   claim: Claim;
   expiry?: Date;
 }


### PR DESCRIPTION
These functions now receive an array of `ClaimTarget` (an object with a target DID, a claim and an
optional expiry)

BREAKING CHANGE: The `ClaimTargets` interface has been replaced with `ClaimTarget`. Instead of
representing a set of identities with one claim, it now represents a single identity/claim pair