### PR TITLE
feat: return null when identity doesn't exist

### DIFF
--- a/src/Claims.ts
+++ b/src/Claims.ts
@@ -83,8 +83,7 @@ export class Claims {
     if (target) {
       did = signerToString(target);
     } else {
-      const { did: identityId } = await context.getCurrentIdentity();
-      did = identityId;
+      ({ did } = await context.getCurrentIdentity());
     }
 
     const result = await context.issuedClaims({
@@ -174,8 +173,7 @@ export class Claims {
     if (target) {
       did = signerToString(target);
     } else {
-      const { did: identityId } = await context.getCurrentIdentity();
-      did = identityId;
+      ({ did } = await context.getCurrentIdentity());
     }
 
     const {
@@ -266,8 +264,7 @@ export class Claims {
     if (target) {
       did = signerToString(target);
     } else {
-      const { did: identityId } = await context.getCurrentIdentity();
-      did = identityId;
+      ({ did } = await context.getCurrentIdentity());
     }
 
     const result = await context.queryMiddleware<Ensured<Query, 'issuerDidsWithClaimsByTarget'>>(

--- a/src/Claims.ts
+++ b/src/Claims.ts
@@ -11,6 +11,7 @@ import { ClaimData, ClaimScope, ClaimType, Ensured, IdentityWithClaims, ResultSe
 import { ClaimOperation } from '~/types/internal';
 import {
   calculateNextKey,
+  getDid,
   removePadding,
   signerToString,
   toIdentityWithClaimsArray,
@@ -76,15 +77,9 @@ export class Claims {
     } = { includeExpired: true }
   ): Promise<ResultSet<ClaimData>> {
     const { context } = this;
-
     const { target, includeExpired, size, start } = opts;
 
-    let did;
-    if (target) {
-      did = signerToString(target);
-    } else {
-      ({ did } = await context.getCurrentIdentity());
-    }
+    const did = await getDid(target, context);
 
     const result = await context.issuedClaims({
       trustedClaimIssuers: [did],
@@ -169,12 +164,7 @@ export class Claims {
     const { context } = this;
     const { target } = opts;
 
-    let did;
-    if (target) {
-      did = signerToString(target);
-    } else {
-      ({ did } = await context.getCurrentIdentity());
-    }
+    const did = await getDid(target, context);
 
     const {
       data: { scopesByIdentity: scopes },
@@ -219,12 +209,7 @@ export class Claims {
     const { context } = this;
     const { target, includeExpired, size, start } = opts;
 
-    let did;
-    if (target) {
-      did = signerToString(target);
-    } else {
-      ({ did } = await context.getCurrentIdentity());
-    }
+    const did = await getDid(target, context);
 
     const result = await context.issuedClaims({
       targets: [did],
@@ -260,12 +245,7 @@ export class Claims {
 
     const { target, trustedClaimIssuers, scope, includeExpired, size, start } = opts;
 
-    let did;
-    if (target) {
-      did = signerToString(target);
-    } else {
-      ({ did } = await context.getCurrentIdentity());
-    }
+    const did = await getDid(target, context);
 
     const result = await context.queryMiddleware<Ensured<Query, 'issuerDidsWithClaimsByTarget'>>(
       issuerDidsWithClaimsByTarget({

--- a/src/Polymesh.ts
+++ b/src/Polymesh.ts
@@ -34,6 +34,7 @@ import {
   UnsubCallback,
 } from '~/types';
 import {
+  getDid,
   moduleAddressToString,
   signerToString,
   stringToIdentityId,
@@ -354,13 +355,7 @@ export class Polymesh {
       context,
     } = this;
 
-    let did: string;
-
-    if (args) {
-      did = signerToString(args.owner);
-    } else {
-      ({ did } = await context.getCurrentIdentity());
-    }
+    const did = await getDid(args?.owner, context);
 
     const entries = await query.asset.assetOwnershipRelations.entries(
       stringToIdentityId(did, context)
@@ -508,13 +503,7 @@ export class Polymesh {
       context,
     } = this;
 
-    let did: string;
-
-    if (args) {
-      did = signerToString(args.owner);
-    } else {
-      ({ did } = await context.getCurrentIdentity());
-    }
+    const did = await getDid(args?.owner, context);
 
     const entries = await query.asset.assetOwnershipRelations.entries(
       stringToIdentityId(did, context)

--- a/src/Polymesh.ts
+++ b/src/Polymesh.ts
@@ -326,16 +326,16 @@ export class Polymesh {
       context,
     } = this;
 
-    let identity: string;
+    let did: string;
 
     if (args) {
-      identity = signerToString(args.owner);
+      did = signerToString(args.owner);
     } else {
-      ({ did: identity } = await context.getCurrentIdentity());
+      ({ did } = await context.getCurrentIdentity());
     }
 
     const entries = await query.asset.assetOwnershipRelations.entries(
-      stringToIdentityId(identity, context)
+      stringToIdentityId(did, context)
     );
 
     const tickerReservations: TickerReservation[] = entries
@@ -385,10 +385,10 @@ export class Polymesh {
   }
 
   /**
-   * Retrieve the Identity associated to the current Account
+   * Retrieve the Identity associated to the current Account (null if there is none)
    */
-  public getCurrentIdentity(): Promise<CurrentIdentity> {
-    return this.context.getCurrentIdentity();
+  public getCurrentIdentity(): Promise<CurrentIdentity | null> {
+    return this.context.getCurrentAccount().getIdentity();
   }
 
   /**
@@ -480,16 +480,16 @@ export class Polymesh {
       context,
     } = this;
 
-    let identity: string;
+    let did: string;
 
     if (args) {
-      identity = signerToString(args.owner);
+      did = signerToString(args.owner);
     } else {
-      ({ did: identity } = await context.getCurrentIdentity());
+      ({ did } = await context.getCurrentIdentity());
     }
 
     const entries = await query.asset.assetOwnershipRelations.entries(
-      stringToIdentityId(identity, context)
+      stringToIdentityId(did, context)
     );
 
     const securityTokens: SecurityToken[] = entries

--- a/src/Polymesh.ts
+++ b/src/Polymesh.ts
@@ -83,18 +83,46 @@ export class Polymesh {
   }
 
   /**
-   * Create the instance and connect to the Polymesh node
+   * Create the instance and connect to the Polymesh node using an account seed
+   *
+   * @param params.nodeUrl - URL of the Polymesh node this instance will be connecting to
+   * @param params.signer - injected signer object (optional, only relevant if using a wallet browser extension)
+   * @param params.middleware - middleware API URL and key (optional, used for historic queries)
+   * @param params.accountSeed - hex seed of the account
    */
   static async connect(params: ConnectParamsBase & { accountSeed: string }): Promise<Polymesh>;
 
+  /**
+   * Create the instance and connect to the Polymesh node using a keyring
+   *
+   * @param params.nodeUrl - URL of the Polymesh node this instance will be connecting to
+   * @param params.signer - injected signer object (optional, only relevant if using a wallet browser extension)
+   * @param params.middleware - middleware API URL and key (optional, used for historic queries)
+   * @param params.keyring - object that holds several accounts (useful when using a wallet browser extension)
+   */
   static async connect(
     params: ConnectParamsBase & {
       keyring: CommonKeyring | UiKeyring;
     }
   ): Promise<Polymesh>;
 
+  /**
+   * Create the instance and connect to the Polymesh node using an account URI
+   *
+   * @param params.nodeUrl - URL of the Polymesh node this instance will be connecting to
+   * @param params.signer - injected signer object (optional, only relevant if using a wallet browser extension)
+   * @param params.middleware - middleware API URL and key (optional, used for historic queries)
+   * @param params.accountUri - account URI or mnemonic
+   */
   static async connect(params: ConnectParamsBase & { accountUri: string }): Promise<Polymesh>;
 
+  /**
+   * Create the instance and connect to the Polymesh node without an account
+   *
+   * @param params.nodeUrl - URL of the Polymesh node this instance will be connecting to
+   * @param params.signer - injected signer object (optional, only relevant if using a wallet browser extension)
+   * @param params.middleware - middleware API URL and key (optional, used for historic queries)
+   */
   static async connect(params: ConnectParamsBase): Promise<Polymesh>;
 
   // eslint-disable-next-line require-jsdoc

--- a/src/api/entities/Account.ts
+++ b/src/api/entities/Account.ts
@@ -2,13 +2,12 @@ import { TxTag } from 'polymesh-types/types';
 
 import { Entity, Identity } from '~/api/entities';
 import { Authorizations } from '~/api/entities/common/namespaces/Authorizations';
-import { Context, PolymeshError } from '~/base';
+import { Context } from '~/base';
 import { transactions } from '~/middleware/queries';
 import { Query, TransactionOrderByInput } from '~/middleware/types';
 import {
   AccountBalance,
   Ensured,
-  ErrorCode,
   ExtrinsicData,
   ResultSet,
   SubCallback,
@@ -89,11 +88,9 @@ export class Account extends Entity<UniqueIdentifiers> {
   }
 
   /**
-   * Retrieve the Identity associated to this Account
-   *
-   * @throws if there is no Identity associated to the Account
+   * Retrieve the Identity associated to this Account (null if there is none)
    */
-  public async getIdentity(): Promise<Identity> {
+  public async getIdentity(): Promise<Identity | null> {
     const {
       context: {
         polymeshApi: {
@@ -112,10 +109,7 @@ export class Account extends Entity<UniqueIdentifiers> {
 
       return new Identity({ did }, context);
     } catch (err) {
-      throw new PolymeshError({
-        code: ErrorCode.IdentityNotPresent,
-        message: 'The current account does not have an associated Identity',
-      });
+      return null;
     }
   }
 

--- a/src/api/entities/CurrentAccount.ts
+++ b/src/api/entities/CurrentAccount.ts
@@ -5,11 +5,11 @@ import { Account, CurrentIdentity } from '~/api/entities';
  */
 export class CurrentAccount extends Account {
   /**
-   * Retrieves the current Identity
+   * Retrieves the current Identity (null if there is none)
    */
-  public async getIdentity(): Promise<CurrentIdentity> {
-    const { did } = await super.getIdentity();
+  public async getIdentity(): Promise<CurrentIdentity | null> {
+    const identity = await super.getIdentity();
 
-    return new CurrentIdentity({ did }, this.context);
+    return identity && new CurrentIdentity({ did: identity.did }, this.context);
   }
 }

--- a/src/api/entities/Proposal/index.ts
+++ b/src/api/entities/Proposal/index.ts
@@ -15,10 +15,10 @@ import { EventIdEnum, ModuleIdEnum, Query } from '~/middleware/types';
 import { Ensured, ResultSet } from '~/types';
 import {
   balanceToBigNumber,
+  getDid,
   middlewareProposalToProposalDetails,
   numberToPipId,
   requestAtBlock,
-  signerToString,
   u32ToBigNumber,
 } from '~/utils';
 
@@ -71,13 +71,7 @@ export class Proposal extends Entity<UniqueIdentifiers> {
   public async identityHasVoted(args?: { identity: string | Identity }): Promise<boolean> {
     const { pipId, context } = this;
 
-    let did: string;
-
-    if (args) {
-      did = signerToString(args.identity);
-    } else {
-      ({ did } = await context.getCurrentIdentity());
-    }
+    const did = await getDid(args?.identity, context);
 
     const result = await context.queryMiddleware<Ensured<Query, 'eventByIndexedArgs'>>(
       eventByIndexedArgs({

--- a/src/api/entities/Proposal/index.ts
+++ b/src/api/entities/Proposal/index.ts
@@ -64,26 +64,26 @@ export class Proposal extends Entity<UniqueIdentifiers> {
   /**
    * Check if an Identity has voted on the proposal
    *
-   * @param args.identity - identity representation or Identity ID as stored in the blockchain
+   * @param args.identity - defaults to the current Identity
    *
    * @note uses the middleware
    */
   public async identityHasVoted(args?: { identity: string | Identity }): Promise<boolean> {
     const { pipId, context } = this;
 
-    let identity: string;
+    let did: string;
 
     if (args) {
-      identity = signerToString(args.identity);
+      did = signerToString(args.identity);
     } else {
-      ({ did: identity } = await context.getCurrentIdentity());
+      ({ did } = await context.getCurrentIdentity());
     }
 
     const result = await context.queryMiddleware<Ensured<Query, 'eventByIndexedArgs'>>(
       eventByIndexedArgs({
         moduleId: ModuleIdEnum.Pips,
         eventId: EventIdEnum.Voted,
-        eventArg0: identity,
+        eventArg0: did,
         eventArg2: pipId.toString(),
       })
     );

--- a/src/api/entities/__tests__/Account.ts
+++ b/src/api/entities/__tests__/Account.ts
@@ -107,15 +107,15 @@ describe('Account class', () => {
       });
 
       const result = await account.getIdentity();
-      expect(result.did).toBe(did);
+      expect(result?.did).toBe(did);
     });
 
-    test('should throw an error if there is no Identity associated to the Account', () => {
+    test('should return null if there is no Identity associated to the Account', async () => {
       dsMockUtils.createQueryStub('identity', 'keyToIdentityIds').throws();
 
-      return expect(account.getIdentity()).rejects.toThrow(
-        'The current account does not have an associated Identity'
-      );
+      const result = await account.getIdentity();
+
+      expect(result).toBe(null);
     });
   });
 

--- a/src/api/entities/__tests__/CurrentAccount.ts
+++ b/src/api/entities/__tests__/CurrentAccount.ts
@@ -41,7 +41,7 @@ describe('CurrentAccount class', () => {
       const result = await account.getIdentity();
 
       expect(result instanceof CurrentIdentity).toBe(true);
-      expect(result.did).toBe(did);
+      expect(result?.did).toBe(did);
     });
   });
 });

--- a/src/api/procedures/consumeAuthorizationRequests.ts
+++ b/src/api/procedures/consumeAuthorizationRequests.ts
@@ -76,6 +76,8 @@ export async function isAuthorized(
 
   const unexpiredRequests = authRequests.filter(request => !request.isExpired());
 
+  const fetchDid = async (): Promise<string> => did || (await context.getCurrentIdentity()).did;
+
   const authorized = await P.mapSeries(unexpiredRequests, async ({ target, issuer }) => {
     let condition;
 
@@ -83,13 +85,12 @@ export async function isAuthorized(
       const { address } = context.getCurrentAccount();
       condition = address === target.address;
     } else {
-      if (!did) {
-        ({ did } = await context.getCurrentIdentity());
-      }
+      did = await fetchDid();
       condition = did === target.did;
     }
 
     if (!accept) {
+      did = await fetchDid();
       condition = condition || did === issuer.did;
     }
 

--- a/src/base/Context.ts
+++ b/src/base/Context.ts
@@ -306,7 +306,16 @@ export class Context {
   public async getCurrentIdentity(): Promise<CurrentIdentity> {
     const account = this.getCurrentAccount();
 
-    return account.getIdentity();
+    const identity = await account.getIdentity();
+
+    if (identity === null) {
+      throw new PolymeshError({
+        code: ErrorCode.IdentityNotPresent,
+        message: 'The current account does not have an associated Identity',
+      });
+    }
+
+    return identity;
   }
 
   /**

--- a/src/base/__tests__/Context.ts
+++ b/src/base/__tests__/Context.ts
@@ -455,6 +455,20 @@ describe('Context class', () => {
       const result = await context.getCurrentIdentity();
       expect(result.did).toBe(did);
     });
+
+    test('should throw an error if there is no Identity associated to the Current Account', async () => {
+      entityMockUtils.getCurrentAccountGetIdentityStub().resolves(null);
+
+      const context = await Context.create({
+        polymeshApi: dsMockUtils.getApiInstance(),
+        middlewareApi: dsMockUtils.getMiddlewareApi(),
+        seed: 'Alice'.padEnd(32, ' '),
+      });
+
+      return expect(context.getCurrentIdentity()).rejects.toThrow(
+        'The current account does not have an associated Identity'
+      );
+    });
   });
 
   describe('method: getCurrentAccount', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import './polkadot/augment-api';
+
 import BigNumber from 'bignumber.js';
 
 export { Polymesh } from './Polymesh';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -339,6 +339,24 @@ export function signerToString(signer: string | Signer): string {
 
 /**
  * @hidden
+ * Extract the DID from an Identity, or return the Current DID if no Identity is passed
+ */
+export async function getDid(
+  target: string | Identity | undefined,
+  context: Context
+): Promise<string> {
+  let did;
+  if (target) {
+    did = signerToString(target);
+  } else {
+    ({ did } = await context.getCurrentIdentity());
+  }
+
+  return did;
+}
+
+/**
+ * @hidden
  */
 export function authorizationToAuthorizationData(
   auth: Authorization,


### PR DESCRIPTION
BREAKING CHANGE: `account.getIdentity()`, `currentAccount.getIdentity()` and `api.getCurrentIdentity()` now return null if the Identity doesn't exist (used to throw an error)