### PR TITLE
fix: fix validation when PIA is set to None

### DIFF
--- a/src/api/entities/SecurityToken/index.ts
+++ b/src/api/entities/SecurityToken/index.ts
@@ -343,7 +343,7 @@ export class SecurityToken extends Entity<UniqueIdentifiers> {
   /**
    * Remove the primary issuance agent of the Security Token
    *
-   * @note issuance won’t be possible if primary issuance agent is not set
+   * @note if primary issuance agent is not set, Security Token owner would be used by default
    */
   public removePrimaryIssuanceAgent(): Promise<TransactionQueue<void>> {
     const { ticker, context } = this;

--- a/src/api/procedures/__tests__/issueTokens.ts
+++ b/src/api/procedures/__tests__/issueTokens.ts
@@ -95,33 +95,6 @@ describe('issueTokens procedure', () => {
     });
   });
 
-  test('should throw an error if primary issuance agent is undefined', async () => {
-    const args = {
-      amount,
-      ticker,
-    };
-
-    entityMockUtils.configureMocks({
-      securityTokenOptions: {
-        details: {
-          primaryIssuanceAgent: undefined,
-        },
-      },
-    });
-
-    const proc = procedureMockUtils.getInstance<IssueTokensParams, SecurityToken>(mockContext);
-
-    let error;
-
-    try {
-      await prepareIssueTokens.call(proc, args);
-    } catch (err) {
-      error = err;
-    }
-
-    expect(error.message).toBe('You should set a primary issuance agent to issue tokens');
-  });
-
   test('should add a issue transaction to the queue', async () => {
     const isDivisible = true;
     const args = {

--- a/src/api/procedures/issueTokens.ts
+++ b/src/api/procedures/issueTokens.ts
@@ -30,7 +30,7 @@ export async function prepareIssueTokens(
 
   const securityToken = new SecurityToken({ ticker }, context);
 
-  const { isDivisible, totalSupply, primaryIssuanceAgent } = await securityToken.details();
+  const { isDivisible, totalSupply } = await securityToken.details();
 
   const supplyAfterMint = amount.plus(totalSupply);
 
@@ -42,13 +42,6 @@ export async function prepareIssueTokens(
         currentSupply: totalSupply,
         supplyLimit: MAX_TOKEN_AMOUNT,
       },
-    });
-  }
-
-  if (!primaryIssuanceAgent) {
-    throw new PolymeshError({
-      code: ErrorCode.ValidationError,
-      message: 'You should set a primary issuance agent to issue tokens',
     });
   }
 


### PR DESCRIPTION
If PIA is set to None, issuance should be possible, taking the token nowner as default PIA