### PR TITLE
feat: export utility types and classes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,5 @@
+import BigNumber from 'bignumber.js';
+
 export { Polymesh } from './Polymesh';
+export { Keyring, WsProvider } from '@polkadot/api';
+export { BigNumber };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -470,6 +470,7 @@ export interface Signer {
 }
 
 export { TxTags } from 'polymesh-types/types';
+export { Signer as PolkadotSigner } from '@polkadot/api/types';
 export * from '~/api/entities/types';
 export * from '~/base/types';
 export { Order } from '~/middleware/types';


### PR DESCRIPTION
- export the `PolkadotSigner` type from `/types`
- export `BigNumber`, `Keyring` and `WsProvider` from the index