### PR TITLE
feat: allow the SDK to be instanced with an account that has no identity

### DIFF
--- a/docs/classes/authorizationrequest.md
+++ b/docs/classes/authorizationrequest.md
@@ -35,7 +35,7 @@ who then has to accept it in order for the ownership transfer to be complete
 
 • **authId**: *BigNumber*
 
-*Defined in [src/api/entities/AuthorizationRequest.ts:71](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/AuthorizationRequest.ts#L71)*
+*Defined in [src/api/entities/AuthorizationRequest.ts:71](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/AuthorizationRequest.ts#L71)*
 
 internal identifier for the request (used to accept/reject/cancel)
 
@@ -47,7 +47,7 @@ ___
 
 *Inherited from [Entity](entity.md).[context](entity.md#protected-context)*
 
-*Defined in [src/base/Entity.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L49)*
+*Defined in [src/base/Entity.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L49)*
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 • **data**: *[Authorization](../globals.md#authorization)*
 
-*Defined in [src/api/entities/AuthorizationRequest.ts:60](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/AuthorizationRequest.ts#L60)*
+*Defined in [src/api/entities/AuthorizationRequest.ts:60](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/AuthorizationRequest.ts#L60)*
 
 authorization request data corresponding to type of authorization
 
@@ -76,7 +76,7 @@ ___
 
 • **expiry**: *Date | null*
 
-*Defined in [src/api/entities/AuthorizationRequest.ts:66](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/AuthorizationRequest.ts#L66)*
+*Defined in [src/api/entities/AuthorizationRequest.ts:66](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/AuthorizationRequest.ts#L66)*
 
 date at which the authorization request expires and can no longer be accepted.
 At this point, a new authorization request must be emitted. Null if the request never expires
@@ -87,7 +87,7 @@ ___
 
 • **issuerIdentity**: *[Identity](identity.md)*
 
-*Defined in [src/api/entities/AuthorizationRequest.ts:44](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/AuthorizationRequest.ts#L44)*
+*Defined in [src/api/entities/AuthorizationRequest.ts:44](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/AuthorizationRequest.ts#L44)*
 
 Identity that emitted the request
 
@@ -97,7 +97,7 @@ ___
 
 • **targetIdentity**: *[Identity](identity.md)*
 
-*Defined in [src/api/entities/AuthorizationRequest.ts:39](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/AuthorizationRequest.ts#L39)*
+*Defined in [src/api/entities/AuthorizationRequest.ts:39](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/AuthorizationRequest.ts#L39)*
 
 Identity to which the request was emitted
 
@@ -109,7 +109,7 @@ ___
 
 *Inherited from [Entity](entity.md).[uuid](entity.md#uuid)*
 
-*Defined in [src/base/Entity.ts:47](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L47)*
+*Defined in [src/base/Entity.ts:47](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L47)*
 
 ## Methods
 
@@ -117,7 +117,7 @@ ___
 
 ▸ **accept**(): *Promise‹[TransactionQueue](transactionqueue.md)›*
 
-*Defined in [src/api/entities/AuthorizationRequest.ts:93](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/AuthorizationRequest.ts#L93)*
+*Defined in [src/api/entities/AuthorizationRequest.ts:93](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/AuthorizationRequest.ts#L93)*
 
 Accept the authorization request. You must be the target of the request to be able to accept it
 
@@ -129,7 +129,7 @@ ___
 
 ▸ **remove**(): *Promise‹[TransactionQueue](transactionqueue.md)›*
 
-*Defined in [src/api/entities/AuthorizationRequest.ts:106](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/AuthorizationRequest.ts#L106)*
+*Defined in [src/api/entities/AuthorizationRequest.ts:106](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/AuthorizationRequest.ts#L106)*
 
 Remove the authorization request
 
@@ -146,7 +146,7 @@ ___
 
 *Inherited from [Entity](entity.md).[generateUuid](entity.md#static-generateuuid)*
 
-*Defined in [src/base/Entity.ts:15](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L15)*
+*Defined in [src/base/Entity.ts:15](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L15)*
 
 Generate the Entity's UUID from its identifying properties
 
@@ -170,7 +170,7 @@ ___
 
 *Inherited from [Entity](entity.md).[unserialize](entity.md#static-unserialize)*
 
-*Defined in [src/base/Entity.ts:24](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L24)*
+*Defined in [src/base/Entity.ts:24](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L24)*
 
 Unserialize a UUID into its Unique Identifiers
 

--- a/docs/classes/authorizations.md
+++ b/docs/classes/authorizations.md
@@ -28,7 +28,7 @@ Handles all Identity Authorization related functionality
 
 *Inherited from void*
 
-*Defined in [src/base/Namespace.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Namespace.ts#L12)*
+*Defined in [src/base/Namespace.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Namespace.ts#L12)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 *Inherited from void*
 
-*Defined in [src/base/Namespace.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Namespace.ts#L10)*
+*Defined in [src/base/Namespace.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Namespace.ts#L10)*
 
 ## Methods
 
@@ -46,7 +46,7 @@ ___
 
 ▸ **getReceived**(`paginationOpts?`: [PaginationOptions](../interfaces/paginationoptions.md)): *Promise‹[ResultSet](../interfaces/resultset.md)‹[AuthorizationRequest](authorizationrequest.md)››*
 
-*Defined in [src/api/entities/Identity/Authorizations.ts:30](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Identity/Authorizations.ts#L30)*
+*Defined in [src/api/entities/Identity/Authorizations.ts:30](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Identity/Authorizations.ts#L30)*
 
 Fetch all pending authorization requests for which this identity is the target
 
@@ -66,7 +66,7 @@ ___
 
 ▸ **getSent**(`paginationOpts?`: [PaginationOptions](../interfaces/paginationoptions.md)): *Promise‹[ResultSet](../interfaces/resultset.md)‹[AuthorizationRequest](authorizationrequest.md)››*
 
-*Defined in [src/api/entities/Identity/Authorizations.ts:64](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Identity/Authorizations.ts#L64)*
+*Defined in [src/api/entities/Identity/Authorizations.ts:64](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Identity/Authorizations.ts#L64)*
 
 Fetch all pending authorization requests issued by this identity
 

--- a/docs/classes/compliance.md
+++ b/docs/classes/compliance.md
@@ -25,7 +25,7 @@ Handles all Security Token Compliance related functionality
 
 *Inherited from void*
 
-*Defined in [src/base/Namespace.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Namespace.ts#L12)*
+*Defined in [src/base/Namespace.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Namespace.ts#L12)*
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 *Inherited from void*
 
-*Defined in [src/base/Namespace.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Namespace.ts#L10)*
+*Defined in [src/base/Namespace.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Namespace.ts#L10)*
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 • **rules**: *[Rules](rules.md)*
 
-*Defined in [src/api/entities/SecurityToken/Compliance/index.ts:13](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Compliance/index.ts#L13)*
+*Defined in [src/api/entities/SecurityToken/Compliance/index.ts:13](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Compliance/index.ts#L13)*
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 • **trustedClaimIssuers**: *[TrustedClaimIssuers](trustedclaimissuers.md)*
 
-*Defined in [src/api/entities/SecurityToken/Compliance/index.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Compliance/index.ts#L12)*
+*Defined in [src/api/entities/SecurityToken/Compliance/index.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Compliance/index.ts#L12)*

--- a/docs/classes/documents.md
+++ b/docs/classes/documents.md
@@ -28,7 +28,7 @@ Handles all Security Token Document related functionality
 
 *Inherited from void*
 
-*Defined in [src/base/Namespace.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Namespace.ts#L12)*
+*Defined in [src/base/Namespace.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Namespace.ts#L12)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 *Inherited from void*
 
-*Defined in [src/base/Namespace.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Namespace.ts#L10)*
+*Defined in [src/base/Namespace.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Namespace.ts#L10)*
 
 ## Methods
 
@@ -46,7 +46,7 @@ ___
 
 ▸ **get**(`paginationOpts?`: [PaginationOptions](../interfaces/paginationoptions.md)): *Promise‹[ResultSet](../interfaces/resultset.md)‹[TokenDocument](../interfaces/tokendocument.md)››*
 
-*Defined in [src/api/entities/SecurityToken/Documents.ts:38](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Documents.ts#L38)*
+*Defined in [src/api/entities/SecurityToken/Documents.ts:38](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Documents.ts#L38)*
 
 Retrieve all documents linked to the Security Token
 
@@ -66,7 +66,7 @@ ___
 
 ▸ **set**(`args`: [SetTokenDocumentsParams](../interfaces/settokendocumentsparams.md)): *Promise‹[TransactionQueue](transactionqueue.md)‹[SecurityToken](securitytoken.md)››*
 
-*Defined in [src/api/entities/SecurityToken/Documents.ts:25](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Documents.ts#L25)*
+*Defined in [src/api/entities/SecurityToken/Documents.ts:25](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Documents.ts#L25)*
 
 Assign a new list of documents to the Security Token by replacing the existing list of documents with the one passed in the parameters
 

--- a/docs/classes/entity.md
+++ b/docs/classes/entity.md
@@ -41,7 +41,7 @@ Represents an object or resource in the Polymesh Ecosystem with its own set of p
 
 • **context**: *Context*
 
-*Defined in [src/base/Entity.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L49)*
+*Defined in [src/base/Entity.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L49)*
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 • **uuid**: *string*
 
-*Defined in [src/base/Entity.ts:47](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L47)*
+*Defined in [src/base/Entity.ts:47](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L47)*
 
 ## Methods
 
@@ -57,7 +57,7 @@ ___
 
 ▸ **generateUuid**‹**Identifiers**›(`identifiers`: Identifiers): *string*
 
-*Defined in [src/base/Entity.ts:15](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L15)*
+*Defined in [src/base/Entity.ts:15](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L15)*
 
 Generate the Entity's UUID from its identifying properties
 
@@ -79,7 +79,7 @@ ___
 
 ▸ **isUniqueIdentifiers**(`identifiers`: unknown): *boolean*
 
-*Defined in [src/base/Entity.ts:43](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L43)*
+*Defined in [src/base/Entity.ts:43](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L43)*
 
 Typeguard that checks whether the object passed corresponds to the unique identifiers of the class. Must be overridden
 
@@ -97,7 +97,7 @@ ___
 
 ▸ **unserialize**‹**Identifiers**›(`serialized`: string): *Identifiers*
 
-*Defined in [src/base/Entity.ts:24](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L24)*
+*Defined in [src/base/Entity.ts:24](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L24)*
 
 Unserialize a UUID into its Unique Identifiers
 

--- a/docs/classes/governance.md
+++ b/docs/classes/governance.md
@@ -23,7 +23,7 @@ Handles all Governance related functionality
 
 ▸ **createProposal**(`args`: [CreateProposalParams](../interfaces/createproposalparams.md)): *Promise‹[TransactionQueue](transactionqueue.md)‹[Proposal](proposal.md)››*
 
-*Defined in [src/Governance.ts:103](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Governance.ts#L103)*
+*Defined in [src/Governance.ts:103](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Governance.ts#L103)*
 
 Create a proposal
 
@@ -41,7 +41,7 @@ ___
 
 ▸ **getGovernanceCommitteeMembers**(): *Promise‹[Identity](identity.md)[]›*
 
-*Defined in [src/Governance.ts:36](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Governance.ts#L36)*
+*Defined in [src/Governance.ts:36](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Governance.ts#L36)*
 
 Retrieve a list of all active committee members
 
@@ -53,7 +53,7 @@ ___
 
 ▸ **getProposals**(`opts`: object): *Promise‹[Proposal](proposal.md)[]›*
 
-*Defined in [src/Governance.ts:69](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Governance.ts#L69)*
+*Defined in [src/Governance.ts:69](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Governance.ts#L69)*
 
 Retrieve a list of proposals. Can be filtered using parameters
 
@@ -77,7 +77,7 @@ ___
 
 ▸ **getTransactionArguments**(`args`: object): *[TransactionArgument](../globals.md#transactionargument)[]*
 
-*Defined in [src/Governance.ts:56](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Governance.ts#L56)*
+*Defined in [src/Governance.ts:56](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Governance.ts#L56)*
 
 Retrieve the types of arguments that a certain transaction requires to be run
 
@@ -97,7 +97,7 @@ ___
 
 ▸ **minimumProposalDeposit**(): *Promise‹BigNumber›*
 
-*Defined in [src/Governance.ts:112](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Governance.ts#L112)*
+*Defined in [src/Governance.ts:112](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Governance.ts#L112)*
 
 Get the minimum amount of POLYX that has to be deposited when creating a proposal
 
@@ -107,7 +107,7 @@ Get the minimum amount of POLYX that has to be deposited when creating a proposa
 
 ▸ **minimumProposalDeposit**(`callback`: [SubCallback](../globals.md#subcallback)‹BigNumber›): *Promise‹[UnsubCallback](../globals.md#unsubcallback)›*
 
-*Defined in [src/Governance.ts:113](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Governance.ts#L113)*
+*Defined in [src/Governance.ts:113](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Governance.ts#L113)*
 
 **Parameters:**
 
@@ -123,7 +123,7 @@ ___
 
 ▸ **proposalTimeFrames**(): *Promise‹[ProposalTimeFrames](../interfaces/proposaltimeframes.md)›*
 
-*Defined in [src/Governance.ts:146](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Governance.ts#L146)*
+*Defined in [src/Governance.ts:146](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Governance.ts#L146)*
 
 Retrieve the proposal time frames. This includes:
 
@@ -136,7 +136,7 @@ Retrieve the proposal time frames. This includes:
 
 ▸ **proposalTimeFrames**(`callback`: [SubCallback](../globals.md#subcallback)‹[ProposalTimeFrames](../interfaces/proposaltimeframes.md)›): *Promise‹[UnsubCallback](../globals.md#unsubcallback)›*
 
-*Defined in [src/Governance.ts:147](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Governance.ts#L147)*
+*Defined in [src/Governance.ts:147](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Governance.ts#L147)*
 
 **Parameters:**
 

--- a/docs/classes/identity.md
+++ b/docs/classes/identity.md
@@ -45,7 +45,7 @@ Represents an identity in the Polymesh blockchain
 
 *Overrides void*
 
-*Defined in [src/api/entities/Identity/index.ts:73](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Identity/index.ts#L73)*
+*Defined in [src/api/entities/Identity/index.ts:73](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Identity/index.ts#L73)*
 
 Create an Identity entity
 
@@ -64,7 +64,7 @@ Name | Type |
 
 • **authorizations**: *[Authorizations](authorizations.md)*
 
-*Defined in [src/api/entities/Identity/index.ts:73](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Identity/index.ts#L73)*
+*Defined in [src/api/entities/Identity/index.ts:73](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Identity/index.ts#L73)*
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 *Inherited from [Entity](entity.md).[context](entity.md#protected-context)*
 
-*Defined in [src/base/Entity.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L49)*
+*Defined in [src/base/Entity.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L49)*
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 • **did**: *string*
 
-*Defined in [src/api/entities/Identity/index.ts:70](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Identity/index.ts#L70)*
+*Defined in [src/api/entities/Identity/index.ts:70](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Identity/index.ts#L70)*
 
 identity ID as stored in the blockchain
 
@@ -94,7 +94,7 @@ ___
 
 *Inherited from [Entity](entity.md).[uuid](entity.md#uuid)*
 
-*Defined in [src/base/Entity.ts:47](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L47)*
+*Defined in [src/base/Entity.ts:47](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L47)*
 
 ## Methods
 
@@ -102,7 +102,7 @@ ___
 
 ▸ **getCddClaims**(`opts`: object): *Promise‹[ResultSet](../interfaces/resultset.md)‹[ClaimData](../interfaces/claimdata.md)››*
 
-*Defined in [src/api/entities/Identity/index.ts:249](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Identity/index.ts#L249)*
+*Defined in [src/api/entities/Identity/index.ts:251](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Identity/index.ts#L251)*
 
 Retrieve the list of cdd claims for the current identity
 
@@ -123,7 +123,7 @@ ___
 
 ▸ **getClaimScopes**(): *Promise‹[ClaimScope](../interfaces/claimscope.md)[]›*
 
-*Defined in [src/api/entities/Identity/index.ts:276](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Identity/index.ts#L276)*
+*Defined in [src/api/entities/Identity/index.ts:278](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Identity/index.ts#L278)*
 
 Retrieve all scopes in which claims have been made for this identity.
   If the scope is an asset DID, the corresponding ticker is returned as well
@@ -138,7 +138,7 @@ ___
 
 ▸ **getClaims**(`opts`: object): *Promise‹[ResultSet](../interfaces/resultset.md)‹[IdentityWithClaims](../interfaces/identitywithclaims.md)››*
 
-*Defined in [src/api/entities/Identity/index.ts:375](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Identity/index.ts#L375)*
+*Defined in [src/api/entities/Identity/index.ts:377](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Identity/index.ts#L377)*
 
 Retrieve all claims issued about this identity, grouped by claim issuer
 
@@ -163,7 +163,7 @@ ___
 
 ▸ **getHeldTokens**(`opts`: object): *Promise‹[ResultSet](../interfaces/resultset.md)‹[SecurityToken](securitytoken.md)››*
 
-*Defined in [src/api/entities/Identity/index.ts:305](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Identity/index.ts#L305)*
+*Defined in [src/api/entities/Identity/index.ts:307](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Identity/index.ts#L307)*
 
 Retrieve a list of all tokens which were held at one point by this identity
 
@@ -187,7 +187,7 @@ ___
 
 ▸ **getMasterKey**(): *Promise‹string›*
 
-*Defined in [src/api/entities/Identity/index.ts:215](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Identity/index.ts#L215)*
+*Defined in [src/api/entities/Identity/index.ts:215](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Identity/index.ts#L215)*
 
 Retrieve the master key associated with the identity
 
@@ -197,7 +197,7 @@ Retrieve the master key associated with the identity
 
 ▸ **getMasterKey**(`callback`: [SubCallback](../globals.md#subcallback)‹string›): *Promise‹[UnsubCallback](../globals.md#unsubcallback)›*
 
-*Defined in [src/api/entities/Identity/index.ts:216](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Identity/index.ts#L216)*
+*Defined in [src/api/entities/Identity/index.ts:216](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Identity/index.ts#L216)*
 
 **Parameters:**
 
@@ -213,7 +213,7 @@ ___
 
 ▸ **getTokenBalance**(`args`: object): *Promise‹BigNumber›*
 
-*Defined in [src/api/entities/Identity/index.ts:131](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Identity/index.ts#L131)*
+*Defined in [src/api/entities/Identity/index.ts:131](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Identity/index.ts#L131)*
 
 Retrieve the balance of a particular Security Token
 
@@ -231,7 +231,7 @@ Name | Type |
 
 ▸ **getTokenBalance**(`args`: object, `callback`: [SubCallback](../globals.md#subcallback)‹BigNumber›): *Promise‹[UnsubCallback](../globals.md#unsubcallback)›*
 
-*Defined in [src/api/entities/Identity/index.ts:132](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Identity/index.ts#L132)*
+*Defined in [src/api/entities/Identity/index.ts:132](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Identity/index.ts#L132)*
 
 **Parameters:**
 
@@ -251,7 +251,7 @@ ___
 
 ▸ **getTrustingTokens**(`args`: object): *Promise‹[SecurityToken](securitytoken.md)[]›*
 
-*Defined in [src/api/entities/Identity/index.ts:354](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Identity/index.ts#L354)*
+*Defined in [src/api/entities/Identity/index.ts:356](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Identity/index.ts#L356)*
 
 Get the list of tokens for which this identity is a trusted claim issuer
 
@@ -271,7 +271,7 @@ ___
 
 ▸ **hasRole**(`role`: [Role](../globals.md#role)): *Promise‹boolean›*
 
-*Defined in [src/api/entities/Identity/index.ts:90](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Identity/index.ts#L90)*
+*Defined in [src/api/entities/Identity/index.ts:90](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Identity/index.ts#L90)*
 
 Check whether this Identity possesses the specified Role
 
@@ -289,7 +289,7 @@ ___
 
 ▸ **hasRoles**(`roles`: [Role](../globals.md#role)[]): *Promise‹boolean›*
 
-*Defined in [src/api/entities/Identity/index.ts:345](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Identity/index.ts#L345)*
+*Defined in [src/api/entities/Identity/index.ts:347](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Identity/index.ts#L347)*
 
 Check whether this Identity possesses all specified roles
 
@@ -307,7 +307,7 @@ ___
 
 ▸ **hasValidCdd**(): *Promise‹boolean›*
 
-*Defined in [src/api/entities/Identity/index.ts:179](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Identity/index.ts#L179)*
+*Defined in [src/api/entities/Identity/index.ts:179](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Identity/index.ts#L179)*
 
 Check whether this Identity has a valid CDD claim
 
@@ -319,7 +319,7 @@ ___
 
 ▸ **isGcMember**(): *Promise‹boolean›*
 
-*Defined in [src/api/entities/Identity/index.ts:196](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Identity/index.ts#L196)*
+*Defined in [src/api/entities/Identity/index.ts:196](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Identity/index.ts#L196)*
 
 Check whether this Identity is Governance Committee member
 
@@ -333,7 +333,7 @@ ___
 
 *Inherited from [Entity](entity.md).[generateUuid](entity.md#static-generateuuid)*
 
-*Defined in [src/base/Entity.ts:15](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L15)*
+*Defined in [src/base/Entity.ts:15](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L15)*
 
 Generate the Entity's UUID from its identifying properties
 
@@ -357,7 +357,7 @@ ___
 
 *Inherited from [Entity](entity.md).[unserialize](entity.md#static-unserialize)*
 
-*Defined in [src/base/Entity.ts:24](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L24)*
+*Defined in [src/base/Entity.ts:24](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L24)*
 
 Unserialize a UUID into its Unique Identifiers
 

--- a/docs/classes/issuance.md
+++ b/docs/classes/issuance.md
@@ -27,7 +27,7 @@ Handles all Security Token Issuance related functionality
 
 *Inherited from void*
 
-*Defined in [src/base/Namespace.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Namespace.ts#L12)*
+*Defined in [src/base/Namespace.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Namespace.ts#L12)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 *Inherited from void*
 
-*Defined in [src/base/Namespace.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Namespace.ts#L10)*
+*Defined in [src/base/Namespace.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Namespace.ts#L10)*
 
 ## Methods
 
@@ -45,7 +45,7 @@ ___
 
 ▸ **issue**(`args`: object): *Promise‹[TransactionQueue](transactionqueue.md)‹[SecurityToken](securitytoken.md)››*
 
-*Defined in [src/api/entities/SecurityToken/Issuance.ts:16](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Issuance.ts#L16)*
+*Defined in [src/api/entities/SecurityToken/Issuance.ts:16](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Issuance.ts#L16)*
 
 Issue a certain amount of tokens to one or multiple identities. The receiving identities must comply with any receiver rules set on the token
 

--- a/docs/classes/polymesh.md
+++ b/docs/classes/polymesh.md
@@ -50,7 +50,7 @@ Main entry point of the Polymesh SDK
 
 • **governance**: *[Governance](governance.md)*
 
-*Defined in [src/Polymesh.ts:85](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L85)*
+*Defined in [src/Polymesh.ts:85](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L85)*
 
 ## Accessors
 
@@ -58,7 +58,7 @@ Main entry point of the Polymesh SDK
 
 • **get _polkadotApi**(): *ApiPromise*
 
-*Defined in [src/Polymesh.ts:779](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L779)*
+*Defined in [src/Polymesh.ts:779](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L779)*
 
 Polkadot client
 
@@ -70,7 +70,7 @@ Polkadot client
 
 ▸ **addClaims**(`args`: Omit‹[ModifyClaimsParams](../globals.md#modifyclaimsparams), "operation"›): *Promise‹[TransactionQueue](transactionqueue.md)‹void››*
 
-*Defined in [src/Polymesh.ts:409](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L409)*
+*Defined in [src/Polymesh.ts:409](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L409)*
 
 Add claims to identities
 
@@ -88,7 +88,7 @@ ___
 
 ▸ **editClaims**(`args`: Omit‹[ModifyClaimsParams](../globals.md#modifyclaimsparams), "operation"›): *Promise‹[TransactionQueue](transactionqueue.md)‹void››*
 
-*Defined in [src/Polymesh.ts:418](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L418)*
+*Defined in [src/Polymesh.ts:418](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L418)*
 
 Edit claims associated to identities (only the expiry date can be modified)
 
@@ -108,7 +108,7 @@ ___
 
 ▸ **getAccountBalance**(`args?`: undefined | object): *Promise‹[AccountBalance](../interfaces/accountbalance.md)›*
 
-*Defined in [src/Polymesh.ts:226](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L226)*
+*Defined in [src/Polymesh.ts:226](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L226)*
 
 Get the free/locked POLYX balance of an account
 
@@ -124,7 +124,7 @@ Name | Type |
 
 ▸ **getAccountBalance**(`callback`: [SubCallback](../globals.md#subcallback)‹[AccountBalance](../interfaces/accountbalance.md)›): *Promise‹[UnsubCallback](../globals.md#unsubcallback)›*
 
-*Defined in [src/Polymesh.ts:227](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L227)*
+*Defined in [src/Polymesh.ts:227](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L227)*
 
 **Parameters:**
 
@@ -136,7 +136,7 @@ Name | Type |
 
 ▸ **getAccountBalance**(`args`: object, `callback`: [SubCallback](../globals.md#subcallback)‹[AccountBalance](../interfaces/accountbalance.md)›): *Promise‹[UnsubCallback](../globals.md#unsubcallback)›*
 
-*Defined in [src/Polymesh.ts:228](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L228)*
+*Defined in [src/Polymesh.ts:228](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L228)*
 
 **Parameters:**
 
@@ -156,7 +156,7 @@ ___
 
 ▸ **getIdentitiesWithClaims**(`opts`: object): *Promise‹[ResultSet](../interfaces/resultset.md)‹[IdentityWithClaims](../interfaces/identitywithclaims.md)››*
 
-*Defined in [src/Polymesh.ts:564](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L564)*
+*Defined in [src/Polymesh.ts:564](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L564)*
 
 Retrieve a list of identities with claims associated to them. Can be filtered using parameters
 
@@ -179,9 +179,9 @@ ___
 
 ###  getIdentity
 
-▸ **getIdentity**(`args?`: undefined | object): *[Identity](identity.md)*
+▸ **getIdentity**(`args?`: undefined | object): *Promise‹[Identity](identity.md)›*
 
-*Defined in [src/Polymesh.ts:372](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L372)*
+*Defined in [src/Polymesh.ts:372](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L372)*
 
 Create an identity instance from a DID. If no DID is passed, the current identity is returned
 
@@ -191,7 +191,7 @@ Name | Type |
 ------ | ------ |
 `args?` | undefined &#124; object |
 
-**Returns:** *[Identity](identity.md)*
+**Returns:** *Promise‹[Identity](identity.md)›*
 
 ___
 
@@ -199,7 +199,7 @@ ___
 
 ▸ **getIssuedClaims**(`opts`: object): *Promise‹[ResultSet](../interfaces/resultset.md)‹[ClaimData](../interfaces/claimdata.md)››*
 
-*Defined in [src/Polymesh.ts:534](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L534)*
+*Defined in [src/Polymesh.ts:534](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L534)*
 
 Retrieve all claims issued by the current identity
 
@@ -220,7 +220,7 @@ ___
 
 ▸ **getMySigningKeys**(): *Promise‹[Signer](../interfaces/signer.md)[]›*
 
-*Defined in [src/Polymesh.ts:751](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L751)*
+*Defined in [src/Polymesh.ts:751](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L751)*
 
 Get the list of signing keys related to the current identity
 
@@ -230,7 +230,7 @@ Get the list of signing keys related to the current identity
 
 ▸ **getMySigningKeys**(`callback`: [SubCallback](../globals.md#subcallback)‹[Signer](../interfaces/signer.md)[]›): *Promise‹[UnsubCallback](../globals.md#unsubcallback)›*
 
-*Defined in [src/Polymesh.ts:752](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L752)*
+*Defined in [src/Polymesh.ts:752](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L752)*
 
 **Parameters:**
 
@@ -246,7 +246,7 @@ ___
 
 ▸ **getNetworkProperties**(): *Promise‹[NetworkProperties](../interfaces/networkproperties.md)›*
 
-*Defined in [src/Polymesh.ts:611](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L611)*
+*Defined in [src/Polymesh.ts:611](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L611)*
 
 Retrieve information for the current network
 
@@ -258,7 +258,7 @@ ___
 
 ▸ **getSecurityToken**(`args`: object): *Promise‹[SecurityToken](securitytoken.md)›*
 
-*Defined in [src/Polymesh.ts:508](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L508)*
+*Defined in [src/Polymesh.ts:508](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L508)*
 
 Retrieve a Security Token
 
@@ -278,7 +278,7 @@ ___
 
 ▸ **getSecurityTokens**(`args?`: undefined | object): *Promise‹[SecurityToken](securitytoken.md)[]›*
 
-*Defined in [src/Polymesh.ts:472](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L472)*
+*Defined in [src/Polymesh.ts:472](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L472)*
 
 Retrieve all the Security Tokens owned by an identity
 
@@ -296,7 +296,7 @@ ___
 
 ▸ **getTickerReservation**(`args`: object): *Promise‹[TickerReservation](tickerreservation.md)›*
 
-*Defined in [src/Polymesh.ts:346](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L346)*
+*Defined in [src/Polymesh.ts:346](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L346)*
 
 Retrieve a Ticker Reservation
 
@@ -316,7 +316,7 @@ ___
 
 ▸ **getTickerReservations**(`args?`: undefined | object): *Promise‹[TickerReservation](tickerreservation.md)[]›*
 
-*Defined in [src/Polymesh.ts:308](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L308)*
+*Defined in [src/Polymesh.ts:308](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L308)*
 
 Retrieve all the ticker reservations currently owned by an identity. This doesn't include tokens that
   have already been launched
@@ -335,7 +335,7 @@ ___
 
 ▸ **getTransactionFees**(`args`: object): *Promise‹BigNumber›*
 
-*Defined in [src/Polymesh.ts:393](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L393)*
+*Defined in [src/Polymesh.ts:393](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L393)*
 
 Retrieve the protocol fees associated with running a specific transaction
 
@@ -355,7 +355,7 @@ ___
 
 ▸ **getTransactionHistory**(`filters`: object): *Promise‹[ResultSet](../interfaces/resultset.md)‹[ExtrinsicData](../interfaces/extrinsicdata.md)››*
 
-*Defined in [src/Polymesh.ts:639](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L639)*
+*Defined in [src/Polymesh.ts:639](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L639)*
 
 Retrieve a list of transactions. Can be filtered using parameters
 
@@ -381,7 +381,7 @@ ___
 
 ▸ **getTreasuryAddress**(): *string*
 
-*Defined in [src/Polymesh.ts:400](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L400)*
+*Defined in [src/Polymesh.ts:400](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L400)*
 
 Get the treasury wallet address
 
@@ -393,7 +393,7 @@ ___
 
 ▸ **getTreasuryBalance**(): *Promise‹BigNumber›*
 
-*Defined in [src/Polymesh.ts:727](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L727)*
+*Defined in [src/Polymesh.ts:727](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L727)*
 
 Get the Treasury POLYX balance
 
@@ -403,7 +403,7 @@ Get the Treasury POLYX balance
 
 ▸ **getTreasuryBalance**(`callback`: [SubCallback](../globals.md#subcallback)‹BigNumber›): *Promise‹[UnsubCallback](../globals.md#unsubcallback)›*
 
-*Defined in [src/Polymesh.ts:728](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L728)*
+*Defined in [src/Polymesh.ts:728](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L728)*
 
 **Parameters:**
 
@@ -419,7 +419,7 @@ ___
 
 ▸ **isIdentityValid**(`args`: object): *Promise‹boolean›*
 
-*Defined in [src/Polymesh.ts:382](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L382)*
+*Defined in [src/Polymesh.ts:382](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L382)*
 
 Return whether the supplied identity/DID exists
 
@@ -439,7 +439,7 @@ ___
 
 ▸ **isTickerAvailable**(`args`: object): *Promise‹boolean›*
 
-*Defined in [src/Polymesh.ts:278](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L278)*
+*Defined in [src/Polymesh.ts:278](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L278)*
 
 Check if a ticker hasn't been reserved
 
@@ -457,7 +457,7 @@ Name | Type |
 
 ▸ **isTickerAvailable**(`args`: object, `callback`: [SubCallback](../globals.md#subcallback)‹boolean›): *Promise‹[UnsubCallback](../globals.md#unsubcallback)›*
 
-*Defined in [src/Polymesh.ts:279](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L279)*
+*Defined in [src/Polymesh.ts:279](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L279)*
 
 **Parameters:**
 
@@ -477,7 +477,7 @@ ___
 
 ▸ **onConnectionError**(`callback`: function): *function*
 
-*Defined in [src/Polymesh.ts:438](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L438)*
+*Defined in [src/Polymesh.ts:438](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L438)*
 
 Handle connection errors
 
@@ -505,7 +505,7 @@ ___
 
 ▸ **onDisconnect**(`callback`: function): *function*
 
-*Defined in [src/Polymesh.ts:455](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L455)*
+*Defined in [src/Polymesh.ts:455](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L455)*
 
 Handle disconnection
 
@@ -533,7 +533,7 @@ ___
 
 ▸ **removeMySigningKeys**(`args`: object): *Promise‹[TransactionQueue](transactionqueue.md)‹void››*
 
-*Defined in [src/Polymesh.ts:770](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L770)*
+*Defined in [src/Polymesh.ts:770](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L770)*
 
 Remove a list of signing keys associated with the current identity
 
@@ -553,7 +553,7 @@ ___
 
 ▸ **reserveTicker**(`args`: [ReserveTickerParams](../interfaces/reservetickerparams.md)): *Promise‹[TransactionQueue](transactionqueue.md)‹[TickerReservation](tickerreservation.md)››*
 
-*Defined in [src/Polymesh.ts:269](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L269)*
+*Defined in [src/Polymesh.ts:269](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L269)*
 
 Reserve a ticker symbol to later use in the creation of a Security Token.
 The ticker will expire after a set amount of time, after which other users can reserve it
@@ -572,7 +572,7 @@ ___
 
 ▸ **revokeClaims**(`args`: Omit‹[ModifyClaimsParams](../globals.md#modifyclaimsparams), "operation"›): *Promise‹[TransactionQueue](transactionqueue.md)‹void››*
 
-*Defined in [src/Polymesh.ts:427](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L427)*
+*Defined in [src/Polymesh.ts:427](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L427)*
 
 Revoke claims from identities
 
@@ -590,7 +590,7 @@ ___
 
 ▸ **transferPolyX**(`args`: [TransferPolyXParams](../interfaces/transferpolyxparams.md)): *Promise‹[TransactionQueue](transactionqueue.md)‹void››*
 
-*Defined in [src/Polymesh.ts:215](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L215)*
+*Defined in [src/Polymesh.ts:215](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L215)*
 
 Transfer an amount of POLYX to a specified account
 
@@ -608,7 +608,7 @@ ___
 
 ▸ **connect**(`params`: [ConnectParamsBase](../interfaces/connectparamsbase.md) & object): *Promise‹[Polymesh](polymesh.md)›*
 
-*Defined in [src/Polymesh.ts:99](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L99)*
+*Defined in [src/Polymesh.ts:99](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L99)*
 
 Create the instance and connect to the Polymesh node
 
@@ -622,7 +622,7 @@ Name | Type |
 
 ▸ **connect**(`params`: [ConnectParamsBase](../interfaces/connectparamsbase.md) & object): *Promise‹[Polymesh](polymesh.md)›*
 
-*Defined in [src/Polymesh.ts:101](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L101)*
+*Defined in [src/Polymesh.ts:101](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L101)*
 
 **Parameters:**
 
@@ -634,7 +634,7 @@ Name | Type |
 
 ▸ **connect**(`params`: [ConnectParamsBase](../interfaces/connectparamsbase.md) & object): *Promise‹[Polymesh](polymesh.md)›*
 
-*Defined in [src/Polymesh.ts:107](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L107)*
+*Defined in [src/Polymesh.ts:107](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L107)*
 
 **Parameters:**
 
@@ -646,7 +646,7 @@ Name | Type |
 
 ▸ **connect**(`params`: [ConnectParamsBase](../interfaces/connectparamsbase.md)): *Promise‹[Polymesh](polymesh.md)›*
 
-*Defined in [src/Polymesh.ts:109](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L109)*
+*Defined in [src/Polymesh.ts:109](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L109)*
 
 **Parameters:**
 

--- a/docs/classes/polymesherror.md
+++ b/docs/classes/polymesherror.md
@@ -25,7 +25,7 @@ Wraps an error to give more information about its type
 
 • **code**: *[ErrorCode](../enums/errorcode.md)*
 
-*Defined in [src/base/PolymeshError.ts:16](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/PolymeshError.ts#L16)*
+*Defined in [src/base/PolymeshError.ts:16](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/PolymeshError.ts#L16)*
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 • **data**? : *Record‹string, unknown›*
 
-*Defined in [src/base/PolymeshError.ts:18](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/PolymeshError.ts#L18)*
+*Defined in [src/base/PolymeshError.ts:18](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/PolymeshError.ts#L18)*
 
 ___
 

--- a/docs/classes/polymeshtransaction.md
+++ b/docs/classes/polymeshtransaction.md
@@ -40,7 +40,7 @@ Wrapper class for a Polymesh Transaction
 
 • **args**: *MapMaybePostTransactionValue‹Args›*
 
-*Defined in [src/base/PolymeshTransaction.ts:67](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/PolymeshTransaction.ts#L67)*
+*Defined in [src/base/PolymeshTransaction.ts:67](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/PolymeshTransaction.ts#L67)*
 
 arguments arguments for the transaction. Available after the transaction starts running
 (may be Post Transaction Values from a previous transaction in the queue that haven't resolved yet)
@@ -51,7 +51,7 @@ ___
 
 • **blockHash**? : *undefined | string*
 
-*Defined in [src/base/PolymeshTransaction.ts:56](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/PolymeshTransaction.ts#L56)*
+*Defined in [src/base/PolymeshTransaction.ts:56](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/PolymeshTransaction.ts#L56)*
 
 hash of the block where this transaction resides (status: `Succeeded`, `Failed`)
 
@@ -61,7 +61,7 @@ ___
 
 • **error**? : *[PolymeshError](polymesherror.md)*
 
-*Defined in [src/base/PolymeshTransaction.ts:41](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/PolymeshTransaction.ts#L41)*
+*Defined in [src/base/PolymeshTransaction.ts:41](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/PolymeshTransaction.ts#L41)*
 
 stores errors thrown while running the transaction (status: `Failed`, `Aborted`)
 
@@ -71,7 +71,7 @@ ___
 
 • **isCritical**: *boolean*
 
-*Defined in [src/base/PolymeshTransaction.ts:61](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/PolymeshTransaction.ts#L61)*
+*Defined in [src/base/PolymeshTransaction.ts:61](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/PolymeshTransaction.ts#L61)*
 
 whether this tx failing makes the entire tx queue fail or not
 
@@ -81,7 +81,7 @@ ___
 
 • **receipt**? : *ISubmittableResult*
 
-*Defined in [src/base/PolymeshTransaction.ts:46](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/PolymeshTransaction.ts#L46)*
+*Defined in [src/base/PolymeshTransaction.ts:46](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/PolymeshTransaction.ts#L46)*
 
 stores the transaction receipt (if successful)
 
@@ -91,7 +91,7 @@ ___
 
 • **status**: *[TransactionStatus](../enums/transactionstatus.md)* = TransactionStatus.Idle
 
-*Defined in [src/base/PolymeshTransaction.ts:36](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/PolymeshTransaction.ts#L36)*
+*Defined in [src/base/PolymeshTransaction.ts:36](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/PolymeshTransaction.ts#L36)*
 
 current status of the transaction
 
@@ -101,7 +101,7 @@ ___
 
 • **txHash**? : *undefined | string*
 
-*Defined in [src/base/PolymeshTransaction.ts:51](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/PolymeshTransaction.ts#L51)*
+*Defined in [src/base/PolymeshTransaction.ts:51](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/PolymeshTransaction.ts#L51)*
 
 transaction hash (status: `Running`, `Succeeded`, `Failed`)
 
@@ -111,7 +111,7 @@ transaction hash (status: `Running`, `Succeeded`, `Failed`)
 
 • **get tag**(): *TxTag*
 
-*Defined in [src/base/PolymeshTransaction.ts:243](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/PolymeshTransaction.ts#L243)*
+*Defined in [src/base/PolymeshTransaction.ts:243](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/PolymeshTransaction.ts#L243)*
 
 type of transaction represented by this instance for display purposes.
 If the transaction isn't defined at design time, the tag won't be set (will be empty string) until the transaction is about to be run
@@ -124,7 +124,7 @@ If the transaction isn't defined at design time, the tag won't be set (will be e
 
 ▸ **getFees**(): *Promise‹[Fees](../interfaces/fees.md) | null›*
 
-*Defined in [src/base/PolymeshTransaction.ts:203](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/PolymeshTransaction.ts#L203)*
+*Defined in [src/base/PolymeshTransaction.ts:203](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/PolymeshTransaction.ts#L203)*
 
 Get all (protocol and gas) fees associated with this transaction. Returns null
 if the transaction is not ready yet (this can happen if it depends on the execution of a
@@ -138,7 +138,7 @@ ___
 
 ▸ **onStatusChange**(`listener`: function): *function*
 
-*Defined in [src/base/PolymeshTransaction.ts:190](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/PolymeshTransaction.ts#L190)*
+*Defined in [src/base/PolymeshTransaction.ts:190](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/PolymeshTransaction.ts#L190)*
 
 Subscribe to status changes
 
@@ -168,7 +168,7 @@ ___
 
 ▸ **run**(): *Promise‹void›*
 
-*Defined in [src/base/PolymeshTransaction.ts:149](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/PolymeshTransaction.ts#L149)*
+*Defined in [src/base/PolymeshTransaction.ts:149](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/PolymeshTransaction.ts#L149)*
 
 Run the poly transaction and update the transaction status
 

--- a/docs/classes/proposal.md
+++ b/docs/classes/proposal.md
@@ -35,7 +35,7 @@ Represents a Polymesh Improvement Proposal (PIP)
 
 *Inherited from [Entity](entity.md).[context](entity.md#protected-context)*
 
-*Defined in [src/base/Entity.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L49)*
+*Defined in [src/base/Entity.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L49)*
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 • **pipId**: *number*
 
-*Defined in [src/api/entities/Proposal/index.ts:38](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/index.ts#L38)*
+*Defined in [src/api/entities/Proposal/index.ts:38](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/index.ts#L38)*
 
 internal identifier
 
@@ -55,7 +55,7 @@ ___
 
 *Inherited from [Entity](entity.md).[uuid](entity.md#uuid)*
 
-*Defined in [src/base/Entity.ts:47](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L47)*
+*Defined in [src/base/Entity.ts:47](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L47)*
 
 ## Methods
 
@@ -63,7 +63,7 @@ ___
 
 ▸ **cancel**(): *Promise‹[TransactionQueue](transactionqueue.md)‹void››*
 
-*Defined in [src/api/entities/Proposal/index.ts:141](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/index.ts#L141)*
+*Defined in [src/api/entities/Proposal/index.ts:141](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/index.ts#L141)*
 
 Cancel the proposal
 
@@ -75,7 +75,7 @@ ___
 
 ▸ **edit**(`args`: [EditProposalParams](../globals.md#editproposalparams)): *Promise‹[TransactionQueue](transactionqueue.md)‹void››*
 
-*Defined in [src/api/entities/Proposal/index.ts:133](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/index.ts#L133)*
+*Defined in [src/api/entities/Proposal/index.ts:133](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/index.ts#L133)*
 
 Edit a proposal
 
@@ -93,7 +93,7 @@ ___
 
 ▸ **getDetails**(): *Promise‹[ProposalDetails](../interfaces/proposaldetails.md)›*
 
-*Defined in [src/api/entities/Proposal/index.ts:149](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/index.ts#L149)*
+*Defined in [src/api/entities/Proposal/index.ts:149](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/index.ts#L149)*
 
 Retrieve the proposal details
 
@@ -105,7 +105,7 @@ ___
 
 ▸ **getStage**(): *Promise‹[ProposalStage](../enums/proposalstage.md)›*
 
-*Defined in [src/api/entities/Proposal/index.ts:175](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/index.ts#L175)*
+*Defined in [src/api/entities/Proposal/index.ts:175](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/index.ts#L175)*
 
 Retrieve the current stage of the proposal
 
@@ -117,7 +117,7 @@ ___
 
 ▸ **getVotes**(`opts`: object): *Promise‹[ResultSet](../interfaces/resultset.md)‹[ProposalVote](../interfaces/proposalvote.md)››*
 
-*Defined in [src/api/entities/Proposal/index.ts:91](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/index.ts#L91)*
+*Defined in [src/api/entities/Proposal/index.ts:91](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/index.ts#L91)*
 
 Retrieve all the votes of the proposal. Can be filtered using parameters
 
@@ -140,7 +140,7 @@ ___
 
 ▸ **identityHasVoted**(`args?`: undefined | object): *Promise‹boolean›*
 
-*Defined in [src/api/entities/Proposal/index.ts:56](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/index.ts#L56)*
+*Defined in [src/api/entities/Proposal/index.ts:56](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/index.ts#L56)*
 
 Check if an identity has voted on the proposal
 
@@ -160,7 +160,7 @@ ___
 
 *Inherited from [Entity](entity.md).[generateUuid](entity.md#static-generateuuid)*
 
-*Defined in [src/base/Entity.ts:15](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L15)*
+*Defined in [src/base/Entity.ts:15](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L15)*
 
 Generate the Entity's UUID from its identifying properties
 
@@ -184,7 +184,7 @@ ___
 
 *Inherited from [Entity](entity.md).[unserialize](entity.md#static-unserialize)*
 
-*Defined in [src/base/Entity.ts:24](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L24)*
+*Defined in [src/base/Entity.ts:24](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L24)*
 
 Unserialize a UUID into its Unique Identifiers
 

--- a/docs/classes/rules.md
+++ b/docs/classes/rules.md
@@ -34,7 +34,7 @@ Handles all Security Token Rules related functionality
 
 *Inherited from void*
 
-*Defined in [src/base/Namespace.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Namespace.ts#L12)*
+*Defined in [src/base/Namespace.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Namespace.ts#L12)*
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 *Inherited from void*
 
-*Defined in [src/base/Namespace.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Namespace.ts#L10)*
+*Defined in [src/base/Namespace.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Namespace.ts#L10)*
 
 ## Methods
 
@@ -52,7 +52,7 @@ ___
 
 ▸ **arePaused**(): *Promise‹boolean›*
 
-*Defined in [src/api/entities/SecurityToken/Compliance/Rules.ts:168](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Compliance/Rules.ts#L168)*
+*Defined in [src/api/entities/SecurityToken/Compliance/Rules.ts:168](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Compliance/Rules.ts#L168)*
 
 Check whether compliance rules are paused or not
 
@@ -64,7 +64,7 @@ ___
 
 ▸ **checkMint**(`args`: object): *Promise‹[RuleCompliance](../interfaces/rulecompliance.md)›*
 
-*Defined in [src/api/entities/SecurityToken/Compliance/Rules.ts:158](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Compliance/Rules.ts#L158)*
+*Defined in [src/api/entities/SecurityToken/Compliance/Rules.ts:158](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Compliance/Rules.ts#L158)*
 
 Check whether minting to an identity complies with all the rules of this asset
 
@@ -84,7 +84,7 @@ ___
 
 ▸ **checkTransfer**(`args`: object): *Promise‹[RuleCompliance](../interfaces/rulecompliance.md)›*
 
-*Defined in [src/api/entities/SecurityToken/Compliance/Rules.ts:145](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Compliance/Rules.ts#L145)*
+*Defined in [src/api/entities/SecurityToken/Compliance/Rules.ts:145](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Compliance/Rules.ts#L145)*
 
 Check whether transferring from one identity to another complies with all the rules of this asset
 
@@ -105,7 +105,7 @@ ___
 
 ▸ **get**(): *Promise‹[Rule](../interfaces/rule.md)[]›*
 
-*Defined in [src/api/entities/SecurityToken/Compliance/Rules.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Compliance/Rules.ts#L49)*
+*Defined in [src/api/entities/SecurityToken/Compliance/Rules.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Compliance/Rules.ts#L49)*
 
 Retrieve all of the Security Token's transfer rules
 
@@ -115,7 +115,7 @@ Retrieve all of the Security Token's transfer rules
 
 ▸ **get**(`callback`: [SubCallback](../globals.md#subcallback)‹[Rule](../interfaces/rule.md)[]›): *Promise‹[UnsubCallback](../globals.md#unsubcallback)›*
 
-*Defined in [src/api/entities/SecurityToken/Compliance/Rules.ts:50](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Compliance/Rules.ts#L50)*
+*Defined in [src/api/entities/SecurityToken/Compliance/Rules.ts:50](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Compliance/Rules.ts#L50)*
 
 **Parameters:**
 
@@ -131,7 +131,7 @@ ___
 
 ▸ **pause**(): *Promise‹[TransactionQueue](transactionqueue.md)‹[SecurityToken](securitytoken.md)››*
 
-*Defined in [src/api/entities/SecurityToken/Compliance/Rules.ts:120](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Compliance/Rules.ts#L120)*
+*Defined in [src/api/entities/SecurityToken/Compliance/Rules.ts:120](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Compliance/Rules.ts#L120)*
 
 Pause all the Security Token's rules. This means that all transfers and token issuance will be allowed until rules are unpaused
 
@@ -143,7 +143,7 @@ ___
 
 ▸ **reset**(): *Promise‹[TransactionQueue](transactionqueue.md)‹[SecurityToken](securitytoken.md)››*
 
-*Defined in [src/api/entities/SecurityToken/Compliance/Rules.ts:109](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Compliance/Rules.ts#L109)*
+*Defined in [src/api/entities/SecurityToken/Compliance/Rules.ts:109](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Compliance/Rules.ts#L109)*
 
 Detele all the current rules for the Security Token.
 
@@ -155,7 +155,7 @@ ___
 
 ▸ **set**(`args`: [SetTokenRulesParams](../interfaces/settokenrulesparams.md)): *Promise‹[TransactionQueue](transactionqueue.md)‹[SecurityToken](securitytoken.md)››*
 
-*Defined in [src/api/entities/SecurityToken/Compliance/Rules.ts:36](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Compliance/Rules.ts#L36)*
+*Defined in [src/api/entities/SecurityToken/Compliance/Rules.ts:36](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Compliance/Rules.ts#L36)*
 
 Configure transfer rules for the Security Token. This operation will replace all existing rules with a new rule set
 
@@ -178,7 +178,7 @@ ___
 
 ▸ **unpause**(): *Promise‹[TransactionQueue](transactionqueue.md)‹[SecurityToken](securitytoken.md)››*
 
-*Defined in [src/api/entities/SecurityToken/Compliance/Rules.ts:131](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Compliance/Rules.ts#L131)*
+*Defined in [src/api/entities/SecurityToken/Compliance/Rules.ts:131](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Compliance/Rules.ts#L131)*
 
 Un-pause all the Security Token's current rules
 

--- a/docs/classes/securitytoken.md
+++ b/docs/classes/securitytoken.md
@@ -39,7 +39,7 @@ Class used to manage all the Security Token functionality
 
 • **compliance**: *[Compliance](compliance.md)*
 
-*Defined in [src/api/entities/SecurityToken/index.ts:82](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/index.ts#L82)*
+*Defined in [src/api/entities/SecurityToken/index.ts:82](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/index.ts#L82)*
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 *Inherited from [Entity](entity.md).[context](entity.md#protected-context)*
 
-*Defined in [src/base/Entity.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L49)*
+*Defined in [src/base/Entity.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L49)*
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 • **did**: *string*
 
-*Defined in [src/api/entities/SecurityToken/index.ts:70](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/index.ts#L70)*
+*Defined in [src/api/entities/SecurityToken/index.ts:70](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/index.ts#L70)*
 
 identity id of the Security Token
 
@@ -67,7 +67,7 @@ ___
 
 • **documents**: *[Documents](documents.md)*
 
-*Defined in [src/api/entities/SecurityToken/index.ts:78](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/index.ts#L78)*
+*Defined in [src/api/entities/SecurityToken/index.ts:78](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/index.ts#L78)*
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 • **issuance**: *[Issuance](issuance.md)*
 
-*Defined in [src/api/entities/SecurityToken/index.ts:81](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/index.ts#L81)*
+*Defined in [src/api/entities/SecurityToken/index.ts:81](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/index.ts#L81)*
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 • **ticker**: *string*
 
-*Defined in [src/api/entities/SecurityToken/index.ts:75](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/index.ts#L75)*
+*Defined in [src/api/entities/SecurityToken/index.ts:75](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/index.ts#L75)*
 
 ticker of the Security Token
 
@@ -93,7 +93,7 @@ ___
 
 • **tokenHolders**: *[TokenHolders](tokenholders.md)*
 
-*Defined in [src/api/entities/SecurityToken/index.ts:80](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/index.ts#L80)*
+*Defined in [src/api/entities/SecurityToken/index.ts:80](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/index.ts#L80)*
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 • **transfers**: *[Transfers](transfers.md)*
 
-*Defined in [src/api/entities/SecurityToken/index.ts:79](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/index.ts#L79)*
+*Defined in [src/api/entities/SecurityToken/index.ts:79](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/index.ts#L79)*
 
 ___
 
@@ -111,7 +111,7 @@ ___
 
 *Inherited from [Entity](entity.md).[uuid](entity.md#uuid)*
 
-*Defined in [src/base/Entity.ts:47](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L47)*
+*Defined in [src/base/Entity.ts:47](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L47)*
 
 ## Methods
 
@@ -119,7 +119,7 @@ ___
 
 ▸ **createdAt**(): *Promise‹[EventIdentifier](../interfaces/eventidentifier.md) | null›*
 
-*Defined in [src/api/entities/SecurityToken/index.ts:261](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/index.ts#L261)*
+*Defined in [src/api/entities/SecurityToken/index.ts:261](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/index.ts#L261)*
 
 Retrieve the identifier data (block number, date and event index) of the event that was emitted when the token was created
 
@@ -133,7 +133,7 @@ ___
 
 ▸ **currentFundingRound**(): *Promise‹string›*
 
-*Defined in [src/api/entities/SecurityToken/index.ts:184](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/index.ts#L184)*
+*Defined in [src/api/entities/SecurityToken/index.ts:184](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/index.ts#L184)*
 
 Retrieve the Security Token's funding round
 
@@ -143,7 +143,7 @@ Retrieve the Security Token's funding round
 
 ▸ **currentFundingRound**(`callback`: [SubCallback](../globals.md#subcallback)‹string›): *Promise‹[UnsubCallback](../globals.md#unsubcallback)›*
 
-*Defined in [src/api/entities/SecurityToken/index.ts:185](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/index.ts#L185)*
+*Defined in [src/api/entities/SecurityToken/index.ts:185](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/index.ts#L185)*
 
 **Parameters:**
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **details**(): *Promise‹[SecurityTokenDetails](../interfaces/securitytokendetails.md)›*
 
-*Defined in [src/api/entities/SecurityToken/index.ts:131](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/index.ts#L131)*
+*Defined in [src/api/entities/SecurityToken/index.ts:131](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/index.ts#L131)*
 
 Retrieve the Security Token's name, total supply, whether it is divisible or not and the identity of the owner
 
@@ -169,7 +169,7 @@ Retrieve the Security Token's name, total supply, whether it is divisible or not
 
 ▸ **details**(`callback`: [SubCallback](../globals.md#subcallback)‹[SecurityTokenDetails](../interfaces/securitytokendetails.md)›): *Promise‹[UnsubCallback](../globals.md#unsubcallback)›*
 
-*Defined in [src/api/entities/SecurityToken/index.ts:132](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/index.ts#L132)*
+*Defined in [src/api/entities/SecurityToken/index.ts:132](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/index.ts#L132)*
 
 **Parameters:**
 
@@ -185,7 +185,7 @@ ___
 
 ▸ **getIdentifiers**(): *Promise‹[TokenIdentifier](../interfaces/tokenidentifier.md)[]›*
 
-*Defined in [src/api/entities/SecurityToken/index.ts:215](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/index.ts#L215)*
+*Defined in [src/api/entities/SecurityToken/index.ts:215](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/index.ts#L215)*
 
 Retrive the Security Token's asset identifiers list
 
@@ -195,7 +195,7 @@ Retrive the Security Token's asset identifiers list
 
 ▸ **getIdentifiers**(`callback?`: [SubCallback](../globals.md#subcallback)‹[TokenIdentifier](../interfaces/tokenidentifier.md)[]›): *Promise‹[UnsubCallback](../globals.md#unsubcallback)›*
 
-*Defined in [src/api/entities/SecurityToken/index.ts:216](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/index.ts#L216)*
+*Defined in [src/api/entities/SecurityToken/index.ts:216](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/index.ts#L216)*
 
 **Parameters:**
 
@@ -211,7 +211,7 @@ ___
 
 ▸ **modify**(`args`: [ModifyTokenParams](../globals.md#modifytokenparams)): *Promise‹[TransactionQueue](transactionqueue.md)‹[SecurityToken](securitytoken.md)››*
 
-*Defined in [src/api/entities/SecurityToken/index.ts:121](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/index.ts#L121)*
+*Defined in [src/api/entities/SecurityToken/index.ts:121](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/index.ts#L121)*
 
 Modify some properties of the Security Token
 
@@ -231,7 +231,7 @@ ___
 
 ▸ **transferOwnership**(`args`: [TransferTokenOwnershipParams](../interfaces/transfertokenownershipparams.md)): *Promise‹[TransactionQueue](transactionqueue.md)‹[SecurityToken](securitytoken.md)››*
 
-*Defined in [src/api/entities/SecurityToken/index.ts:108](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/index.ts#L108)*
+*Defined in [src/api/entities/SecurityToken/index.ts:108](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/index.ts#L108)*
 
 Transfer ownership of the Security Token to another identity. This generates an authorization request that must be accepted
 by the destinatary
@@ -252,7 +252,7 @@ ___
 
 *Inherited from [Entity](entity.md).[generateUuid](entity.md#static-generateuuid)*
 
-*Defined in [src/base/Entity.ts:15](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L15)*
+*Defined in [src/base/Entity.ts:15](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L15)*
 
 Generate the Entity's UUID from its identifying properties
 
@@ -276,7 +276,7 @@ ___
 
 *Inherited from [Entity](entity.md).[unserialize](entity.md#static-unserialize)*
 
-*Defined in [src/base/Entity.ts:24](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L24)*
+*Defined in [src/base/Entity.ts:24](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L24)*
 
 Unserialize a UUID into its Unique Identifiers
 

--- a/docs/classes/tickerreservation.md
+++ b/docs/classes/tickerreservation.md
@@ -34,7 +34,7 @@ A Ticker must be previously reserved by an identity for that identity to be able
 
 *Inherited from [Entity](entity.md).[context](entity.md#protected-context)*
 
-*Defined in [src/base/Entity.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L49)*
+*Defined in [src/base/Entity.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L49)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 • **ticker**: *string*
 
-*Defined in [src/api/entities/TickerReservation/index.ts:44](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/TickerReservation/index.ts#L44)*
+*Defined in [src/api/entities/TickerReservation/index.ts:44](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/TickerReservation/index.ts#L44)*
 
 reserved ticker
 
@@ -54,7 +54,7 @@ ___
 
 *Inherited from [Entity](entity.md).[uuid](entity.md#uuid)*
 
-*Defined in [src/base/Entity.ts:47](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L47)*
+*Defined in [src/base/Entity.ts:47](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L47)*
 
 ## Methods
 
@@ -62,7 +62,7 @@ ___
 
 ▸ **createToken**(`args`: [CreateSecurityTokenParams](../interfaces/createsecuritytokenparams.md)): *Promise‹[TransactionQueue](transactionqueue.md)‹[SecurityToken](securitytoken.md)››*
 
-*Defined in [src/api/entities/TickerReservation/index.ts:164](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/TickerReservation/index.ts#L164)*
+*Defined in [src/api/entities/TickerReservation/index.ts:164](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/TickerReservation/index.ts#L164)*
 
 Create a Security Token using the reserved ticker
 
@@ -80,7 +80,7 @@ ___
 
 ▸ **details**(): *Promise‹[TickerReservationDetails](../interfaces/tickerreservationdetails.md)›*
 
-*Defined in [src/api/entities/TickerReservation/index.ts:62](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/TickerReservation/index.ts#L62)*
+*Defined in [src/api/entities/TickerReservation/index.ts:62](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/TickerReservation/index.ts#L62)*
 
 Retrieve the reservation's owner, expiry date and status
 
@@ -90,7 +90,7 @@ Retrieve the reservation's owner, expiry date and status
 
 ▸ **details**(`callback`: [SubCallback](../globals.md#subcallback)‹[TickerReservationDetails](../interfaces/tickerreservationdetails.md)›): *Promise‹[UnsubCallback](../globals.md#unsubcallback)›*
 
-*Defined in [src/api/entities/TickerReservation/index.ts:63](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/TickerReservation/index.ts#L63)*
+*Defined in [src/api/entities/TickerReservation/index.ts:63](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/TickerReservation/index.ts#L63)*
 
 **Parameters:**
 
@@ -106,7 +106,7 @@ ___
 
 ▸ **extend**(): *Promise‹[TransactionQueue](transactionqueue.md)‹[TickerReservation](tickerreservation.md)››*
 
-*Defined in [src/api/entities/TickerReservation/index.ts:143](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/TickerReservation/index.ts#L143)*
+*Defined in [src/api/entities/TickerReservation/index.ts:143](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/TickerReservation/index.ts#L143)*
 
 Extend the reservation time period of the ticker for 60 days from now
 to later use it in the creation of a Security Token.
@@ -121,7 +121,7 @@ ___
 
 *Inherited from [Entity](entity.md).[generateUuid](entity.md#static-generateuuid)*
 
-*Defined in [src/base/Entity.ts:15](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L15)*
+*Defined in [src/base/Entity.ts:15](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L15)*
 
 Generate the Entity's UUID from its identifying properties
 
@@ -145,7 +145,7 @@ ___
 
 *Inherited from [Entity](entity.md).[unserialize](entity.md#static-unserialize)*
 
-*Defined in [src/base/Entity.ts:24](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L24)*
+*Defined in [src/base/Entity.ts:24](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L24)*
 
 Unserialize a UUID into its Unique Identifiers
 

--- a/docs/classes/tokenholders.md
+++ b/docs/classes/tokenholders.md
@@ -27,7 +27,7 @@ Handles all Security Token Holders related functionality
 
 *Inherited from void*
 
-*Defined in [src/base/Namespace.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Namespace.ts#L12)*
+*Defined in [src/base/Namespace.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Namespace.ts#L12)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 *Inherited from void*
 
-*Defined in [src/base/Namespace.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Namespace.ts#L10)*
+*Defined in [src/base/Namespace.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Namespace.ts#L10)*
 
 ## Methods
 
@@ -45,7 +45,7 @@ ___
 
 ▸ **get**(`opts`: Pick‹[TokenHolderOptions](../interfaces/tokenholderoptions.md), "canBeIssuedTo"›, `paginationOpts?`: [PaginationOptions](../interfaces/paginationoptions.md)): *Promise‹[ResultSet](../interfaces/resultset.md)‹[IdentityBalance](../interfaces/identitybalance.md) & Pick‹[TokenHolderProperties](../interfaces/tokenholderproperties.md), "canBeIssuedTo"›››*
 
-*Defined in [src/api/entities/SecurityToken/TokenHolders.ts:27](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/TokenHolders.ts#L27)*
+*Defined in [src/api/entities/SecurityToken/TokenHolders.ts:27](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/TokenHolders.ts#L27)*
 
 Retrieve all the token holders with balance
 
@@ -62,7 +62,7 @@ Name | Type | Description |
 
 ▸ **get**(`paginationOpts?`: [PaginationOptions](../interfaces/paginationoptions.md)): *Promise‹[ResultSet](../interfaces/resultset.md)‹[IdentityBalance](../interfaces/identitybalance.md)››*
 
-*Defined in [src/api/entities/SecurityToken/TokenHolders.ts:32](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/TokenHolders.ts#L32)*
+*Defined in [src/api/entities/SecurityToken/TokenHolders.ts:32](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/TokenHolders.ts#L32)*
 
 **Parameters:**
 

--- a/docs/classes/transactionqueue.md
+++ b/docs/classes/transactionqueue.md
@@ -37,7 +37,7 @@ Class to manage procedural transaction queues
 
 \+ **new TransactionQueue**(`transactions`: [TransactionSpecArray](../globals.md#transactionspecarray)‹TransactionArgs›, `returnValue`: MaybePostTransactionValue‹ReturnType›, `context`: Context): *[TransactionQueue](transactionqueue.md)*
 
-*Defined in [src/base/TransactionQueue.ts:78](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/TransactionQueue.ts#L78)*
+*Defined in [src/base/TransactionQueue.ts:78](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/TransactionQueue.ts#L78)*
 
 Create a transaction queue
 
@@ -57,7 +57,7 @@ Name | Type | Description |
 
 • **error**? : *[PolymeshError](polymesherror.md)*
 
-*Defined in [src/base/TransactionQueue.ts:52](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/TransactionQueue.ts#L52)*
+*Defined in [src/base/TransactionQueue.ts:52](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/TransactionQueue.ts#L52)*
 
 optional error information
 
@@ -67,7 +67,7 @@ ___
 
 • **status**: *[TransactionQueueStatus](../enums/transactionqueuestatus.md)* = TransactionQueueStatus.Idle
 
-*Defined in [src/base/TransactionQueue.ts:47](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/TransactionQueue.ts#L47)*
+*Defined in [src/base/TransactionQueue.ts:47](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/TransactionQueue.ts#L47)*
 
 status of the queue
 
@@ -77,7 +77,7 @@ ___
 
 • **transactions**: *PolymeshTransactionArray‹TransactionArgs›*
 
-*Defined in [src/base/TransactionQueue.ts:42](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/TransactionQueue.ts#L42)*
+*Defined in [src/base/TransactionQueue.ts:42](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/TransactionQueue.ts#L42)*
 
 transactions that will be run in the queue
 
@@ -87,7 +87,7 @@ transactions that will be run in the queue
 
 ▸ **getMinFees**(): *Promise‹[Fees](../interfaces/fees.md)›*
 
-*Defined in [src/base/TransactionQueue.ts:176](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/TransactionQueue.ts#L176)*
+*Defined in [src/base/TransactionQueue.ts:176](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/TransactionQueue.ts#L176)*
 
 Retrieves a lower bound of the fees required to execute this transaction queue.
   Transaction fees can be higher at execution time for two reasons:
@@ -105,7 +105,7 @@ ___
 
 ▸ **onStatusChange**(`listener`: function): *function*
 
-*Defined in [src/base/TransactionQueue.ts:198](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/TransactionQueue.ts#L198)*
+*Defined in [src/base/TransactionQueue.ts:198](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/TransactionQueue.ts#L198)*
 
 Subscribe to status changes on the Transaction Queue
 
@@ -135,7 +135,7 @@ ___
 
 ▸ **onTransactionStatusChange**‹**TxArgs**, **Values**›(`listener`: function): *function*
 
-*Defined in [src/base/TransactionQueue.ts:213](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/TransactionQueue.ts#L213)*
+*Defined in [src/base/TransactionQueue.ts:213](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/TransactionQueue.ts#L213)*
 
 Subscribe to status changes on individual transactions
 
@@ -172,7 +172,7 @@ ___
 
 ▸ **run**(): *Promise‹ReturnType›*
 
-*Defined in [src/base/TransactionQueue.ts:115](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/TransactionQueue.ts#L115)*
+*Defined in [src/base/TransactionQueue.ts:115](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/TransactionQueue.ts#L115)*
 
 Run the transactions in the queue in sequential order. If a transaction fails or the user refuses to sign it, one of two things can happen:
 

--- a/docs/classes/transfers.md
+++ b/docs/classes/transfers.md
@@ -32,7 +32,7 @@ Handles all Security Token Transfer related functionality
 
 *Inherited from void*
 
-*Defined in [src/base/Namespace.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Namespace.ts#L12)*
+*Defined in [src/base/Namespace.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Namespace.ts#L12)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 *Inherited from void*
 
-*Defined in [src/base/Namespace.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Namespace.ts#L10)*
+*Defined in [src/base/Namespace.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Namespace.ts#L10)*
 
 ## Methods
 
@@ -50,7 +50,7 @@ ___
 
 ▸ **areFrozen**(): *Promise‹boolean›*
 
-*Defined in [src/api/entities/SecurityToken/Transfers.ts:52](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Transfers.ts#L52)*
+*Defined in [src/api/entities/SecurityToken/Transfers.ts:52](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Transfers.ts#L52)*
 
 Check whether transfers are frozen for the Security Token
 
@@ -60,7 +60,7 @@ Check whether transfers are frozen for the Security Token
 
 ▸ **areFrozen**(`callback`: [SubCallback](../globals.md#subcallback)‹boolean›): *Promise‹[UnsubCallback](../globals.md#unsubcallback)›*
 
-*Defined in [src/api/entities/SecurityToken/Transfers.ts:53](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Transfers.ts#L53)*
+*Defined in [src/api/entities/SecurityToken/Transfers.ts:53](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Transfers.ts#L53)*
 
 **Parameters:**
 
@@ -76,7 +76,7 @@ ___
 
 ▸ **canMint**(`args`: object): *Promise‹[TransferStatus](../enums/transferstatus.md)›*
 
-*Defined in [src/api/entities/SecurityToken/Transfers.ts:102](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Transfers.ts#L102)*
+*Defined in [src/api/entities/SecurityToken/Transfers.ts:102](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Transfers.ts#L102)*
 
 Check whether it is possible to mint a certain amount of this asset
 
@@ -97,7 +97,7 @@ ___
 
 ▸ **canTransfer**(`args`: object): *Promise‹[TransferStatus](../enums/transferstatus.md)›*
 
-*Defined in [src/api/entities/SecurityToken/Transfers.ts:87](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Transfers.ts#L87)*
+*Defined in [src/api/entities/SecurityToken/Transfers.ts:87](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Transfers.ts#L87)*
 
 Check whether it is possible to transfer a certain amount of this asset between two identities
 
@@ -119,7 +119,7 @@ ___
 
 ▸ **freeze**(): *Promise‹[TransactionQueue](transactionqueue.md)‹[SecurityToken](securitytoken.md)››*
 
-*Defined in [src/api/entities/SecurityToken/Transfers.ts:28](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Transfers.ts#L28)*
+*Defined in [src/api/entities/SecurityToken/Transfers.ts:28](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Transfers.ts#L28)*
 
 Freezes transfers and minting of the Security Token
 
@@ -131,7 +131,7 @@ ___
 
 ▸ **transfer**(`args`: [TransferTokenParams](../interfaces/transfertokenparams.md)): *Promise‹[TransactionQueue](transactionqueue.md)‹[SecurityToken](securitytoken.md)››*
 
-*Defined in [src/api/entities/SecurityToken/Transfers.ts:151](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Transfers.ts#L151)*
+*Defined in [src/api/entities/SecurityToken/Transfers.ts:151](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Transfers.ts#L151)*
 
 Transfer an amount of the token to another identity.
 
@@ -149,7 +149,7 @@ ___
 
 ▸ **unfreeze**(): *Promise‹[TransactionQueue](transactionqueue.md)‹[SecurityToken](securitytoken.md)››*
 
-*Defined in [src/api/entities/SecurityToken/Transfers.ts:39](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Transfers.ts#L39)*
+*Defined in [src/api/entities/SecurityToken/Transfers.ts:39](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Transfers.ts#L39)*
 
 Unfreeze transfers and minting of the Security Token
 

--- a/docs/classes/trustedclaimissuer.md
+++ b/docs/classes/trustedclaimissuer.md
@@ -31,7 +31,7 @@ Represents a trusted claim issuer for a specific token in the Polymesh blockchai
 
 *Inherited from [Entity](entity.md).[context](entity.md#protected-context)*
 
-*Defined in [src/base/Entity.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L49)*
+*Defined in [src/base/Entity.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L49)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • **identity**: *[Identity](identity.md)*
 
-*Defined in [src/api/entities/TrustedClaimIssuer.ts:32](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/TrustedClaimIssuer.ts#L32)*
+*Defined in [src/api/entities/TrustedClaimIssuer.ts:32](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/TrustedClaimIssuer.ts#L32)*
 
 identity of the trusted claim issuer
 
@@ -49,7 +49,7 @@ ___
 
 • **ticker**: *string*
 
-*Defined in [src/api/entities/TrustedClaimIssuer.ts:37](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/TrustedClaimIssuer.ts#L37)*
+*Defined in [src/api/entities/TrustedClaimIssuer.ts:37](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/TrustedClaimIssuer.ts#L37)*
 
 ticker of the Security Token
 
@@ -61,7 +61,7 @@ ___
 
 *Inherited from [Entity](entity.md).[uuid](entity.md#uuid)*
 
-*Defined in [src/base/Entity.ts:47](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L47)*
+*Defined in [src/base/Entity.ts:47](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L47)*
 
 ## Methods
 
@@ -69,7 +69,7 @@ ___
 
 ▸ **addedAt**(): *Promise‹[EventIdentifier](../interfaces/eventidentifier.md) | null›*
 
-*Defined in [src/api/entities/TrustedClaimIssuer.ts:56](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/TrustedClaimIssuer.ts#L56)*
+*Defined in [src/api/entities/TrustedClaimIssuer.ts:56](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/TrustedClaimIssuer.ts#L56)*
 
 Retrieve the identifier data (block number, date and event index) of the event that was emitted when the token was created
 
@@ -85,7 +85,7 @@ ___
 
 *Inherited from [Entity](entity.md).[generateUuid](entity.md#static-generateuuid)*
 
-*Defined in [src/base/Entity.ts:15](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L15)*
+*Defined in [src/base/Entity.ts:15](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L15)*
 
 Generate the Entity's UUID from its identifying properties
 
@@ -109,7 +109,7 @@ ___
 
 *Inherited from [Entity](entity.md).[unserialize](entity.md#static-unserialize)*
 
-*Defined in [src/base/Entity.ts:24](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Entity.ts#L24)*
+*Defined in [src/base/Entity.ts:24](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Entity.ts#L24)*
 
 Unserialize a UUID into its Unique Identifiers
 

--- a/docs/classes/trustedclaimissuers.md
+++ b/docs/classes/trustedclaimissuers.md
@@ -30,7 +30,7 @@ Handles all Security Token Default Trusted Claim Issuers related functionality
 
 *Inherited from void*
 
-*Defined in [src/base/Namespace.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Namespace.ts#L12)*
+*Defined in [src/base/Namespace.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Namespace.ts#L12)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 *Inherited from void*
 
-*Defined in [src/base/Namespace.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Namespace.ts#L10)*
+*Defined in [src/base/Namespace.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Namespace.ts#L10)*
 
 ## Methods
 
@@ -48,7 +48,7 @@ ___
 
 ▸ **add**(`args`: [ModifyTokenTrustedClaimIssuersParams](../interfaces/modifytokentrustedclaimissuersparams.md)): *Promise‹[TransactionQueue](transactionqueue.md)‹[SecurityToken](securitytoken.md)››*
 
-*Defined in [src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts:42](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts#L42)*
+*Defined in [src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts:42](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts#L42)*
 
 Add the supplied identities to the Security Token's list of trusted claim issuers
 
@@ -66,7 +66,7 @@ ___
 
 ▸ **get**(): *Promise‹[TrustedClaimIssuer](trustedclaimissuer.md)[]›*
 
-*Defined in [src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts:76](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts#L76)*
+*Defined in [src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts:76](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts#L76)*
 
 Retrieve the current default trusted claim issuers of the Security Token
 
@@ -76,7 +76,7 @@ Retrieve the current default trusted claim issuers of the Security Token
 
 ▸ **get**(`callback`: [SubCallback](../globals.md#subcallback)‹[TrustedClaimIssuer](trustedclaimissuer.md)[]›): *Promise‹[UnsubCallback](../globals.md#unsubcallback)›*
 
-*Defined in [src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts:77](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts#L77)*
+*Defined in [src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts:77](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts#L77)*
 
 **Parameters:**
 
@@ -92,7 +92,7 @@ ___
 
 ▸ **remove**(`args`: [ModifyTokenTrustedClaimIssuersParams](../interfaces/modifytokentrustedclaimissuersparams.md)): *Promise‹[TransactionQueue](transactionqueue.md)‹[SecurityToken](securitytoken.md)››*
 
-*Defined in [src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts:58](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts#L58)*
+*Defined in [src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts:58](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts#L58)*
 
 Remove the supplied identities from the Security Token's list of trusted claim issuers   *
 
@@ -110,7 +110,7 @@ ___
 
 ▸ **set**(`args`: [ModifyTokenTrustedClaimIssuersParams](../interfaces/modifytokentrustedclaimissuersparams.md)): *Promise‹[TransactionQueue](transactionqueue.md)‹[SecurityToken](securitytoken.md)››*
 
-*Defined in [src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts:26](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts#L26)*
+*Defined in [src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts:26](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts#L26)*
 
 Assign a new default list of trusted claim issuers to the Security Token by replacing the existing ones with the list passed as a parameter
 

--- a/docs/enums/authorizationtype.md
+++ b/docs/enums/authorizationtype.md
@@ -21,7 +21,7 @@ Type of authorization request
 
 • **AddMultiSigSigner**: = "AddMultiSigSigner"
 
-*Defined in [src/types/index.ts:157](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L157)*
+*Defined in [src/types/index.ts:157](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L157)*
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 • **AttestMasterKeyRotation**: = "AttestMasterKeyRotation"
 
-*Defined in [src/types/index.ts:154](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L154)*
+*Defined in [src/types/index.ts:154](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L154)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **Custom**: = "Custom"
 
-*Defined in [src/types/index.ts:160](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L160)*
+*Defined in [src/types/index.ts:160](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L160)*
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 • **JoinIdentity**: = "JoinIdentity"
 
-*Defined in [src/types/index.ts:159](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L159)*
+*Defined in [src/types/index.ts:159](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L159)*
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 • **NoData**: = "NoData"
 
-*Defined in [src/types/index.ts:161](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L161)*
+*Defined in [src/types/index.ts:161](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L161)*
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 • **RotateMasterKey**: = "RotateMasterKey"
 
-*Defined in [src/types/index.ts:155](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L155)*
+*Defined in [src/types/index.ts:155](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L155)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 • **TransferAssetOwnership**: = "TransferAssetOwnership"
 
-*Defined in [src/types/index.ts:158](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L158)*
+*Defined in [src/types/index.ts:158](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L158)*
 
 ___
 
@@ -77,4 +77,4 @@ ___
 
 • **TransferTicker**: = "TransferTicker"
 
-*Defined in [src/types/index.ts:156](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L156)*
+*Defined in [src/types/index.ts:156](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L156)*

--- a/docs/enums/claimtype.md
+++ b/docs/enums/claimtype.md
@@ -21,7 +21,7 @@
 
 • **Accredited**: = "Accredited"
 
-*Defined in [src/types/index.ts:187](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L187)*
+*Defined in [src/types/index.ts:187](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L187)*
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 • **Affiliate**: = "Affiliate"
 
-*Defined in [src/types/index.ts:188](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L188)*
+*Defined in [src/types/index.ts:188](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L188)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **Blocked**: = "Blocked"
 
-*Defined in [src/types/index.ts:195](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L195)*
+*Defined in [src/types/index.ts:195](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L195)*
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 • **BuyLockup**: = "BuyLockup"
 
-*Defined in [src/types/index.ts:189](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L189)*
+*Defined in [src/types/index.ts:189](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L189)*
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 • **CustomerDueDiligence**: = "CustomerDueDiligence"
 
-*Defined in [src/types/index.ts:191](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L191)*
+*Defined in [src/types/index.ts:191](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L191)*
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 • **Exempted**: = "Exempted"
 
-*Defined in [src/types/index.ts:194](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L194)*
+*Defined in [src/types/index.ts:194](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L194)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 • **Jurisdiction**: = "Jurisdiction"
 
-*Defined in [src/types/index.ts:193](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L193)*
+*Defined in [src/types/index.ts:193](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L193)*
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 • **KnowYourCustomer**: = "KnowYourCustomer"
 
-*Defined in [src/types/index.ts:192](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L192)*
+*Defined in [src/types/index.ts:192](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L192)*
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 • **NoData**: = "NoData"
 
-*Defined in [src/types/index.ts:196](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L196)*
+*Defined in [src/types/index.ts:196](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L196)*
 
 ___
 
@@ -93,4 +93,4 @@ ___
 
 • **SellLockup**: = "SellLockup"
 
-*Defined in [src/types/index.ts:190](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L190)*
+*Defined in [src/types/index.ts:190](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L190)*

--- a/docs/enums/conditiontarget.md
+++ b/docs/enums/conditiontarget.md
@@ -14,7 +14,7 @@
 
 • **Both**: = "Both"
 
-*Defined in [src/types/index.ts:183](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L183)*
+*Defined in [src/types/index.ts:183](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L183)*
 
 ___
 
@@ -22,7 +22,7 @@ ___
 
 • **Receiver**: = "Receiver"
 
-*Defined in [src/types/index.ts:182](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L182)*
+*Defined in [src/types/index.ts:182](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L182)*
 
 ___
 
@@ -30,4 +30,4 @@ ___
 
 • **Sender**: = "Sender"
 
-*Defined in [src/types/index.ts:181](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L181)*
+*Defined in [src/types/index.ts:181](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L181)*

--- a/docs/enums/conditiontype.md
+++ b/docs/enums/conditiontype.md
@@ -15,7 +15,7 @@
 
 • **IsAbsent**: = "IsAbsent"
 
-*Defined in [src/types/index.ts:248](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L248)*
+*Defined in [src/types/index.ts:248](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L248)*
 
 ___
 
@@ -23,7 +23,7 @@ ___
 
 • **IsAnyOf**: = "IsAnyOf"
 
-*Defined in [src/types/index.ts:249](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L249)*
+*Defined in [src/types/index.ts:249](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L249)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 • **IsNoneOf**: = "IsNoneOf"
 
-*Defined in [src/types/index.ts:250](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L250)*
+*Defined in [src/types/index.ts:250](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L250)*
 
 ___
 
@@ -39,4 +39,4 @@ ___
 
 • **IsPresent**: = "IsPresent"
 
-*Defined in [src/types/index.ts:247](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L247)*
+*Defined in [src/types/index.ts:247](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L247)*

--- a/docs/enums/errorcode.md
+++ b/docs/enums/errorcode.md
@@ -22,7 +22,7 @@ Specifies possible types of errors in the SDK
 
 • **FatalError**: = "FatalError"
 
-*Defined in [src/types/index.ts:300](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L300)*
+*Defined in [src/types/index.ts:300](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L300)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • **IdentityNotPresent**: = "IdentityNotPresent"
 
-*Defined in [src/types/index.ts:305](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L305)*
+*Defined in [src/types/index.ts:305](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L305)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 • **InvalidUuid**: = "InvalidUuid"
 
-*Defined in [src/types/index.ts:301](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L301)*
+*Defined in [src/types/index.ts:301](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L301)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • **MiddlewareError**: = "MiddlewareError"
 
-*Defined in [src/types/index.ts:304](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L304)*
+*Defined in [src/types/index.ts:304](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L304)*
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 • **NotAuthorized**: = "NotAuthorized"
 
-*Defined in [src/types/index.ts:303](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L303)*
+*Defined in [src/types/index.ts:303](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L303)*
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 • **TransactionAborted**: = "TransactionAborted"
 
-*Defined in [src/types/index.ts:297](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L297)*
+*Defined in [src/types/index.ts:297](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L297)*
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 • **TransactionRejectedByUser**: = "TransactionRejectedByUser"
 
-*Defined in [src/types/index.ts:298](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L298)*
+*Defined in [src/types/index.ts:298](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L298)*
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 • **TransactionReverted**: = "TransactionReverted"
 
-*Defined in [src/types/index.ts:299](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L299)*
+*Defined in [src/types/index.ts:299](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L299)*
 
 ___
 
@@ -86,4 +86,4 @@ ___
 
 • **ValidationError**: = "ValidationError"
 
-*Defined in [src/types/index.ts:302](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L302)*
+*Defined in [src/types/index.ts:302](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L302)*

--- a/docs/enums/knowntokentype.md
+++ b/docs/enums/knowntokentype.md
@@ -20,7 +20,7 @@
 
 • **Commodity**: = "Commodity"
 
-*Defined in [src/types/index.ts:110](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L110)*
+*Defined in [src/types/index.ts:110](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L110)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **Derivative**: = "Derivative"
 
-*Defined in [src/types/index.ts:116](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L116)*
+*Defined in [src/types/index.ts:116](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L116)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 • **EquityCommon**: = "EquityCommon"
 
-*Defined in [src/types/index.ts:108](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L108)*
+*Defined in [src/types/index.ts:108](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L108)*
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 • **EquityPreferred**: = "EquityPreferred"
 
-*Defined in [src/types/index.ts:109](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L109)*
+*Defined in [src/types/index.ts:109](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L109)*
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 • **FixedIncome**: = "FixedIncome"
 
-*Defined in [src/types/index.ts:111](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L111)*
+*Defined in [src/types/index.ts:111](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L111)*
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 • **Fund**: = "Fund"
 
-*Defined in [src/types/index.ts:113](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L113)*
+*Defined in [src/types/index.ts:113](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L113)*
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 • **Reit**: = "Reit"
 
-*Defined in [src/types/index.ts:112](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L112)*
+*Defined in [src/types/index.ts:112](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L112)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 • **RevenueShareAgreement**: = "RevenueShareAgreement"
 
-*Defined in [src/types/index.ts:114](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L114)*
+*Defined in [src/types/index.ts:114](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L114)*
 
 ___
 
@@ -84,4 +84,4 @@ ___
 
 • **StructuredProduct**: = "StructuredProduct"
 
-*Defined in [src/types/index.ts:115](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L115)*
+*Defined in [src/types/index.ts:115](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L115)*

--- a/docs/enums/permission.md
+++ b/docs/enums/permission.md
@@ -15,7 +15,7 @@
 
 • **Admin**: = "Admin"
 
-*Defined in [src/types/index.ts:399](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L399)*
+*Defined in [src/types/index.ts:399](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L399)*
 
 ___
 
@@ -23,7 +23,7 @@ ___
 
 • **Full**: = "Full"
 
-*Defined in [src/types/index.ts:398](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L398)*
+*Defined in [src/types/index.ts:398](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L398)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 • **Operator**: = "Operator"
 
-*Defined in [src/types/index.ts:400](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L400)*
+*Defined in [src/types/index.ts:400](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L400)*
 
 ___
 
@@ -39,4 +39,4 @@ ___
 
 • **SpendFunds**: = "SpendFunds"
 
-*Defined in [src/types/index.ts:401](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L401)*
+*Defined in [src/types/index.ts:401](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L401)*

--- a/docs/enums/proposalstage.md
+++ b/docs/enums/proposalstage.md
@@ -14,7 +14,7 @@
 
 • **CoolOff**: = "CoolOff"
 
-*Defined in [src/api/entities/Proposal/types.ts:43](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L43)*
+*Defined in [src/api/entities/Proposal/types.ts:43](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L43)*
 
 ___
 
@@ -22,7 +22,7 @@ ___
 
 • **Ended**: = "Ended"
 
-*Defined in [src/api/entities/Proposal/types.ts:45](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L45)*
+*Defined in [src/api/entities/Proposal/types.ts:45](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L45)*
 
 ___
 
@@ -30,4 +30,4 @@ ___
 
 • **Open**: = "Open"
 
-*Defined in [src/api/entities/Proposal/types.ts:44](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L44)*
+*Defined in [src/api/entities/Proposal/types.ts:44](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L44)*

--- a/docs/enums/roletype.md
+++ b/docs/enums/roletype.md
@@ -14,7 +14,7 @@
 
 • **CddProvider**: = "CddProvider"
 
-*Defined in [src/types/index.ts:67](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L67)*
+*Defined in [src/types/index.ts:67](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L67)*
 
 ___
 
@@ -22,7 +22,7 @@ ___
 
 • **TickerOwner**: = "TickerOwner"
 
-*Defined in [src/types/index.ts:65](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L65)*
+*Defined in [src/types/index.ts:65](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L65)*
 
 ___
 
@@ -30,4 +30,4 @@ ___
 
 • **TokenOwner**: = "TokenOwner"
 
-*Defined in [src/types/index.ts:66](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L66)*
+*Defined in [src/types/index.ts:66](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L66)*

--- a/docs/enums/signertype.md
+++ b/docs/enums/signertype.md
@@ -13,7 +13,7 @@
 
 • **Account**: = "Account"
 
-*Defined in [src/types/index.ts:407](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L407)*
+*Defined in [src/types/index.ts:407](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L407)*
 
 ___
 
@@ -21,4 +21,4 @@ ___
 
 • **Identity**: = "Identity"
 
-*Defined in [src/types/index.ts:406](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L406)*
+*Defined in [src/types/index.ts:406](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L406)*

--- a/docs/enums/tickerreservationstatus.md
+++ b/docs/enums/tickerreservationstatus.md
@@ -14,7 +14,7 @@
 
 • **Free**: = "Free"
 
-*Defined in [src/api/entities/TickerReservation/types.ts:19](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/TickerReservation/types.ts#L19)*
+*Defined in [src/api/entities/TickerReservation/types.ts:19](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/TickerReservation/types.ts#L19)*
 
 ticker hasn't been reserved or previous reservation expired
 
@@ -24,7 +24,7 @@ ___
 
 • **Reserved**: = "Reserved"
 
-*Defined in [src/api/entities/TickerReservation/types.ts:23](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/TickerReservation/types.ts#L23)*
+*Defined in [src/api/entities/TickerReservation/types.ts:23](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/TickerReservation/types.ts#L23)*
 
 ticker is currently reserved
 
@@ -34,6 +34,6 @@ ___
 
 • **TokenCreated**: = "TokenCreated"
 
-*Defined in [src/api/entities/TickerReservation/types.ts:27](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/TickerReservation/types.ts#L27)*
+*Defined in [src/api/entities/TickerReservation/types.ts:27](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/TickerReservation/types.ts#L27)*
 
 a Security Token using this ticker has already been created

--- a/docs/enums/tokenidentifiertype.md
+++ b/docs/enums/tokenidentifiertype.md
@@ -14,7 +14,7 @@
 
 • **Cins**: = "Cins"
 
-*Defined in [src/types/index.ts:127](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L127)*
+*Defined in [src/types/index.ts:127](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L127)*
 
 ___
 
@@ -22,7 +22,7 @@ ___
 
 • **Cusip**: = "Cusip"
 
-*Defined in [src/types/index.ts:126](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L126)*
+*Defined in [src/types/index.ts:126](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L126)*
 
 ___
 
@@ -30,4 +30,4 @@ ___
 
 • **Isin**: = "Isin"
 
-*Defined in [src/types/index.ts:125](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L125)*
+*Defined in [src/types/index.ts:125](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L125)*

--- a/docs/enums/transactionargumenttype.md
+++ b/docs/enums/transactionargumenttype.md
@@ -25,7 +25,7 @@
 
 • **Address**: = "Address"
 
-*Defined in [src/types/index.ts:412](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L412)*
+*Defined in [src/types/index.ts:412](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L412)*
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 • **Array**: = "Array"
 
-*Defined in [src/types/index.ts:418](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L418)*
+*Defined in [src/types/index.ts:418](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L418)*
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 • **Balance**: = "Balance"
 
-*Defined in [src/types/index.ts:416](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L416)*
+*Defined in [src/types/index.ts:416](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L416)*
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 • **Boolean**: = "Boolean"
 
-*Defined in [src/types/index.ts:414](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L414)*
+*Defined in [src/types/index.ts:414](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L414)*
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 • **Date**: = "Date"
 
-*Defined in [src/types/index.ts:417](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L417)*
+*Defined in [src/types/index.ts:417](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L417)*
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 • **Did**: = "Did"
 
-*Defined in [src/types/index.ts:411](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L411)*
+*Defined in [src/types/index.ts:411](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L411)*
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 • **Null**: = "Null"
 
-*Defined in [src/types/index.ts:424](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L424)*
+*Defined in [src/types/index.ts:424](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L424)*
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 • **Number**: = "Number"
 
-*Defined in [src/types/index.ts:415](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L415)*
+*Defined in [src/types/index.ts:415](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L415)*
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 • **Object**: = "Object"
 
-*Defined in [src/types/index.ts:422](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L422)*
+*Defined in [src/types/index.ts:422](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L422)*
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 • **RichEnum**: = "RichEnum"
 
-*Defined in [src/types/index.ts:421](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L421)*
+*Defined in [src/types/index.ts:421](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L421)*
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 • **SimpleEnum**: = "SimpleEnum"
 
-*Defined in [src/types/index.ts:420](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L420)*
+*Defined in [src/types/index.ts:420](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L420)*
 
 ___
 
@@ -113,7 +113,7 @@ ___
 
 • **Text**: = "Text"
 
-*Defined in [src/types/index.ts:413](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L413)*
+*Defined in [src/types/index.ts:413](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L413)*
 
 ___
 
@@ -121,7 +121,7 @@ ___
 
 • **Tuple**: = "Tuple"
 
-*Defined in [src/types/index.ts:419](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L419)*
+*Defined in [src/types/index.ts:419](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L419)*
 
 ___
 
@@ -129,4 +129,4 @@ ___
 
 • **Unknown**: = "Unknown"
 
-*Defined in [src/types/index.ts:423](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L423)*
+*Defined in [src/types/index.ts:423](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L423)*

--- a/docs/enums/transactionqueuestatus.md
+++ b/docs/enums/transactionqueuestatus.md
@@ -15,7 +15,7 @@
 
 • **Failed**: = "Failed"
 
-*Defined in [src/types/index.ts:54](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L54)*
+*Defined in [src/types/index.ts:54](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L54)*
 
 a critical transaction's execution failed.
 This might mean the transaction was rejected,
@@ -27,7 +27,7 @@ ___
 
 • **Idle**: = "Idle"
 
-*Defined in [src/types/index.ts:44](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L44)*
+*Defined in [src/types/index.ts:44](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L44)*
 
 the queue is prepped to run
 
@@ -37,7 +37,7 @@ ___
 
 • **Running**: = "Running"
 
-*Defined in [src/types/index.ts:48](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L48)*
+*Defined in [src/types/index.ts:48](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L48)*
 
 transactions in the queue are being executed
 
@@ -47,7 +47,7 @@ ___
 
 • **Succeeded**: = "Succeeded"
 
-*Defined in [src/types/index.ts:59](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L59)*
+*Defined in [src/types/index.ts:59](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L59)*
 
 the queue finished running all of its transactions. Non-critical transactions
 might still have failed

--- a/docs/enums/transactionstatus.md
+++ b/docs/enums/transactionstatus.md
@@ -18,7 +18,7 @@
 
 • **Aborted**: = "Aborted"
 
-*Defined in [src/types/index.ts:37](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L37)*
+*Defined in [src/types/index.ts:37](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L37)*
 
 the transaction couldn't be broadcast. It was either dropped, usurped or invalidated
 see https://github.com/paritytech/substrate/blob/master/primitives/transaction-pool/src/pool.rs#L58-L110
@@ -29,7 +29,7 @@ ___
 
 • **Failed**: = "Failed"
 
-*Defined in [src/types/index.ts:32](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L32)*
+*Defined in [src/types/index.ts:32](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L32)*
 
 the transaction's execution failed due to a revert
 
@@ -39,7 +39,7 @@ ___
 
 • **Idle**: = "Idle"
 
-*Defined in [src/types/index.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L12)*
+*Defined in [src/types/index.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L12)*
 
 the transaction is prepped to run
 
@@ -49,7 +49,7 @@ ___
 
 • **Rejected**: = "Rejected"
 
-*Defined in [src/types/index.ts:24](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L24)*
+*Defined in [src/types/index.ts:24](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L24)*
 
 the transaction was rejected by the signer
 
@@ -59,7 +59,7 @@ ___
 
 • **Running**: = "Running"
 
-*Defined in [src/types/index.ts:20](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L20)*
+*Defined in [src/types/index.ts:20](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L20)*
 
 the transaction is being executed
 
@@ -69,7 +69,7 @@ ___
 
 • **Succeeded**: = "Succeeded"
 
-*Defined in [src/types/index.ts:28](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L28)*
+*Defined in [src/types/index.ts:28](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L28)*
 
 the transaction was run successfully
 
@@ -79,6 +79,6 @@ ___
 
 • **Unapproved**: = "Unapproved"
 
-*Defined in [src/types/index.ts:16](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L16)*
+*Defined in [src/types/index.ts:16](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L16)*
 
 the transaction is waiting for the user's signature

--- a/docs/enums/transferstatus.md
+++ b/docs/enums/transferstatus.md
@@ -28,7 +28,7 @@
 
 • **BlockedTransaction**: = "BlockedTransaction"
 
-*Defined in [src/types/index.ts:332](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L332)*
+*Defined in [src/types/index.ts:332](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L332)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 • **ComplianceFailure**: = "ComplianceFailure"
 
-*Defined in [src/types/index.ts:328](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L328)*
+*Defined in [src/types/index.ts:328](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L328)*
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 • **Failure**: = "Failure"
 
-*Defined in [src/types/index.ts:317](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L317)*
+*Defined in [src/types/index.ts:317](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L317)*
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 • **FundsLimitReached**: = "FundsLimitReached"
 
-*Defined in [src/types/index.ts:333](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L333)*
+*Defined in [src/types/index.ts:333](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L333)*
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 • **FundsLocked**: = "FundsLocked"
 
-*Defined in [src/types/index.ts:322](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L322)*
+*Defined in [src/types/index.ts:322](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L322)*
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 • **InsufficientAllowance**: = "InsufficientAllowance"
 
-*Defined in [src/types/index.ts:320](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L320)*
+*Defined in [src/types/index.ts:320](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L320)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 • **InsufficientBalance**: = "InsufficientBalance"
 
-*Defined in [src/types/index.ts:319](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L319)*
+*Defined in [src/types/index.ts:319](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L319)*
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 • **InvalidGranularity**: = "InvalidGranularity"
 
-*Defined in [src/types/index.ts:330](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L330)*
+*Defined in [src/types/index.ts:330](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L330)*
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 • **InvalidOperator**: = "InvalidOperator"
 
-*Defined in [src/types/index.ts:325](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L325)*
+*Defined in [src/types/index.ts:325](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L325)*
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 • **InvalidReceiverAddress**: = "InvalidReceiverAddress"
 
-*Defined in [src/types/index.ts:324](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L324)*
+*Defined in [src/types/index.ts:324](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L324)*
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 • **InvalidReceiverIdentity**: = "InvalidReceiverIdentity"
 
-*Defined in [src/types/index.ts:327](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L327)*
+*Defined in [src/types/index.ts:327](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L327)*
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 • **InvalidSenderAddress**: = "InvalidSenderAddress"
 
-*Defined in [src/types/index.ts:323](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L323)*
+*Defined in [src/types/index.ts:323](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L323)*
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 • **InvalidSenderIdentity**: = "InvalidSenderIdentity"
 
-*Defined in [src/types/index.ts:326](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L326)*
+*Defined in [src/types/index.ts:326](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L326)*
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 • **SmartExtensionFailure**: = "SmartExtensionFailure"
 
-*Defined in [src/types/index.ts:329](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L329)*
+*Defined in [src/types/index.ts:329](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L329)*
 
 ___
 
@@ -140,7 +140,7 @@ ___
 
 • **Success**: = "Success"
 
-*Defined in [src/types/index.ts:318](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L318)*
+*Defined in [src/types/index.ts:318](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L318)*
 
 ___
 
@@ -148,7 +148,7 @@ ___
 
 • **TransfersHalted**: = "TransfersHalted"
 
-*Defined in [src/types/index.ts:321](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L321)*
+*Defined in [src/types/index.ts:321](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L321)*
 
 ___
 
@@ -156,4 +156,4 @@ ___
 
 • **VolumeLimitReached**: = "VolumeLimitReached"
 
-*Defined in [src/types/index.ts:331](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L331)*
+*Defined in [src/types/index.ts:331](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L331)*

--- a/docs/globals.md
+++ b/docs/globals.md
@@ -145,7 +145,7 @@
 
 Ƭ **Authorization**: *object | object | object*
 
-*Defined in [src/types/index.ts:167](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L167)*
+*Defined in [src/types/index.ts:167](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L167)*
 
 Authorization request data corresponding to type
 
@@ -155,7 +155,7 @@ ___
 
 Ƭ **Claim**: *[ScopedClaim](globals.md#scopedclaim) | [UnscopedClaim](globals.md#unscopedclaim)*
 
-*Defined in [src/types/index.ts:205](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L205)*
+*Defined in [src/types/index.ts:205](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L205)*
 
 ___
 
@@ -163,7 +163,7 @@ ___
 
 Ƭ **CommonKeyring**: *Pick‹Keyring, "getPair" | "getPairs" | "addFromSeed" | "addFromUri"›*
 
-*Defined in [src/types/index.ts:353](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L353)*
+*Defined in [src/types/index.ts:353](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L353)*
 
 ___
 
@@ -171,7 +171,7 @@ ___
 
 Ƭ **Condition**: *[SingleClaimCondition](globals.md#singleclaimcondition) | [MultiClaimCondition](globals.md#multiclaimcondition)*
 
-*Defined in [src/types/index.ts:265](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L265)*
+*Defined in [src/types/index.ts:265](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L265)*
 
 ___
 
@@ -179,7 +179,7 @@ ___
 
 Ƭ **ConditionBase**: *object*
 
-*Defined in [src/types/index.ts:253](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L253)*
+*Defined in [src/types/index.ts:253](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L253)*
 
 #### Type declaration:
 
@@ -193,7 +193,7 @@ ___
 
 Ƭ **EditProposalParams**: *object | object*
 
-*Defined in [src/api/procedures/editProposal.ts:6](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/editProposal.ts#L6)*
+*Defined in [src/api/procedures/editProposal.ts:6](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/editProposal.ts#L6)*
 
 ___
 
@@ -201,7 +201,7 @@ ___
 
 Ƭ **Ensured**: *Required‹Pick‹T, K››*
 
-*Defined in [src/types/index.ts:346](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L346)*
+*Defined in [src/types/index.ts:346](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L346)*
 
 ___
 
@@ -209,7 +209,7 @@ ___
 
 Ƭ **ModifyClaimsParams**: *[AddClaimsParams](interfaces/addclaimsparams.md) | [EditClaimsParams](interfaces/editclaimsparams.md) | [RevokeClaimsParams](interfaces/revokeclaimsparams.md)*
 
-*Defined in [src/api/procedures/modifyClaims.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/modifyClaims.ts#L49)*
+*Defined in [src/api/procedures/modifyClaims.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/modifyClaims.ts#L49)*
 
 ___
 
@@ -217,7 +217,7 @@ ___
 
 Ƭ **ModifyTokenParams**: *object | object | object*
 
-*Defined in [src/api/procedures/modifyToken.ts:6](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/modifyToken.ts#L6)*
+*Defined in [src/api/procedures/modifyToken.ts:6](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/modifyToken.ts#L6)*
 
 ___
 
@@ -225,7 +225,7 @@ ___
 
 Ƭ **MultiClaimCondition**: *[ConditionBase](globals.md#conditionbase) & object*
 
-*Defined in [src/types/index.ts:260](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L260)*
+*Defined in [src/types/index.ts:260](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L260)*
 
 ___
 
@@ -233,7 +233,7 @@ ___
 
 Ƭ **Mutable**: *object*
 
-*Defined in [src/types/utils/index.ts:1](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/utils/index.ts#L1)*
+*Defined in [src/types/utils/index.ts:1](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/utils/index.ts#L1)*
 
 #### Type declaration:
 
@@ -243,7 +243,7 @@ ___
 
 Ƭ **NextKey**: *string | number | null*
 
-*Defined in [src/types/index.ts:379](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L379)*
+*Defined in [src/types/index.ts:379](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L379)*
 
 ___
 
@@ -251,7 +251,7 @@ ___
 
 Ƭ **Role**: *[TickerOwnerRole](interfaces/tickerownerrole.md) | [TokenOwnerRole](interfaces/tokenownerrole.md) | [CddProviderRole](interfaces/cddproviderrole.md)*
 
-*Defined in [src/types/index.ts:105](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L105)*
+*Defined in [src/types/index.ts:105](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L105)*
 
 ___
 
@@ -259,7 +259,7 @@ ___
 
 Ƭ **ScopedClaim**: *object | object*
 
-*Defined in [src/types/index.ts:199](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L199)*
+*Defined in [src/types/index.ts:199](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L199)*
 
 ___
 
@@ -267,7 +267,7 @@ ___
 
 Ƭ **SingleClaimCondition**: *[ConditionBase](globals.md#conditionbase) & object*
 
-*Defined in [src/types/index.ts:255](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L255)*
+*Defined in [src/types/index.ts:255](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L255)*
 
 ___
 
@@ -275,7 +275,7 @@ ___
 
 Ƭ **SubCallback**: *function*
 
-*Defined in [src/types/index.ts:342](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L342)*
+*Defined in [src/types/index.ts:342](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L342)*
 
 #### Type declaration:
 
@@ -293,7 +293,7 @@ ___
 
 Ƭ **TokenType**: *[KnownTokenType](enums/knowntokentype.md) | object*
 
-*Defined in [src/types/index.ts:122](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L122)*
+*Defined in [src/types/index.ts:122](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L122)*
 
 Type of security that the token represents
 
@@ -303,7 +303,7 @@ ___
 
 Ƭ **TransactionArgument**: *object & [PlainTransactionArgument](interfaces/plaintransactionargument.md) | [ArrayTransactionArgument](interfaces/arraytransactionargument.md) | [SimpleEnumTransactionArgument](interfaces/simpleenumtransactionargument.md) | [ComplexTransactionArgument](interfaces/complextransactionargument.md)*
 
-*Defined in [src/types/index.ts:456](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L456)*
+*Defined in [src/types/index.ts:456](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L456)*
 
 ___
 
@@ -311,7 +311,7 @@ ___
 
 Ƭ **TransactionSpecArray**: *object*
 
-*Defined in [src/base/TransactionQueue.ts:26](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/TransactionQueue.ts#L26)*
+*Defined in [src/base/TransactionQueue.ts:26](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/TransactionQueue.ts#L26)*
 
 #### Type declaration:
 
@@ -321,7 +321,7 @@ ___
 
 Ƭ **UnscopedClaim**: *object*
 
-*Defined in [src/types/index.ts:203](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L203)*
+*Defined in [src/types/index.ts:203](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L203)*
 
 #### Type declaration:
 
@@ -333,7 +333,7 @@ ___
 
 Ƭ **UnsubCallback**: *function*
 
-*Defined in [src/types/index.ts:344](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L344)*
+*Defined in [src/types/index.ts:344](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L344)*
 
 #### Type declaration:
 
@@ -345,7 +345,7 @@ ___
 
 ▸ **tickerToDid**(`ticker`: string): *string*
 
-*Defined in [src/utils/index.ts:156](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/utils/index.ts#L156)*
+*Defined in [src/utils/index.ts:156](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/utils/index.ts#L156)*
 
 Generate a Security Token's DID from a ticker
 
@@ -363,7 +363,7 @@ ___
 
 ▸ **tuple**‹**T**›(...`args`: T): *T*
 
-*Defined in [src/types/utils/index.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/utils/index.ts#L10)*
+*Defined in [src/types/utils/index.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/utils/index.ts#L10)*
 
 Create a literal tuple type from a list of arguments
 
@@ -385,22 +385,22 @@ Name | Type | Description |
 
 ### ▪ **ErrorMessagesPerCode**: *object*
 
-*Defined in [src/base/PolymeshError.ts:3](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/PolymeshError.ts#L3)*
+*Defined in [src/base/PolymeshError.ts:3](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/PolymeshError.ts#L3)*
 
 ###  [ErrorCode.TransactionAborted]
 
 • **[ErrorCode.TransactionAborted]**: *string* = "The transaction was removed from the transaction pool. This might mean that it was malformed (nonce too large/nonce too small/duplicated or invalid transaction)"
 
-*Defined in [src/base/PolymeshError.ts:7](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/PolymeshError.ts#L7)*
+*Defined in [src/base/PolymeshError.ts:7](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/PolymeshError.ts#L7)*
 
 ###  [ErrorCode.TransactionRejectedByUser]
 
 • **[ErrorCode.TransactionRejectedByUser]**: *string* = "The user canceled the transaction signature"
 
-*Defined in [src/base/PolymeshError.ts:9](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/PolymeshError.ts#L9)*
+*Defined in [src/base/PolymeshError.ts:9](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/PolymeshError.ts#L9)*
 
 ###  [ErrorCode.TransactionReverted]
 
 • **[ErrorCode.TransactionReverted]**: *string* = "The transaction execution reverted due to an error"
 
-*Defined in [src/base/PolymeshError.ts:6](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/PolymeshError.ts#L6)*
+*Defined in [src/base/PolymeshError.ts:6](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/PolymeshError.ts#L6)*

--- a/docs/interfaces/accountbalance.md
+++ b/docs/interfaces/accountbalance.md
@@ -17,7 +17,7 @@
 
 • **free**: *BigNumber*
 
-*Defined in [src/types/index.ts:370](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L370)*
+*Defined in [src/types/index.ts:370](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L370)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **locked**: *BigNumber*
 
-*Defined in [src/types/index.ts:371](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L371)*
+*Defined in [src/types/index.ts:371](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L371)*

--- a/docs/interfaces/addclaimitem.md
+++ b/docs/interfaces/addclaimitem.md
@@ -18,7 +18,7 @@
 
 • **claim**: *MeshClaim*
 
-*Defined in [src/api/procedures/modifyClaims.ts:30](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/modifyClaims.ts#L30)*
+*Defined in [src/api/procedures/modifyClaims.ts:30](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/modifyClaims.ts#L30)*
 
 ___
 
@@ -26,7 +26,7 @@ ___
 
 • **expiry**: *Moment | null*
 
-*Defined in [src/api/procedures/modifyClaims.ts:31](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/modifyClaims.ts#L31)*
+*Defined in [src/api/procedures/modifyClaims.ts:31](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/modifyClaims.ts#L31)*
 
 ___
 
@@ -34,4 +34,4 @@ ___
 
 • **target**: *IdentityId*
 
-*Defined in [src/api/procedures/modifyClaims.ts:29](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/modifyClaims.ts#L29)*
+*Defined in [src/api/procedures/modifyClaims.ts:29](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/modifyClaims.ts#L29)*

--- a/docs/interfaces/addclaimsparams.md
+++ b/docs/interfaces/addclaimsparams.md
@@ -17,7 +17,7 @@
 
 • **claims**: *[ClaimTarget](claimtarget.md)[]*
 
-*Defined in [src/api/procedures/modifyClaims.ts:35](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/modifyClaims.ts#L35)*
+*Defined in [src/api/procedures/modifyClaims.ts:35](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/modifyClaims.ts#L35)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **operation**: *Add*
 
-*Defined in [src/api/procedures/modifyClaims.ts:36](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/modifyClaims.ts#L36)*
+*Defined in [src/api/procedures/modifyClaims.ts:36](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/modifyClaims.ts#L36)*

--- a/docs/interfaces/addtransactionopts.md
+++ b/docs/interfaces/addtransactionopts.md
@@ -24,7 +24,7 @@
 
 • **batchSize**? : *undefined | number*
 
-*Defined in [src/base/Procedure.ts:23](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Procedure.ts#L23)*
+*Defined in [src/base/Procedure.ts:23](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Procedure.ts#L23)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • **fee**? : *BigNumber*
 
-*Defined in [src/base/Procedure.ts:19](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Procedure.ts#L19)*
+*Defined in [src/base/Procedure.ts:19](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Procedure.ts#L19)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **isCritical**? : *undefined | false | true*
 
-*Defined in [src/base/Procedure.ts:21](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Procedure.ts#L21)*
+*Defined in [src/base/Procedure.ts:21](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Procedure.ts#L21)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **resolvers**? : *ResolverFunctionArray‹Values›*
 
-*Defined in [src/base/Procedure.ts:20](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Procedure.ts#L20)*
+*Defined in [src/base/Procedure.ts:20](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Procedure.ts#L20)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • **signer**? : *AddressOrPair*
 
-*Defined in [src/base/Procedure.ts:22](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/base/Procedure.ts#L22)*
+*Defined in [src/base/Procedure.ts:22](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/base/Procedure.ts#L22)*

--- a/docs/interfaces/arraytransactionargument.md
+++ b/docs/interfaces/arraytransactionargument.md
@@ -17,7 +17,7 @@
 
 • **internal**: *[TransactionArgument](../globals.md#transactionargument)*
 
-*Defined in [src/types/index.ts:440](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L440)*
+*Defined in [src/types/index.ts:440](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L440)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **type**: *[Array](../enums/transactionargumenttype.md#array)*
 
-*Defined in [src/types/index.ts:439](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L439)*
+*Defined in [src/types/index.ts:439](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L439)*

--- a/docs/interfaces/call.md
+++ b/docs/interfaces/call.md
@@ -19,7 +19,7 @@
 
 • **args**: *[CallArguments](callarguments.md)[]*
 
-*Defined in [src/api/entities/Proposal/types.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L12)*
+*Defined in [src/api/entities/Proposal/types.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L12)*
 
 ___
 
@@ -27,7 +27,7 @@ ___
 
 • **extrinsic**: *string*
 
-*Defined in [src/api/entities/Proposal/types.ts:14](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L14)*
+*Defined in [src/api/entities/Proposal/types.ts:14](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L14)*
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 • **functionalCall**: *string*
 
-*Defined in [src/api/entities/Proposal/types.ts:13](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L13)*
+*Defined in [src/api/entities/Proposal/types.ts:13](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L13)*
 
 ___
 
@@ -43,4 +43,4 @@ ___
 
 • **module**: *string*
 
-*Defined in [src/api/entities/Proposal/types.ts:15](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L15)*
+*Defined in [src/api/entities/Proposal/types.ts:15](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L15)*

--- a/docs/interfaces/callarguments.md
+++ b/docs/interfaces/callarguments.md
@@ -17,7 +17,7 @@
 
 • **name**: *string*
 
-*Defined in [src/api/entities/Proposal/types.ts:7](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L7)*
+*Defined in [src/api/entities/Proposal/types.ts:7](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L7)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **value**: *string*
 
-*Defined in [src/api/entities/Proposal/types.ts:8](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L8)*
+*Defined in [src/api/entities/Proposal/types.ts:8](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L8)*

--- a/docs/interfaces/cddproviderrole.md
+++ b/docs/interfaces/cddproviderrole.md
@@ -16,4 +16,4 @@
 
 • **type**: *[CddProvider](../enums/roletype.md#cddprovider)*
 
-*Defined in [src/types/index.ts:95](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L95)*
+*Defined in [src/types/index.ts:95](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L95)*

--- a/docs/interfaces/claimdata.md
+++ b/docs/interfaces/claimdata.md
@@ -20,7 +20,7 @@
 
 • **claim**: *[Claim](../globals.md#claim)*
 
-*Defined in [src/types/index.ts:221](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L221)*
+*Defined in [src/types/index.ts:221](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L221)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **expiry**: *Date | null*
 
-*Defined in [src/types/index.ts:220](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L220)*
+*Defined in [src/types/index.ts:220](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L220)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 • **issuedAt**: *Date*
 
-*Defined in [src/types/index.ts:219](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L219)*
+*Defined in [src/types/index.ts:219](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L219)*
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 • **issuer**: *[Identity](../classes/identity.md)*
 
-*Defined in [src/types/index.ts:218](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L218)*
+*Defined in [src/types/index.ts:218](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L218)*
 
 ___
 
@@ -52,4 +52,4 @@ ___
 
 • **target**: *[Identity](../classes/identity.md)*
 
-*Defined in [src/types/index.ts:217](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L217)*
+*Defined in [src/types/index.ts:217](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L217)*

--- a/docs/interfaces/claimscope.md
+++ b/docs/interfaces/claimscope.md
@@ -17,7 +17,7 @@
 
 • **scope**: *string | null*
 
-*Defined in [src/types/index.ts:242](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L242)*
+*Defined in [src/types/index.ts:242](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L242)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **ticker**? : *undefined | string*
 
-*Defined in [src/types/index.ts:243](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L243)*
+*Defined in [src/types/index.ts:243](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L243)*

--- a/docs/interfaces/claimtarget.md
+++ b/docs/interfaces/claimtarget.md
@@ -18,7 +18,7 @@
 
 • **claim**: *[Claim](../globals.md#claim)*
 
-*Defined in [src/types/index.ts:338](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L338)*
+*Defined in [src/types/index.ts:338](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L338)*
 
 ___
 
@@ -26,7 +26,7 @@ ___
 
 • **expiry**? : *[Date](../enums/transactionargumenttype.md#date)*
 
-*Defined in [src/types/index.ts:339](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L339)*
+*Defined in [src/types/index.ts:339](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L339)*
 
 ___
 
@@ -34,4 +34,4 @@ ___
 
 • **target**: *string | [Identity](../classes/identity.md)*
 
-*Defined in [src/types/index.ts:337](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L337)*
+*Defined in [src/types/index.ts:337](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L337)*

--- a/docs/interfaces/complextransactionargument.md
+++ b/docs/interfaces/complextransactionargument.md
@@ -17,7 +17,7 @@
 
 • **internal**: *[TransactionArgument](../globals.md#transactionargument)[]*
 
-*Defined in [src/types/index.ts:453](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L453)*
+*Defined in [src/types/index.ts:453](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L453)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **type**: *[RichEnum](../enums/transactionargumenttype.md#richenum) | [Object](../enums/transactionargumenttype.md#object) | [Tuple](../enums/transactionargumenttype.md#tuple)*
 
-*Defined in [src/types/index.ts:449](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L449)*
+*Defined in [src/types/index.ts:449](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L449)*

--- a/docs/interfaces/connectparamsbase.md
+++ b/docs/interfaces/connectparamsbase.md
@@ -18,7 +18,7 @@
 
 • **middleware**? : *[MiddlewareConfig](middlewareconfig.md)*
 
-*Defined in [src/Polymesh.ts:66](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L66)*
+*Defined in [src/Polymesh.ts:66](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L66)*
 
 ___
 
@@ -26,7 +26,7 @@ ___
 
 • **nodeUrl**: *string*
 
-*Defined in [src/Polymesh.ts:64](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L64)*
+*Defined in [src/Polymesh.ts:64](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L64)*
 
 ___
 
@@ -34,4 +34,4 @@ ___
 
 • **signer**? : *PolkadotSigner*
 
-*Defined in [src/Polymesh.ts:65](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/Polymesh.ts#L65)*
+*Defined in [src/Polymesh.ts:65](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/Polymesh.ts#L65)*

--- a/docs/interfaces/consumeparams.md
+++ b/docs/interfaces/consumeparams.md
@@ -16,4 +16,4 @@
 
 • **accept**: *boolean*
 
-*Defined in [src/api/procedures/consumeAuthorizationRequests.ts:8](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/consumeAuthorizationRequests.ts#L8)*
+*Defined in [src/api/procedures/consumeAuthorizationRequests.ts:8](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/consumeAuthorizationRequests.ts#L8)*

--- a/docs/interfaces/createproposalparams.md
+++ b/docs/interfaces/createproposalparams.md
@@ -20,7 +20,7 @@
 
 • **args**: *unknown[]*
 
-*Defined in [src/api/procedures/createProposal.ts:23](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/createProposal.ts#L23)*
+*Defined in [src/api/procedures/createProposal.ts:23](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/createProposal.ts#L23)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **bondAmount**: *BigNumber*
 
-*Defined in [src/api/procedures/createProposal.ts:21](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/createProposal.ts#L21)*
+*Defined in [src/api/procedures/createProposal.ts:21](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/createProposal.ts#L21)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 • **description**? : *undefined | string*
 
-*Defined in [src/api/procedures/createProposal.ts:19](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/createProposal.ts#L19)*
+*Defined in [src/api/procedures/createProposal.ts:19](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/createProposal.ts#L19)*
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 • **discussionUrl**? : *undefined | string*
 
-*Defined in [src/api/procedures/createProposal.ts:20](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/createProposal.ts#L20)*
+*Defined in [src/api/procedures/createProposal.ts:20](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/createProposal.ts#L20)*
 
 ___
 
@@ -52,4 +52,4 @@ ___
 
 • **tag**: *TxTag*
 
-*Defined in [src/api/procedures/createProposal.ts:22](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/createProposal.ts#L22)*
+*Defined in [src/api/procedures/createProposal.ts:22](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/createProposal.ts#L22)*

--- a/docs/interfaces/createsecuritytokenparams.md
+++ b/docs/interfaces/createsecuritytokenparams.md
@@ -23,7 +23,7 @@
 
 • **documents**? : *[TokenDocument](tokendocument.md)[]*
 
-*Defined in [src/api/procedures/createSecurityToken.ts:41](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/createSecurityToken.ts#L41)*
+*Defined in [src/api/procedures/createSecurityToken.ts:41](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/createSecurityToken.ts#L41)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 • **fundingRound**? : *undefined | string*
 
-*Defined in [src/api/procedures/createSecurityToken.ts:39](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/createSecurityToken.ts#L39)*
+*Defined in [src/api/procedures/createSecurityToken.ts:39](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/createSecurityToken.ts#L39)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • **isDivisible**: *boolean*
 
-*Defined in [src/api/procedures/createSecurityToken.ts:36](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/createSecurityToken.ts#L36)*
+*Defined in [src/api/procedures/createSecurityToken.ts:36](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/createSecurityToken.ts#L36)*
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/api/procedures/createSecurityToken.ts:34](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/createSecurityToken.ts#L34)*
+*Defined in [src/api/procedures/createSecurityToken.ts:34](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/createSecurityToken.ts#L34)*
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 • **tokenIdentifiers**? : *[TokenIdentifier](tokenidentifier.md)[]*
 
-*Defined in [src/api/procedures/createSecurityToken.ts:38](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/createSecurityToken.ts#L38)*
+*Defined in [src/api/procedures/createSecurityToken.ts:38](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/createSecurityToken.ts#L38)*
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 • **tokenType**: *[TokenType](../globals.md#tokentype)*
 
-*Defined in [src/api/procedures/createSecurityToken.ts:37](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/createSecurityToken.ts#L37)*
+*Defined in [src/api/procedures/createSecurityToken.ts:37](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/createSecurityToken.ts#L37)*
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 • **totalSupply**: *BigNumber*
 
-*Defined in [src/api/procedures/createSecurityToken.ts:35](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/createSecurityToken.ts#L35)*
+*Defined in [src/api/procedures/createSecurityToken.ts:35](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/createSecurityToken.ts#L35)*
 
 ___
 
@@ -79,4 +79,4 @@ ___
 
 • **treasury**? : *string | [Identity](../classes/identity.md)*
 
-*Defined in [src/api/procedures/createSecurityToken.ts:40](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/createSecurityToken.ts#L40)*
+*Defined in [src/api/procedures/createSecurityToken.ts:40](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/createSecurityToken.ts#L40)*

--- a/docs/interfaces/editclaimsparams.md
+++ b/docs/interfaces/editclaimsparams.md
@@ -17,7 +17,7 @@
 
 • **claims**: *[ClaimTarget](claimtarget.md)[]*
 
-*Defined in [src/api/procedures/modifyClaims.ts:40](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/modifyClaims.ts#L40)*
+*Defined in [src/api/procedures/modifyClaims.ts:40](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/modifyClaims.ts#L40)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **operation**: *Edit*
 
-*Defined in [src/api/procedures/modifyClaims.ts:41](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/modifyClaims.ts#L41)*
+*Defined in [src/api/procedures/modifyClaims.ts:41](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/modifyClaims.ts#L41)*

--- a/docs/interfaces/eventidentifier.md
+++ b/docs/interfaces/eventidentifier.md
@@ -18,7 +18,7 @@
 
 • **blockDate**: *Date*
 
-*Defined in [src/types/index.ts:361](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L361)*
+*Defined in [src/types/index.ts:361](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L361)*
 
 ___
 
@@ -26,7 +26,7 @@ ___
 
 • **blockNumber**: *number*
 
-*Defined in [src/types/index.ts:360](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L360)*
+*Defined in [src/types/index.ts:360](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L360)*
 
 ___
 
@@ -34,4 +34,4 @@ ___
 
 • **eventIndex**: *number*
 
-*Defined in [src/types/index.ts:362](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L362)*
+*Defined in [src/types/index.ts:362](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L362)*

--- a/docs/interfaces/extrinsicdata.md
+++ b/docs/interfaces/extrinsicdata.md
@@ -24,7 +24,7 @@
 
 • **address**: *string | null*
 
-*Defined in [src/types/index.ts:232](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L232)*
+*Defined in [src/types/index.ts:232](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L232)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • **blockId**: *number*
 
-*Defined in [src/types/index.ts:230](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L230)*
+*Defined in [src/types/index.ts:230](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L230)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **extrinsicHash**: *string*
 
-*Defined in [src/types/index.ts:238](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L238)*
+*Defined in [src/types/index.ts:238](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L238)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **extrinsicIdx**: *number*
 
-*Defined in [src/types/index.ts:231](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L231)*
+*Defined in [src/types/index.ts:231](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L231)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • **nonce**: *number*
 
-*Defined in [src/types/index.ts:233](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L233)*
+*Defined in [src/types/index.ts:233](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L233)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • **params**: *object*
 
-*Defined in [src/types/index.ts:235](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L235)*
+*Defined in [src/types/index.ts:235](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L235)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 • **specVersionId**: *number*
 
-*Defined in [src/types/index.ts:237](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L237)*
+*Defined in [src/types/index.ts:237](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L237)*
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 • **success**: *boolean*
 
-*Defined in [src/types/index.ts:236](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L236)*
+*Defined in [src/types/index.ts:236](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L236)*
 
 ___
 
@@ -88,4 +88,4 @@ ___
 
 • **txTag**: *TxTag*
 
-*Defined in [src/types/index.ts:234](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L234)*
+*Defined in [src/types/index.ts:234](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L234)*

--- a/docs/interfaces/fees.md
+++ b/docs/interfaces/fees.md
@@ -17,7 +17,7 @@
 
 • **gas**: *BigNumber*
 
-*Defined in [src/types/index.ts:394](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L394)*
+*Defined in [src/types/index.ts:394](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L394)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **protocol**: *BigNumber*
 
-*Defined in [src/types/index.ts:393](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L393)*
+*Defined in [src/types/index.ts:393](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L393)*

--- a/docs/interfaces/identitybalance.md
+++ b/docs/interfaces/identitybalance.md
@@ -19,7 +19,7 @@ Represents the balance of a token holder
 
 • **balance**: *BigNumber*
 
-*Defined in [src/api/entities/SecurityToken/types.ts:19](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/types.ts#L19)*
+*Defined in [src/api/entities/SecurityToken/types.ts:19](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/types.ts#L19)*
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 • **identity**: *[Identity](../classes/identity.md)*
 
-*Defined in [src/api/entities/SecurityToken/types.ts:18](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/types.ts#L18)*
+*Defined in [src/api/entities/SecurityToken/types.ts:18](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/types.ts#L18)*

--- a/docs/interfaces/identitywithclaims.md
+++ b/docs/interfaces/identitywithclaims.md
@@ -17,7 +17,7 @@
 
 • **claims**: *[ClaimData](claimdata.md)[]*
 
-*Defined in [src/types/index.ts:226](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L226)*
+*Defined in [src/types/index.ts:226](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L226)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **identity**: *[Identity](../classes/identity.md)*
 
-*Defined in [src/types/index.ts:225](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L225)*
+*Defined in [src/types/index.ts:225](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L225)*

--- a/docs/interfaces/issuancedata.md
+++ b/docs/interfaces/issuancedata.md
@@ -19,7 +19,7 @@ Represents an amount of tokens to be issued to an identity
 
 • **amount**: *BigNumber*
 
-*Defined in [src/types/index.ts:313](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L313)*
+*Defined in [src/types/index.ts:313](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L313)*
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 • **identity**: *string | [Identity](../classes/identity.md)*
 
-*Defined in [src/types/index.ts:312](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L312)*
+*Defined in [src/types/index.ts:312](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L312)*

--- a/docs/interfaces/issuetokensparams.md
+++ b/docs/interfaces/issuetokensparams.md
@@ -16,4 +16,4 @@
 
 • **issuanceData**: *[IssuanceData](issuancedata.md)[]*
 
-*Defined in [src/api/procedures/issueTokens.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/issueTokens.ts#L12)*
+*Defined in [src/api/procedures/issueTokens.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/issueTokens.ts#L12)*

--- a/docs/interfaces/keyringpair.md
+++ b/docs/interfaces/keyringpair.md
@@ -31,7 +31,7 @@ ___
 
 • **isLocked**: *boolean*
 
-*Defined in [src/types/index.ts:366](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L366)*
+*Defined in [src/types/index.ts:366](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L366)*
 
 ___
 

--- a/docs/interfaces/metadata.md
+++ b/docs/interfaces/metadata.md
@@ -25,7 +25,7 @@
 
 • **ayesBonded**: *BigNumber*
 
-*Defined in [src/api/entities/Proposal/types.ts:26](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L26)*
+*Defined in [src/api/entities/Proposal/types.ts:26](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L26)*
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 • **coolOff**: *number*
 
-*Defined in [src/api/entities/Proposal/types.ts:24](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L24)*
+*Defined in [src/api/entities/Proposal/types.ts:24](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L24)*
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 • **createdAt**: *Date*
 
-*Defined in [src/api/entities/Proposal/types.ts:20](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L20)*
+*Defined in [src/api/entities/Proposal/types.ts:20](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L20)*
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 • **description**? : *undefined | string*
 
-*Defined in [src/api/entities/Proposal/types.ts:22](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L22)*
+*Defined in [src/api/entities/Proposal/types.ts:22](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L22)*
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 • **endBlock**: *number*
 
-*Defined in [src/api/entities/Proposal/types.ts:21](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L21)*
+*Defined in [src/api/entities/Proposal/types.ts:21](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L21)*
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 • **lastStateUpdated**: *number*
 
-*Defined in [src/api/entities/Proposal/types.ts:25](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L25)*
+*Defined in [src/api/entities/Proposal/types.ts:25](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L25)*
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 • **naysBonded**: *BigNumber*
 
-*Defined in [src/api/entities/Proposal/types.ts:27](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L27)*
+*Defined in [src/api/entities/Proposal/types.ts:27](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L27)*
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 • **proposer**: *[Identity](../classes/identity.md)*
 
-*Defined in [src/api/entities/Proposal/types.ts:19](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L19)*
+*Defined in [src/api/entities/Proposal/types.ts:19](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L19)*
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 • **totalVotes**: *number*
 
-*Defined in [src/api/entities/Proposal/types.ts:28](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L28)*
+*Defined in [src/api/entities/Proposal/types.ts:28](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L28)*
 
 ___
 
@@ -97,4 +97,4 @@ ___
 
 • **url**? : *undefined | string*
 
-*Defined in [src/api/entities/Proposal/types.ts:23](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L23)*
+*Defined in [src/api/entities/Proposal/types.ts:23](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L23)*

--- a/docs/interfaces/middlewareconfig.md
+++ b/docs/interfaces/middlewareconfig.md
@@ -17,7 +17,7 @@
 
 • **key**: *string*
 
-*Defined in [src/types/index.ts:350](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L350)*
+*Defined in [src/types/index.ts:350](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L350)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **link**: *string*
 
-*Defined in [src/types/index.ts:349](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L349)*
+*Defined in [src/types/index.ts:349](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L349)*

--- a/docs/interfaces/modifytokentrustedclaimissuersparams.md
+++ b/docs/interfaces/modifytokentrustedclaimissuersparams.md
@@ -16,4 +16,4 @@
 
 • **claimIssuerIdentities**: *(string | [Identity](../classes/identity.md)‹›)[]*
 
-*Defined in [src/api/procedures/modifyTokenTrustedClaimIssuers.ts:17](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/modifyTokenTrustedClaimIssuers.ts#L17)*
+*Defined in [src/api/procedures/modifyTokenTrustedClaimIssuers.ts:17](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/modifyTokenTrustedClaimIssuers.ts#L17)*

--- a/docs/interfaces/networkproperties.md
+++ b/docs/interfaces/networkproperties.md
@@ -17,7 +17,7 @@
 
 • **name**: *string*
 
-*Defined in [src/types/index.ts:388](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L388)*
+*Defined in [src/types/index.ts:388](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L388)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **version**: *number*
 
-*Defined in [src/types/index.ts:389](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L389)*
+*Defined in [src/types/index.ts:389](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L389)*

--- a/docs/interfaces/paginationoptions.md
+++ b/docs/interfaces/paginationoptions.md
@@ -17,7 +17,7 @@
 
 • **size**: *number*
 
-*Defined in [src/types/index.ts:375](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L375)*
+*Defined in [src/types/index.ts:375](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L375)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **start**? : *undefined | string*
 
-*Defined in [src/types/index.ts:376](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L376)*
+*Defined in [src/types/index.ts:376](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L376)*

--- a/docs/interfaces/plaintransactionargument.md
+++ b/docs/interfaces/plaintransactionargument.md
@@ -16,4 +16,4 @@
 
 • **type**: *Exclude‹[TransactionArgumentType](../enums/transactionargumenttype.md), [Array](../enums/transactionargumenttype.md#array) | [Tuple](../enums/transactionargumenttype.md#tuple) | [SimpleEnum](../enums/transactionargumenttype.md#simpleenum) | [RichEnum](../enums/transactionargumenttype.md#richenum) | [Object](../enums/transactionargumenttype.md#object)›*
 
-*Defined in [src/types/index.ts:428](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L428)*
+*Defined in [src/types/index.ts:428](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L428)*

--- a/docs/interfaces/proposaldetails.md
+++ b/docs/interfaces/proposaldetails.md
@@ -18,7 +18,7 @@
 
 • **method**: *string*
 
-*Defined in [src/api/entities/Proposal/types.ts:51](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L51)*
+*Defined in [src/api/entities/Proposal/types.ts:51](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L51)*
 
 ___
 
@@ -26,7 +26,7 @@ ___
 
 • **module**: *string*
 
-*Defined in [src/api/entities/Proposal/types.ts:50](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L50)*
+*Defined in [src/api/entities/Proposal/types.ts:50](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L50)*
 
 ___
 
@@ -34,4 +34,4 @@ ___
 
 • **state**: *ProposalState*
 
-*Defined in [src/api/entities/Proposal/types.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L49)*
+*Defined in [src/api/entities/Proposal/types.ts:49](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L49)*

--- a/docs/interfaces/proposaltimeframes.md
+++ b/docs/interfaces/proposaltimeframes.md
@@ -17,7 +17,7 @@
 
 • **coolOff**: *number*
 
-*Defined in [src/api/entities/Proposal/types.ts:39](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L39)*
+*Defined in [src/api/entities/Proposal/types.ts:39](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L39)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **duration**: *number*
 
-*Defined in [src/api/entities/Proposal/types.ts:38](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L38)*
+*Defined in [src/api/entities/Proposal/types.ts:38](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L38)*

--- a/docs/interfaces/proposalvote.md
+++ b/docs/interfaces/proposalvote.md
@@ -18,7 +18,7 @@
 
 • **identity**: *[Identity](../classes/identity.md)*
 
-*Defined in [src/api/entities/Proposal/types.ts:32](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L32)*
+*Defined in [src/api/entities/Proposal/types.ts:32](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L32)*
 
 ___
 
@@ -26,7 +26,7 @@ ___
 
 • **vote**: *boolean*
 
-*Defined in [src/api/entities/Proposal/types.ts:33](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L33)*
+*Defined in [src/api/entities/Proposal/types.ts:33](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L33)*
 
 ___
 
@@ -34,4 +34,4 @@ ___
 
 • **weight**: *BigNumber*
 
-*Defined in [src/api/entities/Proposal/types.ts:34](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/types.ts#L34)*
+*Defined in [src/api/entities/Proposal/types.ts:34](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/types.ts#L34)*

--- a/docs/interfaces/removesigningkeysparams.md
+++ b/docs/interfaces/removesigningkeysparams.md
@@ -16,4 +16,4 @@
 
 • **signers**: *[Signer](signer.md)[]*
 
-*Defined in [src/api/procedures/removeSigningKeys.ts:8](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/removeSigningKeys.ts#L8)*
+*Defined in [src/api/procedures/removeSigningKeys.ts:8](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/removeSigningKeys.ts#L8)*

--- a/docs/interfaces/reservetickerparams.md
+++ b/docs/interfaces/reservetickerparams.md
@@ -17,7 +17,7 @@
 
 • **extendPeriod**? : *undefined | false | true*
 
-*Defined in [src/api/procedures/reserveTicker.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/reserveTicker.ts#L12)*
+*Defined in [src/api/procedures/reserveTicker.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/reserveTicker.ts#L12)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **ticker**: *string*
 
-*Defined in [src/api/procedures/reserveTicker.ts:11](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/reserveTicker.ts#L11)*
+*Defined in [src/api/procedures/reserveTicker.ts:11](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/reserveTicker.ts#L11)*

--- a/docs/interfaces/resultset.md
+++ b/docs/interfaces/resultset.md
@@ -22,7 +22,7 @@
 
 • **count**? : *undefined | number*
 
-*Defined in [src/types/index.ts:384](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L384)*
+*Defined in [src/types/index.ts:384](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L384)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • **data**: *T[]*
 
-*Defined in [src/types/index.ts:382](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L382)*
+*Defined in [src/types/index.ts:382](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L382)*
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 • **next**: *[NextKey](../globals.md#nextkey)*
 
-*Defined in [src/types/index.ts:383](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L383)*
+*Defined in [src/types/index.ts:383](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L383)*

--- a/docs/interfaces/revokeclaimsparams.md
+++ b/docs/interfaces/revokeclaimsparams.md
@@ -17,7 +17,7 @@
 
 • **claims**: *Omit‹[ClaimTarget](claimtarget.md), "expiry"›[]*
 
-*Defined in [src/api/procedures/modifyClaims.ts:45](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/modifyClaims.ts#L45)*
+*Defined in [src/api/procedures/modifyClaims.ts:45](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/modifyClaims.ts#L45)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **operation**: *Revoke*
 
-*Defined in [src/api/procedures/modifyClaims.ts:46](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/modifyClaims.ts#L46)*
+*Defined in [src/api/procedures/modifyClaims.ts:46](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/modifyClaims.ts#L46)*

--- a/docs/interfaces/rule.md
+++ b/docs/interfaces/rule.md
@@ -17,7 +17,7 @@
 
 • **conditions**: *[Condition](../globals.md#condition)[]*
 
-*Defined in [src/types/index.ts:283](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L283)*
+*Defined in [src/types/index.ts:283](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L283)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **id**: *number*
 
-*Defined in [src/types/index.ts:282](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L282)*
+*Defined in [src/types/index.ts:282](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L282)*

--- a/docs/interfaces/rulecompliance.md
+++ b/docs/interfaces/rulecompliance.md
@@ -17,7 +17,7 @@
 
 • **complies**: *boolean*
 
-*Defined in [src/types/index.ts:290](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L290)*
+*Defined in [src/types/index.ts:290](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L290)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **rules**: *[Rule](rule.md) & object[]*
 
-*Defined in [src/types/index.ts:287](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L287)*
+*Defined in [src/types/index.ts:287](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L287)*

--- a/docs/interfaces/securitytokendetails.md
+++ b/docs/interfaces/securitytokendetails.md
@@ -21,7 +21,7 @@
 
 • **assetType**: *string*
 
-*Defined in [src/api/entities/SecurityToken/types.ts:6](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/types.ts#L6)*
+*Defined in [src/api/entities/SecurityToken/types.ts:6](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/types.ts#L6)*
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 • **isDivisible**: *boolean*
 
-*Defined in [src/api/entities/SecurityToken/types.ts:7](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/types.ts#L7)*
+*Defined in [src/api/entities/SecurityToken/types.ts:7](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/types.ts#L7)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/api/entities/SecurityToken/types.ts:8](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/types.ts#L8)*
+*Defined in [src/api/entities/SecurityToken/types.ts:8](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/types.ts#L8)*
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 • **owner**: *[Identity](../classes/identity.md)*
 
-*Defined in [src/api/entities/SecurityToken/types.ts:9](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/types.ts#L9)*
+*Defined in [src/api/entities/SecurityToken/types.ts:9](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/types.ts#L9)*
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 • **totalSupply**: *BigNumber*
 
-*Defined in [src/api/entities/SecurityToken/types.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/types.ts#L10)*
+*Defined in [src/api/entities/SecurityToken/types.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/types.ts#L10)*
 
 ___
 
@@ -61,4 +61,4 @@ ___
 
 • **treasuryIdentity**: *[Identity](../classes/identity.md) | null*
 
-*Defined in [src/api/entities/SecurityToken/types.ts:11](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/types.ts#L11)*
+*Defined in [src/api/entities/SecurityToken/types.ts:11](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/types.ts#L11)*

--- a/docs/interfaces/settokendocumentsparams.md
+++ b/docs/interfaces/settokendocumentsparams.md
@@ -16,4 +16,4 @@
 
 • **documents**: *[TokenDocument](tokendocument.md)[]*
 
-*Defined in [src/api/procedures/setTokenDocuments.ts:18](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/setTokenDocuments.ts#L18)*
+*Defined in [src/api/procedures/setTokenDocuments.ts:18](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/setTokenDocuments.ts#L18)*

--- a/docs/interfaces/settokenrulesparams.md
+++ b/docs/interfaces/settokenrulesparams.md
@@ -16,4 +16,4 @@
 
 • **rules**: *[Condition](../globals.md#condition)[][]*
 
-*Defined in [src/api/procedures/setTokenRules.ts:9](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/setTokenRules.ts#L9)*
+*Defined in [src/api/procedures/setTokenRules.ts:9](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/setTokenRules.ts#L9)*

--- a/docs/interfaces/signer.md
+++ b/docs/interfaces/signer.md
@@ -17,7 +17,7 @@
 
 • **type**: *[SignerType](../enums/signertype.md)*
 
-*Defined in [src/types/index.ts:468](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L468)*
+*Defined in [src/types/index.ts:468](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L468)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **value**: *string*
 
-*Defined in [src/types/index.ts:469](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L469)*
+*Defined in [src/types/index.ts:469](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L469)*

--- a/docs/interfaces/simpleenumtransactionargument.md
+++ b/docs/interfaces/simpleenumtransactionargument.md
@@ -17,7 +17,7 @@
 
 • **internal**: *string[]*
 
-*Defined in [src/types/index.ts:445](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L445)*
+*Defined in [src/types/index.ts:445](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L445)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **type**: *[SimpleEnum](../enums/transactionargumenttype.md#simpleenum)*
 
-*Defined in [src/types/index.ts:444](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L444)*
+*Defined in [src/types/index.ts:444](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L444)*

--- a/docs/interfaces/tickerownerrole.md
+++ b/docs/interfaces/tickerownerrole.md
@@ -17,7 +17,7 @@
 
 • **ticker**: *string*
 
-*Defined in [src/types/index.ts:72](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L72)*
+*Defined in [src/types/index.ts:72](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L72)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **type**: *[TickerOwner](../enums/roletype.md#tickerowner)*
 
-*Defined in [src/types/index.ts:71](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L71)*
+*Defined in [src/types/index.ts:71](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L71)*

--- a/docs/interfaces/tickerreservationdetails.md
+++ b/docs/interfaces/tickerreservationdetails.md
@@ -18,7 +18,7 @@
 
 • **expiryDate**: *Date | null*
 
-*Defined in [src/api/entities/TickerReservation/types.ts:11](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/TickerReservation/types.ts#L11)*
+*Defined in [src/api/entities/TickerReservation/types.ts:11](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/TickerReservation/types.ts#L11)*
 
 date at which the reservation expires, null if it never expires (permanent reservation or token already launched)
 
@@ -28,7 +28,7 @@ ___
 
 • **owner**: *[Identity](../classes/identity.md) | null*
 
-*Defined in [src/api/entities/TickerReservation/types.ts:7](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/TickerReservation/types.ts#L7)*
+*Defined in [src/api/entities/TickerReservation/types.ts:7](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/TickerReservation/types.ts#L7)*
 
 identity ID of the owner of the ticker, null if it hasn't been reserved
 
@@ -38,4 +38,4 @@ ___
 
 • **status**: *[TickerReservationStatus](../enums/tickerreservationstatus.md)*
 
-*Defined in [src/api/entities/TickerReservation/types.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/TickerReservation/types.ts#L12)*
+*Defined in [src/api/entities/TickerReservation/types.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/TickerReservation/types.ts#L12)*

--- a/docs/interfaces/togglefreezetransfersparams.md
+++ b/docs/interfaces/togglefreezetransfersparams.md
@@ -16,4 +16,4 @@
 
 • **freeze**: *boolean*
 
-*Defined in [src/api/procedures/toggleFreezeTransfers.ts:7](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/toggleFreezeTransfers.ts#L7)*
+*Defined in [src/api/procedures/toggleFreezeTransfers.ts:7](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/toggleFreezeTransfers.ts#L7)*

--- a/docs/interfaces/togglepauserulesparams.md
+++ b/docs/interfaces/togglepauserulesparams.md
@@ -16,4 +16,4 @@
 
 • **pause**: *boolean*
 
-*Defined in [src/api/procedures/togglePauseRules.ts:7](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/togglePauseRules.ts#L7)*
+*Defined in [src/api/procedures/togglePauseRules.ts:7](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/togglePauseRules.ts#L7)*

--- a/docs/interfaces/tokendocument.md
+++ b/docs/interfaces/tokendocument.md
@@ -20,7 +20,7 @@ Document attached to a token
 
 • **contentHash**: *string*
 
-*Defined in [src/types/index.ts:147](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L147)*
+*Defined in [src/types/index.ts:147](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L147)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/types/index.ts:145](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L145)*
+*Defined in [src/types/index.ts:145](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L145)*
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 • **uri**: *string*
 
-*Defined in [src/types/index.ts:146](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L146)*
+*Defined in [src/types/index.ts:146](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L146)*

--- a/docs/interfaces/tokenholderoptions.md
+++ b/docs/interfaces/tokenholderoptions.md
@@ -16,4 +16,4 @@
 
 • **canBeIssuedTo**: *boolean*
 
-*Defined in [src/api/entities/SecurityToken/types.ts:23](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/types.ts#L23)*
+*Defined in [src/api/entities/SecurityToken/types.ts:23](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/types.ts#L23)*

--- a/docs/interfaces/tokenholderproperties.md
+++ b/docs/interfaces/tokenholderproperties.md
@@ -16,4 +16,4 @@
 
 • **canBeIssuedTo**: *boolean*
 
-*Defined in [src/api/entities/SecurityToken/types.ts:27](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/types.ts#L27)*
+*Defined in [src/api/entities/SecurityToken/types.ts:27](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/types.ts#L27)*

--- a/docs/interfaces/tokenidentifier.md
+++ b/docs/interfaces/tokenidentifier.md
@@ -19,7 +19,7 @@ Alphanumeric standardized security identifier
 
 • **type**: *[TokenIdentifierType](../enums/tokenidentifiertype.md)*
 
-*Defined in [src/types/index.ts:137](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L137)*
+*Defined in [src/types/index.ts:137](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L137)*
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 • **value**: *string*
 
-*Defined in [src/types/index.ts:138](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L138)*
+*Defined in [src/types/index.ts:138](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L138)*

--- a/docs/interfaces/tokenownerrole.md
+++ b/docs/interfaces/tokenownerrole.md
@@ -17,7 +17,7 @@
 
 • **ticker**: *string*
 
-*Defined in [src/types/index.ts:84](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L84)*
+*Defined in [src/types/index.ts:84](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L84)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **type**: *[TokenOwner](../enums/roletype.md#tokenowner)*
 
-*Defined in [src/types/index.ts:83](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L83)*
+*Defined in [src/types/index.ts:83](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L83)*

--- a/docs/interfaces/transferpolyxparams.md
+++ b/docs/interfaces/transferpolyxparams.md
@@ -17,7 +17,7 @@
 
 • **amount**: *BigNumber*
 
-*Defined in [src/api/procedures/transferPolyX.ts:11](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/transferPolyX.ts#L11)*
+*Defined in [src/api/procedures/transferPolyX.ts:11](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/transferPolyX.ts#L11)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **to**: *string*
 
-*Defined in [src/api/procedures/transferPolyX.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/transferPolyX.ts#L10)*
+*Defined in [src/api/procedures/transferPolyX.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/transferPolyX.ts#L10)*

--- a/docs/interfaces/transfertokenownershipparams.md
+++ b/docs/interfaces/transfertokenownershipparams.md
@@ -17,7 +17,7 @@
 
 • **did**: *string*
 
-*Defined in [src/api/procedures/transferTokenOwnership.ts:7](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/transferTokenOwnership.ts#L7)*
+*Defined in [src/api/procedures/transferTokenOwnership.ts:7](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/transferTokenOwnership.ts#L7)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **expiry**? : *[Date](../enums/transactionargumenttype.md#date)*
 
-*Defined in [src/api/procedures/transferTokenOwnership.ts:8](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/transferTokenOwnership.ts#L8)*
+*Defined in [src/api/procedures/transferTokenOwnership.ts:8](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/transferTokenOwnership.ts#L8)*

--- a/docs/interfaces/transfertokenparams.md
+++ b/docs/interfaces/transfertokenparams.md
@@ -17,7 +17,7 @@
 
 • **amount**: *BigNumber*
 
-*Defined in [src/api/procedures/transferToken.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/transferToken.ts#L10)*
+*Defined in [src/api/procedures/transferToken.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/transferToken.ts#L10)*
 
 ___
 
@@ -25,4 +25,4 @@ ___
 
 • **to**: *string | [Identity](../classes/identity.md)*
 
-*Defined in [src/api/procedures/transferToken.ts:9](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/procedures/transferToken.ts#L9)*
+*Defined in [src/api/procedures/transferToken.ts:9](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/procedures/transferToken.ts#L9)*

--- a/docs/interfaces/uikeyring.md
+++ b/docs/interfaces/uikeyring.md
@@ -16,4 +16,4 @@
 
 • **keyring**: *[CommonKeyring](../globals.md#commonkeyring)*
 
-*Defined in [src/types/index.ts:356](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/types/index.ts#L356)*
+*Defined in [src/types/index.ts:356](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/types/index.ts#L356)*

--- a/docs/interfaces/uniqueidentifiers.md
+++ b/docs/interfaces/uniqueidentifiers.md
@@ -24,7 +24,7 @@ Properties that uniquely identify a Proposal
 
 • **authId**: *BigNumber*
 
-*Defined in [src/api/entities/AuthorizationRequest.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/AuthorizationRequest.ts#L10)*
+*Defined in [src/api/entities/AuthorizationRequest.ts:10](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/AuthorizationRequest.ts#L10)*
 
 ___
 
@@ -32,9 +32,9 @@ ___
 
 • **did**: *string*
 
-*Defined in [src/api/entities/TrustedClaimIssuer.ts:11](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/TrustedClaimIssuer.ts#L11)*
+*Defined in [src/api/entities/TrustedClaimIssuer.ts:11](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/TrustedClaimIssuer.ts#L11)*
 
-*Defined in [src/api/entities/Identity/index.ts:50](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Identity/index.ts#L50)*
+*Defined in [src/api/entities/Identity/index.ts:50](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Identity/index.ts#L50)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 • **pipId**: *number*
 
-*Defined in [src/api/entities/Proposal/index.ts:18](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/Proposal/index.ts#L18)*
+*Defined in [src/api/entities/Proposal/index.ts:18](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/Proposal/index.ts#L18)*
 
 ___
 
@@ -50,10 +50,10 @@ ___
 
 • **ticker**: *string*
 
-*Defined in [src/api/entities/TrustedClaimIssuer.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/TrustedClaimIssuer.ts#L12)*
+*Defined in [src/api/entities/TrustedClaimIssuer.ts:12](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/TrustedClaimIssuer.ts#L12)*
 
-*Defined in [src/api/entities/SecurityToken/index.ts:50](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/SecurityToken/index.ts#L50)*
+*Defined in [src/api/entities/SecurityToken/index.ts:50](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/SecurityToken/index.ts#L50)*
 
-*Defined in [src/api/entities/TickerReservation/index.ts:22](https://github.com/PolymathNetwork/polymesh-sdk/blob/4b9adaf/src/api/entities/TickerReservation/index.ts#L22)*
+*Defined in [src/api/entities/TickerReservation/index.ts:22](https://github.com/PolymathNetwork/polymesh-sdk/blob/da3a97f/src/api/entities/TickerReservation/index.ts#L22)*
 
 ticker of the security token

--- a/src/Polymesh.ts
+++ b/src/Polymesh.ts
@@ -320,7 +320,7 @@ export class Polymesh {
     if (args) {
       identity = valueToDid(args.did);
     } else {
-      identity = context.getCurrentIdentity().did;
+      ({ did: identity } = await context.getCurrentIdentity());
     }
 
     const entries = await query.asset.assetOwnershipRelations.entries(
@@ -369,7 +369,7 @@ export class Polymesh {
   /**
    * Create an identity instance from a DID. If no DID is passed, the current identity is returned
    */
-  public getIdentity(args?: { did: string }): Identity {
+  public async getIdentity(args?: { did: string }): Promise<Identity> {
     if (args) {
       return new Identity(args, this.context);
     }
@@ -482,7 +482,7 @@ export class Polymesh {
     if (args) {
       identity = valueToDid(args.did);
     } else {
-      identity = context.getCurrentIdentity().did;
+      ({ did: identity } = await context.getCurrentIdentity());
     }
 
     const entries = await query.asset.assetOwnershipRelations.entries(
@@ -540,7 +540,7 @@ export class Polymesh {
     const { context } = this;
 
     const { size, start } = opts;
-    const { did } = context.getCurrentIdentity();
+    const { did } = await context.getCurrentIdentity();
 
     const result = await context.issuedClaims({
       trustedClaimIssuers: [did],

--- a/src/__tests__/Polymesh.ts
+++ b/src/__tests__/Polymesh.ts
@@ -502,8 +502,12 @@ describe('Polymesh Class', () => {
       });
 
       const context = dsMockUtils.getContextInstance();
+      const [result, currentIdentity] = await Promise.all([
+        polymesh.getIdentity(),
+        context.getCurrentIdentity(),
+      ]);
 
-      expect(polymesh.getIdentity()).toEqual(context.getCurrentIdentity());
+      expect(result).toEqual(currentIdentity);
     });
 
     test('should return an identity object with the passed did', async () => {
@@ -514,7 +518,7 @@ describe('Polymesh Class', () => {
 
       const params = { did: 'testDid' };
 
-      const result = polymesh.getIdentity(params);
+      const result = await polymesh.getIdentity(params);
       const context = dsMockUtils.getContextInstance();
 
       expect(result).toMatchObject(new Identity(params, context));

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -226,17 +226,19 @@ export class Identity extends Entity<UniqueIdentifiers> {
       context,
     } = this;
 
-    const { did } = context.getCurrentIdentity();
+    const { did } = await context.getCurrentIdentity();
 
     const assembleResult = ({ master_key: masterKey }: DidRecord): string => {
       return accountIdToString(masterKey);
     };
 
+    const rawDid = stringToIdentityId(did, context);
+
     if (callback) {
-      return identity.didRecords(did, records => callback(assembleResult(records)));
+      return identity.didRecords(rawDid, records => callback(assembleResult(records)));
     }
 
-    const didRecords = await identity.didRecords(did);
+    const didRecords = await identity.didRecords(rawDid);
     return assembleResult(didRecords);
   }
 

--- a/src/api/entities/Proposal/index.ts
+++ b/src/api/entities/Proposal/index.ts
@@ -61,7 +61,7 @@ export class Proposal extends Entity<UniqueIdentifiers> {
     if (args) {
       identity = valueToDid(args.did);
     } else {
-      identity = context.getCurrentIdentity().did;
+      ({ did: identity } = await context.getCurrentIdentity());
     }
 
     const result = await context.queryMiddleware<Ensured<Query, 'eventByIndexedArgs'>>(

--- a/src/api/entities/SecurityToken/Compliance/Rules.ts
+++ b/src/api/entities/SecurityToken/Compliance/Rules.ts
@@ -146,7 +146,7 @@ export class Rules extends Namespace<SecurityToken> {
     from?: string | Identity;
     to: string | Identity;
   }): Promise<RuleCompliance> {
-    const { from = this.context.getCurrentIdentity(), to } = args;
+    const { from = await this.context.getCurrentIdentity(), to } = args;
     return this._checkTransfer({ from, to });
   }
 

--- a/src/api/entities/SecurityToken/Compliance/__tests__/Rules.ts
+++ b/src/api/entities/SecurityToken/Compliance/__tests__/Rules.ts
@@ -367,11 +367,11 @@ describe('Rules class', () => {
       stringToTickerStub = sinon.stub(utilsModule, 'stringToTicker');
     });
 
-    beforeEach(() => {
+    beforeEach(async () => {
       context = dsMockUtils.getContextInstance();
       token = entityMockUtils.getSecurityTokenInstance();
       rules = new Rules(token, context);
-      currentDid = context.getCurrentIdentity().did;
+      ({ did: currentDid } = await context.getCurrentIdentity());
 
       rawFromDid = dsMockUtils.createMockIdentityId(fromDid);
       rawToDid = dsMockUtils.createMockIdentityId(toDid);

--- a/src/api/entities/SecurityToken/Transfers.ts
+++ b/src/api/entities/SecurityToken/Transfers.ts
@@ -84,12 +84,12 @@ export class Transfers extends Namespace<SecurityToken> {
    * @param args.to - receiver identity
    * @param args.amount - amount of tokens to transfer
    */
-  public canTransfer(args: {
+  public async canTransfer(args: {
     from?: string | Identity;
     to: string | Identity;
     amount: BigNumber;
   }): Promise<TransferStatus> {
-    const { from = this.context.getCurrentIdentity(), to, amount } = args;
+    const { from = await this.context.getCurrentIdentity(), to, amount } = args;
     return this._canTransfer({ from, to, amount });
   }
 

--- a/src/api/entities/SecurityToken/__tests__/Transfers.ts
+++ b/src/api/entities/SecurityToken/__tests__/Transfers.ts
@@ -161,7 +161,7 @@ describe('Transfers class', () => {
     });
 
     test('should return a status value representing whether the transaction can be made from the current identity', async () => {
-      const currentDid = mockContext.getCurrentIdentity().did;
+      const { did: currentDid } = await mockContext.getCurrentIdentity();
 
       const rawCurrentDid = dsMockUtils.createMockIdentityId(currentDid);
       const rawDummyAccountId = dsMockUtils.createMockAccountId(DUMMY_ACCOUNT_ID);

--- a/src/api/procedures/__tests__/consumeAuthorizationRequests.ts
+++ b/src/api/procedures/__tests__/consumeAuthorizationRequests.ts
@@ -159,11 +159,11 @@ describe('consumeAuthorizationRequests procedure', () => {
   });
 
   describe('isAuthorized', () => {
-    test('should return whether the current identity is the target of all non-expired requests if trying to accept', () => {
+    test('should return whether the current identity is the target of all non-expired requests if trying to accept', async () => {
       const proc = procedureMockUtils.getInstance<ConsumeAuthorizationRequestsParams, void>(
         mockContext
       );
-      const { did } = mockContext.getCurrentIdentity();
+      const { did } = await mockContext.getCurrentIdentity();
       const constructorParams = [
         {
           authId: new BigNumber(1),
@@ -192,21 +192,23 @@ describe('consumeAuthorizationRequests procedure', () => {
       } as ConsumeAuthorizationRequestsParams;
 
       const boundFunc = isAuthorized.bind(proc);
-      expect(boundFunc(args)).toBe(true);
+      let result = await boundFunc(args);
+      expect(result).toBe(true);
 
       args.authRequests[0].targetIdentity = new Identity(
         { did: 'notTheCurrentIdentity' },
         mockContext
       );
 
-      expect(boundFunc(args)).toBe(false);
+      result = await boundFunc(args);
+      expect(result).toBe(false);
     });
 
-    test('should return whether the current identity is the target or issuer of all non-expired requests if trying to remove', () => {
+    test('should return whether the current identity is the target or issuer of all non-expired requests if trying to remove', async () => {
       const proc = procedureMockUtils.getInstance<ConsumeAuthorizationRequestsParams, void>(
         mockContext
       );
-      const { did } = mockContext.getCurrentIdentity();
+      const { did } = await mockContext.getCurrentIdentity();
       const constructorParams = [
         {
           authId: new BigNumber(1),
@@ -244,14 +246,16 @@ describe('consumeAuthorizationRequests procedure', () => {
       } as ConsumeAuthorizationRequestsParams;
 
       const boundFunc = isAuthorized.bind(proc);
-      expect(boundFunc(args)).toBe(true);
+      let result = await boundFunc(args);
+      expect(result).toBe(true);
 
       args.authRequests[0].targetIdentity = new Identity(
         { did: 'notTheCurrentIdentity' },
         mockContext
       );
 
-      expect(boundFunc(args)).toBe(false);
+      result = await boundFunc(args);
+      expect(result).toBe(false);
     });
   });
 });

--- a/src/api/procedures/__tests__/modifyClaims.ts
+++ b/src/api/procedures/__tests__/modifyClaims.ts
@@ -131,6 +131,7 @@ describe('modifyClaims procedure', () => {
 
   test('should add an add claims batch transaction to the queue', async () => {
     const proc = procedureMockUtils.getInstance<ModifyClaimsParams, void>(mockContext);
+    const { did } = await mockContext.getCurrentIdentity();
 
     await prepareModifyClaims.call(proc, args);
 
@@ -163,7 +164,7 @@ describe('modifyClaims procedure', () => {
 
     dsMockUtils.createApolloQueryStub(
       didsWithClaims({
-        trustedClaimIssuers: [mockContext.getCurrentIdentity().did],
+        trustedClaimIssuers: [did],
         dids: [someDid, otherDid],
         count: 2,
       }),
@@ -196,10 +197,11 @@ describe('modifyClaims procedure', () => {
 
   test("should throw an error if any of the claims that will be modified weren't issued by the current identity", async () => {
     const proc = procedureMockUtils.getInstance<ModifyClaimsParams, void>(mockContext);
+    const { did } = await mockContext.getCurrentIdentity();
 
     dsMockUtils.createApolloQueryStub(
       didsWithClaims({
-        trustedClaimIssuers: [mockContext.getCurrentIdentity().did],
+        trustedClaimIssuers: [did],
         dids: [someDid, otherDid],
         count: 2,
       }),
@@ -226,10 +228,11 @@ describe('modifyClaims procedure', () => {
 
   test('should add a revoke claims batch transaction to the queue', async () => {
     const proc = procedureMockUtils.getInstance<ModifyClaimsParams, void>(mockContext);
+    const { did } = await mockContext.getCurrentIdentity();
 
     dsMockUtils.createApolloQueryStub(
       didsWithClaims({
-        trustedClaimIssuers: [mockContext.getCurrentIdentity().did],
+        trustedClaimIssuers: [did],
         dids: [someDid, otherDid],
         count: 2,
       }),

--- a/src/api/procedures/consumeAuthorizationRequests.ts
+++ b/src/api/procedures/consumeAuthorizationRequests.ts
@@ -66,11 +66,11 @@ export async function prepareConsumeAuthorizationRequests(
 /**
  * @hidden
  */
-export function isAuthorized(
+export async function isAuthorized(
   this: Procedure<ConsumeAuthorizationRequestsParams>,
   { authRequests, accept }: ConsumeAuthorizationRequestsParams
-): boolean {
-  const { did } = this.context.getCurrentIdentity();
+): Promise<boolean> {
+  const { did } = await this.context.getCurrentIdentity();
 
   return authRequests.filter(isLive).every(({ targetIdentity, issuerIdentity }) => {
     let condition = did === targetIdentity.did;

--- a/src/api/procedures/modifyClaims.ts
+++ b/src/api/procedures/modifyClaims.ts
@@ -93,6 +93,7 @@ export async function prepareModifyClaims(
   }
 
   if (operation !== ClaimOperation.Add) {
+    const { did: currentDid } = await context.getCurrentIdentity();
     const {
       data: {
         didsWithClaims: { items: currentClaims },
@@ -100,7 +101,7 @@ export async function prepareModifyClaims(
     } = await context.queryMiddleware<Ensured<Query, 'didsWithClaims'>>(
       didsWithClaims({
         dids: allTargets,
-        trustedClaimIssuers: [context.getCurrentIdentity().did],
+        trustedClaimIssuers: [currentDid],
         count: allTargets.length,
       })
     );

--- a/src/api/procedures/removeSigningKeys.ts
+++ b/src/api/procedures/removeSigningKeys.ts
@@ -24,7 +24,7 @@ export async function prepareRemoveSigningKeys(
 
   const { signers } = args;
 
-  const identity = context.getCurrentIdentity();
+  const identity = await context.getCurrentIdentity();
 
   const [masterKey, signingKeys] = await Promise.all([
     identity.getMasterKey(),
@@ -71,7 +71,7 @@ export async function prepareRemoveSigningKeys(
 export async function isAuthorized(this: Procedure<RemoveSigningKeysParams>): Promise<boolean> {
   const { context } = this;
 
-  const identity = context.getCurrentIdentity();
+  const identity = await context.getCurrentIdentity();
   const masterKey = await identity.getMasterKey();
 
   return masterKey === context.getCurrentPair().address;

--- a/src/api/procedures/transferPolyX.ts
+++ b/src/api/procedures/transferPolyX.ts
@@ -57,7 +57,7 @@ export async function prepareTransferPolyX(
     });
   }
 
-  const senderIdentity = context.getCurrentIdentity();
+  const senderIdentity = await context.getCurrentIdentity();
   const receiverIdentity = new Identity({ did: identityIdToString(identityId) }, context);
 
   // TODO: queryMulti

--- a/src/base/Procedure.ts
+++ b/src/base/Procedure.ts
@@ -93,7 +93,8 @@ export class Procedure<Args extends unknown = void, ReturnValue extends unknown 
     let allowed: boolean;
 
     if (typeof checkRolesResult !== 'boolean') {
-      allowed = await context.getCurrentIdentity().hasRoles(checkRolesResult);
+      const identity = await context.getCurrentIdentity();
+      allowed = await identity.hasRoles(checkRolesResult);
     } else {
       allowed = checkRolesResult;
     }

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -381,7 +381,7 @@ let keyringOptions: KeyringOptions = defaultKeyringOptions;
 function configureContext(opts: ContextOptions): void {
   const getCurrentIdentity = sinon.stub();
   opts.withSeed
-    ? getCurrentIdentity.returns({
+    ? getCurrentIdentity.resolves({
         getPolyXBalance: sinon.stub().resolves(opts.balance?.free),
         did: opts.did,
         hasRoles: sinon.stub().resolves(opts.hasRoles),


### PR DESCRIPTION
The current identity is now fetched from the chain whenever it is used

BREAKING CHANGE: `getIdentity` in the `Polymesh` class is now async