### PR TITLE
feat(instruction): accept portfolios as input when creating instructions

### DIFF
--- a/src/api/entities/Identity/__tests__/Portfolios.ts
+++ b/src/api/entities/Identity/__tests__/Portfolios.ts
@@ -153,4 +153,28 @@ describe('Portfolios class', () => {
       expect(queue).toBe(expectedQueue);
     });
   });
+
+  describe('method: portfolioExists', () => {
+    test('should return whether a portfolio exists', async () => {
+      const portfolioId = new BigNumber(0);
+
+      const portfoliosStub = dsMockUtils.createQueryStub('portfolio', 'portfolios', {
+        returnValue: dsMockUtils.createMockBytes(),
+      });
+
+      stringToIdentityIdStub.returns(dsMockUtils.createMockIdentityId(did));
+      numberToU64Stub.returns(dsMockUtils.createMockU64(portfolioId.toNumber()));
+
+      let result = await portfolios.portfolioExists({ portfolioId });
+
+      expect(result).toBe(false);
+
+      const portfolioName = 'portfolioName';
+      portfoliosStub.resolves(dsMockUtils.createMockBytes(portfolioName));
+
+      result = await portfolios.portfolioExists({ portfolioId });
+
+      expect(result).toBe(true);
+    });
+  });
 });

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -12,6 +12,7 @@ import {
   meshInstructionStatusToInstructionStatus,
   momentToDate,
   numberToU64,
+  portfolioIdToPortfolio,
   tickerToString,
   u32ToBigNumber,
   u64ToBigNumber,
@@ -145,12 +146,12 @@ export class Instruction extends Entity<UniqueIdentifiers> {
       const { from, to, amount, asset } = leg;
 
       const ticker = tickerToString(asset);
-      const fromDid = identityIdToString(from.did);
-      const toDid = identityIdToString(to.did);
+      const fromPortfolio = portfolioIdToPortfolio(from, context);
+      const toPortfolio = portfolioIdToPortfolio(to, context);
 
       return {
-        from: new Identity({ did: fromDid }, context),
-        to: new Identity({ did: toDid }, context),
+        from: fromPortfolio,
+        to: toPortfolio,
         amount: balanceToBigNumber(amount),
         token: new SecurityToken({ ticker }, context),
       };

--- a/src/api/entities/Instruction/types.ts
+++ b/src/api/entities/Instruction/types.ts
@@ -1,6 +1,12 @@
 import BigNumber from 'bignumber.js';
 
-import { Identity, SecurityToken, Venue } from '~/api/entities';
+import {
+  DefaultPortfolio,
+  Identity,
+  NumberedPortfolio,
+  SecurityToken,
+  Venue,
+} from '~/api/entities';
 
 export enum InstructionStatus {
   Pending = 'Pending',
@@ -31,8 +37,8 @@ export type InstructionDetails = {
 );
 
 export interface Leg {
-  from: Identity; // NOTE @monitz87: change these identities to portfolios when the entity exists
-  to: Identity;
+  from: DefaultPortfolio | NumberedPortfolio;
+  to: DefaultPortfolio | NumberedPortfolio;
   amount: BigNumber;
   token: SecurityToken;
 }

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -74,6 +74,7 @@ interface IdentityOptions {
   hasRole?: boolean;
   hasValidCdd?: boolean;
   getPrimaryKey?: string;
+  portfoliosPortfolioExists?: boolean;
 }
 
 interface CurrentIdentityOptions extends IdentityOptions {
@@ -155,6 +156,7 @@ let identityHasRolesStub: SinonStub;
 let identityHasRoleStub: SinonStub;
 let identityHasValidCddStub: SinonStub;
 let identityGetPrimaryKeyStub: SinonStub;
+let identityPortfoliosPortfolioExistsStub: SinonStub;
 let currentIdentityHasRolesStub: SinonStub;
 let currentIdentityHasRoleStub: SinonStub;
 let currentIdentityHasValidCddStub: SinonStub;
@@ -330,12 +332,14 @@ const defaultIdentityOptions: IdentityOptions = {
   did: 'someDid',
   hasValidCdd: true,
   getPrimaryKey: 'someAddress',
+  portfoliosPortfolioExists: true,
 };
 let identityOptions: IdentityOptions = defaultIdentityOptions;
 const defaultCurrentIdentityOptions: CurrentIdentityOptions = {
   did: 'someDid',
   hasValidCdd: true,
   getPrimaryKey: 'someAddress',
+  portfoliosPortfolioExists: true,
   getSecondaryKeys: [],
 };
 let currentIdentityOptions: CurrentIdentityOptions = defaultCurrentIdentityOptions;
@@ -635,6 +639,11 @@ function configureIdentity(opts: IdentityOptions): void {
     hasRole: identityHasRoleStub.resolves(opts.hasRole),
     hasValidCdd: identityHasValidCddStub.resolves(opts.hasValidCdd),
     getPrimaryKey: identityGetPrimaryKeyStub.resolves(opts.getPrimaryKey),
+    portfolios: {
+      portfolioExists: identityPortfoliosPortfolioExistsStub.resolves(
+        opts.portfoliosPortfolioExists
+      ),
+    },
   } as unknown) as MockIdentity;
 
   Object.assign(mockInstanceContainer.identity, identity);
@@ -653,6 +662,7 @@ function initIdentity(opts?: IdentityOptions): void {
   identityHasRoleStub = sinon.stub();
   identityHasValidCddStub = sinon.stub();
   identityGetPrimaryKeyStub = sinon.stub();
+  identityPortfoliosPortfolioExistsStub = sinon.stub();
 
   identityOptions = { ...defaultIdentityOptions, ...opts };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,13 @@ import BigNumber from 'bignumber.js';
 import { TxTag } from 'polymesh-types/types';
 
 // NOTE uncomment in Governance v2 upgrade
-import { Account, Identity, Portfolio /*, Proposal */ } from '~/api/entities';
+import {
+  Account,
+  DefaultPortfolio,
+  Identity,
+  NumberedPortfolio,
+  Portfolio /*, Proposal */,
+} from '~/api/entities';
 // import { ProposalDetails } from '~/api/entities/Proposal/types';
 import { CountryCode } from '~/generated/types';
 
@@ -501,6 +507,13 @@ export interface SecondaryKey {
   signer: Signer;
   permissions: Permission[];
 }
+
+export type PortfolioLike =
+  | string
+  | Identity
+  | NumberedPortfolio
+  | DefaultPortfolio
+  | { identity: string | Identity; id: BigNumber };
 
 export { TxTags } from 'polymesh-types/types';
 export { Signer as PolkadotSigner } from '@polkadot/api/types';

--- a/src/utils/__tests__/index.ts
+++ b/src/utils/__tests__/index.ts
@@ -54,6 +54,7 @@ import {
   InstructionType,
   KnownTokenType,
   Permission,
+  PortfolioLike,
   Scope,
   ScopeType,
   Signer,
@@ -125,6 +126,7 @@ import {
   padString,
   permissionToMeshPermission,
   portfolioIdToMeshPortfolioId,
+  portfolioLikeToPortfolioId,
   posRatioToBigNumber,
   removePadding,
   requestAtBlock,
@@ -177,6 +179,10 @@ jest.mock(
 jest.mock(
   '~/base/Context',
   require('~/testUtils/mocks/dataSources').mockContextModule('~/base/Context')
+);
+jest.mock(
+  '~/api/entities/Identity',
+  require('~/testUtils/mocks/entities').mockIdentityModule('~/api/entities/Identity')
 );
 
 describe('delay', () => {
@@ -376,6 +382,21 @@ describe('portfolioIdToMeshPortfolioId', () => {
 });
 
 describe('signerToString', () => {
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    entityMockUtils.initMocks();
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+    entityMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+    entityMockUtils.reset();
+  });
+
   test('signerToString should return the Indentity DID string', () => {
     const did = 'someDid';
     const context = dsMockUtils.getContextInstance();
@@ -1515,6 +1536,7 @@ describe('signerToSignerValue and signerValueToSigner', () => {
 
   beforeAll(() => {
     dsMockUtils.initMocks();
+    entityMockUtils.initMocks();
   });
 
   beforeEach(() => {
@@ -1523,10 +1545,12 @@ describe('signerToSignerValue and signerValueToSigner', () => {
 
   afterEach(() => {
     dsMockUtils.reset();
+    entityMockUtils.reset();
   });
 
   afterAll(() => {
     dsMockUtils.cleanup();
+    entityMockUtils.cleanup();
     sinon.restore();
   });
 
@@ -2967,6 +2991,21 @@ describe('meshProposalStateToProposalState', () => {
 });
 
 describe('toIdentityWithClaimsArray', () => {
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    entityMockUtils.initMocks();
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+    entityMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+    entityMockUtils.cleanup();
+  });
+
   test('should return an IdentityWithClaims array object', () => {
     const context = dsMockUtils.getContextInstance();
     const targetDid = 'someTargetDid';
@@ -3395,20 +3434,120 @@ describe('endConditionToSettlementType', () => {
 
     expect(result).toBe(fakeResult);
   });
+});
 
-  describe('scopeToMiddlewareScope', () => {
-    test('scopeToMiddlewareScope should convert a different Scopes to a middlware Scops', () => {
-      let scope: Scope = { type: ScopeType.Identity, value: 'someDid' };
-      let result = scopeToMiddlewareScope(scope);
-      expect(result).toEqual({ type: ClaimScopeTypeEnum.Identity, value: scope.value });
+describe('scopeToMiddlewareScope', () => {
+  test('scopeToMiddlewareScope should convert a different Scopes to a middlware Scops', () => {
+    let scope: Scope = { type: ScopeType.Identity, value: 'someDid' };
+    let result = scopeToMiddlewareScope(scope);
+    expect(result).toEqual({ type: ClaimScopeTypeEnum.Identity, value: scope.value });
 
-      scope = { type: ScopeType.Ticker, value: 'someTicker' };
-      result = scopeToMiddlewareScope(scope);
-      expect(result).toEqual({ type: ClaimScopeTypeEnum.Ticker, value: 'someTicker\0\0' });
+    scope = { type: ScopeType.Ticker, value: 'someTicker' };
+    result = scopeToMiddlewareScope(scope);
+    expect(result).toEqual({ type: ClaimScopeTypeEnum.Ticker, value: 'someTicker\0\0' });
 
-      scope = { type: ScopeType.Custom, value: 'customValue' };
-      result = scopeToMiddlewareScope(scope);
-      expect(result).toEqual({ type: ClaimScopeTypeEnum.Custom, value: scope.value });
+    scope = { type: ScopeType.Custom, value: 'customValue' };
+    result = scopeToMiddlewareScope(scope);
+    expect(result).toEqual({ type: ClaimScopeTypeEnum.Custom, value: scope.value });
+  });
+});
+
+describe('portfolioLikeToPortfolioId', () => {
+  let did: string;
+  let number: BigNumber;
+  let context: Context;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    entityMockUtils.initMocks();
+
+    did = 'someDid';
+    number = new BigNumber(1);
+  });
+
+  beforeEach(() => {
+    context = dsMockUtils.getContextInstance();
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+    entityMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+    entityMockUtils.cleanup();
+  });
+
+  test('should convert a DID string to a PortfolioId', async () => {
+    const result = await portfolioLikeToPortfolioId(did, context);
+
+    expect(result).toEqual({ did, number: undefined });
+  });
+
+  test('should convert an Identity to a PortfolioId', async () => {
+    const identity = entityMockUtils.getIdentityInstance({ did });
+    Object.setPrototypeOf(identity, Identity.prototype);
+
+    const result = await portfolioLikeToPortfolioId(identity, context);
+
+    expect(result).toEqual({ did, number: undefined });
+  });
+
+  test('should convert a NumberedPortfolio to a PortfolioId', async () => {
+    const portfolio = new NumberedPortfolio({ did, id: number }, context);
+
+    const result = await portfolioLikeToPortfolioId(portfolio, context);
+
+    expect(result).toEqual({ did, number });
+  });
+
+  test('should convert a DefaultPortfolio to a PortfolioId', async () => {
+    const portfolio = new DefaultPortfolio({ did }, context);
+
+    const result = await portfolioLikeToPortfolioId(portfolio, context);
+
+    expect(result).toEqual({ did, number: undefined });
+  });
+
+  test('should convert a Portfolio identifier object to a PortfolioId', async () => {
+    const portfolioIdentifier: PortfolioLike = { identity: did, id: number };
+
+    let result = await portfolioLikeToPortfolioId(portfolioIdentifier, context);
+
+    expect(result).toEqual({ did, number });
+
+    portfolioIdentifier.identity = entityMockUtils.getIdentityInstance({
+      did,
+      portfoliosPortfolioExists: true,
+    });
+
+    result = await portfolioLikeToPortfolioId(portfolioIdentifier, context);
+
+    expect(result).toEqual({ did, number });
+  });
+
+  test("should throw an error if the Portfolio identifier object refers to a Portfolio that doesn't exist", async () => {
+    const portfolioIdentifier: PortfolioLike = {
+      identity: entityMockUtils.getIdentityInstance({
+        did,
+        portfoliosPortfolioExists: false,
+      }),
+      id: number,
+    };
+
+    let err;
+
+    try {
+      await portfolioLikeToPortfolioId(portfolioIdentifier, context);
+    } catch (e) {
+      err = e;
+    }
+
+    expect(err.message).toBe("The Portfolio doesn't exist");
+    expect(err.data).toEqual({
+      did,
+      portfolioId: number,
     });
   });
 });


### PR DESCRIPTION
Also changed the `Leg` type

BREAKING CHANGE: `Leg.from` and `Leg.to` changed from `Identity` to `DefaultPortfolio |
NumberedPortfolio`. This affects the output of `Instruction.getLegs`