### PR TITLE
fix: reject `JoinIdentity` authorizations correctly

### DIFF
--- a/src/api/entities/__tests__/AuthorizationRequest.ts
+++ b/src/api/entities/__tests__/AuthorizationRequest.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 import sinon from 'sinon';
 
 import { AuthorizationRequest, Entity, Identity } from '~/api/entities';
-import { acceptJoinIdentityAuthorization, consumeAuthorizationRequests } from '~/api/procedures';
+import { consumeAuthorizationRequests, consumeJoinIdentityAuthorization } from '~/api/procedures';
 import { Context, TransactionQueue } from '~/base';
 import { dsMockUtils } from '~/testUtils/mocks';
 import { Authorization, AuthorizationType } from '~/types';
@@ -92,7 +92,7 @@ describe('AuthorizationRequest class', () => {
       expect(queue).toBe(expectedQueue);
     });
 
-    test('should prepare the acceptJoinIdentityAuthorization procedure with the correct arguments and context, and return the resulting transaction queue', async () => {
+    test('should prepare the consumeJoinIdentityAuthorization procedure with the correct arguments and context, and return the resulting transaction queue', async () => {
       const authorizationRequest = new AuthorizationRequest(
         {
           authId: new BigNumber(1),
@@ -106,12 +106,13 @@ describe('AuthorizationRequest class', () => {
 
       const args = {
         authRequest: authorizationRequest,
+        accept: true,
       };
 
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<void>;
 
       sinon
-        .stub(acceptJoinIdentityAuthorization, 'prepare')
+        .stub(consumeJoinIdentityAuthorization, 'prepare')
         .withArgs({ ...args }, context)
         .resolves(expectedQueue);
 
@@ -126,7 +127,7 @@ describe('AuthorizationRequest class', () => {
       sinon.restore();
     });
 
-    test('should prepare the procedure with the correct arguments and context, and return the resulting transaction queue', async () => {
+    test('should prepare the consumeAuthorizationRequest procedure with the correct arguments and context, and return the resulting transaction queue', async () => {
       const authorizationRequest = new AuthorizationRequest(
         {
           authId: new BigNumber(1),
@@ -147,6 +148,35 @@ describe('AuthorizationRequest class', () => {
 
       sinon
         .stub(consumeAuthorizationRequests, 'prepare')
+        .withArgs({ ...args }, context)
+        .resolves(expectedQueue);
+
+      const queue = await authorizationRequest.remove();
+
+      expect(queue).toBe(expectedQueue);
+    });
+
+    test('should prepare the consumeJoinIdentityAuthorization procedure with the correct arguments and context, and return the resulting transaction queue', async () => {
+      const authorizationRequest = new AuthorizationRequest(
+        {
+          authId: new BigNumber(1),
+          expiry: null,
+          target: new Identity({ did: 'someDid' }, context),
+          issuer: new Identity({ did: 'otherDid' }, context),
+          data: { type: AuthorizationType.JoinIdentity, value: [] },
+        },
+        context
+      );
+
+      const args = {
+        authRequest: authorizationRequest,
+        accept: false,
+      };
+
+      const expectedQueue = ('someQueue' as unknown) as TransactionQueue<void>;
+
+      sinon
+        .stub(consumeJoinIdentityAuthorization, 'prepare')
         .withArgs({ ...args }, context)
         .resolves(expectedQueue);
 

--- a/src/api/procedures/index.ts
+++ b/src/api/procedures/index.ts
@@ -1,9 +1,9 @@
 // NOTE uncomment in Governance v2 upgrade
 
 export {
-  acceptJoinIdentityAuthorization,
-  AcceptJoinIdentityAuthorizationParams,
-} from './acceptJoinIdentityAuthorization';
+  consumeJoinIdentityAuthorization,
+  ConsumeJoinIdentityAuthorizationParams,
+} from './consumeJoinIdentityAuthorization';
 export { addInstruction, AddInstructionParams } from './addInstruction';
 // export { cancelProposal } from './cancelProposal';
 export { consumeAuthorizationRequests, ConsumeParams } from './consumeAuthorizationRequests';

--- a/src/base/PolymeshTransaction.ts
+++ b/src/base/PolymeshTransaction.ts
@@ -3,8 +3,7 @@ import { DispatchError } from '@polkadot/types/interfaces';
 import { ISubmittableResult, RegistryError } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
 import { EventEmitter } from 'events';
-import { includes } from 'lodash';
-import { TxTag, TxTags } from 'polymesh-types/types';
+import { TxTag } from 'polymesh-types/types';
 
 import { Context, PolymeshError, PostTransactionValue } from '~/base';
 import { ErrorCode, Fees, TransactionStatus } from '~/types';
@@ -60,10 +59,16 @@ export class PolymeshTransaction<Args extends unknown[], Values extends unknown[
   public isCritical: boolean;
 
   /**
-   * arguments arguments for the transaction. Available after the transaction starts running
+   * arguments for the transaction. Available after the transaction starts running
    * (may be Post Transaction Values from a previous transaction in the queue that haven't resolved yet)
    */
   public args: MapMaybePostTransactionValue<Args>;
+
+  /**
+   * whether the fees for this tx are paid by a third party.
+   *   For example, when accepting/rejecting a request to join an Identity, fees are paid by the Identity that sent the request
+   */
+  public paidByThirdParty: boolean;
 
   /**
    * @hidden
@@ -124,7 +129,16 @@ export class PolymeshTransaction<Args extends unknown[], Values extends unknown[
    * @hidden
    */
   constructor(transactionSpec: TransactionSpec<Args, Values>, context: Context) {
-    const { postTransactionValues, tx, args, signer, isCritical, fee, batchSize } = transactionSpec;
+    const {
+      postTransactionValues,
+      tx,
+      args,
+      signer,
+      isCritical,
+      fee,
+      batchSize,
+      paidByThirdParty,
+    } = transactionSpec;
 
     if (postTransactionValues) {
       this.postValues = postTransactionValues;
@@ -138,6 +152,7 @@ export class PolymeshTransaction<Args extends unknown[], Values extends unknown[
     this.batchSize = batchSize;
     this.protocolFee = fee;
     this.context = context;
+    this.paidByThirdParty = paidByThirdParty;
 
     this.setTag();
   }
@@ -197,11 +212,11 @@ export class PolymeshTransaction<Args extends unknown[], Values extends unknown[
   /**
    * Get all (protocol and gas) fees associated with this transaction. Returns null
    * if the transaction is not ready yet (this can happen if it depends on the execution of a
-   * previous transaction in the queue). Fees will be returned as zero if they are paid by a third party (such as when joining an identity)
+   * previous transaction in the queue)
    */
   public async getFees(): Promise<Fees | null> {
     const { tx, args, signer, batchSize, context } = this;
-    let { protocolFee, tag } = this;
+    let { protocolFee } = this;
 
     let unwrappedTx;
     let unwrappedArgs;
@@ -211,15 +226,6 @@ export class PolymeshTransaction<Args extends unknown[], Values extends unknown[
       unwrappedArgs = unwrapValues(args);
     } catch (err) {
       return null;
-    }
-
-    if (
-      includes([TxTags.identity.JoinIdentityAsIdentity, TxTags.identity.JoinIdentityAsKey], tag)
-    ) {
-      return {
-        protocol: new BigNumber(0),
-        gas: new BigNumber(0),
-      };
     }
 
     const { partialFee } = await unwrappedTx(...unwrappedArgs).paymentInfo(signer);

--- a/src/base/Procedure.ts
+++ b/src/base/Procedure.ts
@@ -18,6 +18,7 @@ interface AddTransactionOpts<Values extends unknown[]> {
   isCritical?: boolean;
   signer?: AddressOrPair;
   batchSize?: number;
+  paidByThirdParty?: boolean;
 }
 
 /**
@@ -154,6 +155,7 @@ export class Procedure<Args extends unknown = void, ReturnValue extends unknown 
       resolvers = ([] as unknown) as ResolverFunctionArray<Values>,
       isCritical = true,
       batchSize = null,
+      paidByThirdParty = false,
     } = options;
     let { signer } = options;
     const postTransactionValues = resolvers.map(
@@ -180,6 +182,7 @@ export class Procedure<Args extends unknown = void, ReturnValue extends unknown 
       signer,
       fee,
       batchSize,
+      paidByThirdParty,
     });
 
     return postTransactionValues;

--- a/src/base/TransactionQueue.ts
+++ b/src/base/TransactionQueue.ts
@@ -180,9 +180,15 @@ export class TransactionQueue<
    *   This means fees can't be calculated for said transaction until previous transactions in the queue have run
    * - Protocol fees may vary between when this value is fetched and when the transaction is actually executed because of a
    *   governance vote
+   *
+   * @note transaction fees that are paid by a third party aren't included in this total
    */
   public async getMinFees(): Promise<Fees> {
-    const allFees = await Promise.all(this.transactions.map(transaction => transaction.getFees()));
+    const allFees = await Promise.all(
+      this.transactions.map(transaction =>
+        transaction.paidByThirdParty ? null : transaction.getFees()
+      )
+    );
 
     return allFees.reduce<Fees>(
       (acc, next) => ({

--- a/src/base/__tests__/PolymeshTransaction.ts
+++ b/src/base/__tests__/PolymeshTransaction.ts
@@ -29,6 +29,7 @@ describe('Polymesh Transaction class', () => {
     isCritical: false,
     fee: new BigNumber(100),
     batchSize: null,
+    paidByThirdParty: false,
   };
 
   afterEach(() => {
@@ -465,45 +466,6 @@ describe('Polymesh Transaction class', () => {
       return expect(transaction.getFees()).rejects.toThrow(
         'Did not set batch size for batch transaction. Please report this error to the Polymath team'
       );
-    });
-
-    test('should return all fees as zero if the transaction is paid by a third party', async () => {
-      const tx1 = dsMockUtils.createTxStub('identity', 'joinIdentityAsKey', { gas: rawGasFees[0] });
-      const tx2 = dsMockUtils.createTxStub('identity', 'joinIdentityAsIdentity', {
-        gas: rawGasFees[1],
-      });
-
-      const args = tuple('I_SWEAR_TO_ANY_GOD_THAT_IS_LISTENING_THIS_IS_THE_LAST_TIME');
-
-      let transaction = new PolymeshTransaction(
-        {
-          ...txSpec,
-          fee: null,
-          tx: tx1,
-          args,
-        },
-        context
-      );
-
-      let result = await transaction.getFees();
-
-      expect(result?.protocol).toEqual(new BigNumber(0));
-      expect(result?.gas).toEqual(new BigNumber(0));
-
-      transaction = new PolymeshTransaction(
-        {
-          ...txSpec,
-          fee: null,
-          tx: tx2,
-          args,
-        },
-        context
-      );
-
-      result = await transaction.getFees();
-
-      expect(result?.protocol).toEqual(new BigNumber(0));
-      expect(result?.gas).toEqual(new BigNumber(0));
     });
   });
 });

--- a/src/base/__tests__/TransactionQueue.ts
+++ b/src/base/__tests__/TransactionQueue.ts
@@ -610,6 +610,7 @@ describe('Transaction Queue class', () => {
           args: [{ foo: 'bar' }],
           isCritical: true,
           autoresolve: TransactionStatus.Succeeded as TransactionStatus.Succeeded,
+          paidByThirdParty: true,
         },
       ];
 

--- a/src/polkadot/polymesh/definitions.ts
+++ b/src/polkadot/polymesh/definitions.ts
@@ -1,6 +1,12 @@
 /* eslint-disable @typescript-eslint/camelcase */
 export default {
   types: {
+    Proposer: '[u8; 32]',
+    SkippedCount: '[u8; 32]',
+    SnapshotId: '[u8; 32]',
+    SnapshotMetadata: '[u8; 32]',
+    SnapshotResult: '[u8; 32]',
+    SnapshottedPip: '[u8; 32]',
     IdentityId: '[u8; 32]',
     InvestorUid: '[u8; 32]',
     Ticker: '[u8; 12]',

--- a/src/polkadot/polymesh/definitions.ts
+++ b/src/polkadot/polymesh/definitions.ts
@@ -1,12 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 export default {
   types: {
-    Proposer: '[u8; 32]',
-    SkippedCount: '[u8; 32]',
-    SnapshotId: '[u8; 32]',
-    SnapshotMetadata: '[u8; 32]',
-    SnapshotResult: '[u8; 32]',
-    SnapshottedPip: '[u8; 32]',
     IdentityId: '[u8; 32]',
     InvestorUid: '[u8; 32]',
     Ticker: '[u8; 12]',

--- a/src/testUtils/mocks/polymeshTransaction.ts
+++ b/src/testUtils/mocks/polymeshTransaction.ts
@@ -14,6 +14,7 @@ interface MockTransactionSpec {
     protocol: BigNumber;
     gas: BigNumber;
   };
+  paidByThirdParty?: boolean;
 }
 
 interface TransactionMockData {
@@ -72,61 +73,66 @@ export function setupNextTransactions(specs: MockTransactionSpec[]): MockTransac
   const error = 'Transaction Error';
   const updateStatusStub = sinon.stub();
 
-  const instances = specs.map(({ isCritical, autoresolve, fees = null }) => {
-    const instance = {} as MockTransaction;
-    if (autoresolve === TransactionStatus.Failed) {
-      instance.run = (sinon.stub().rejects(new Error(error)) as unknown) as MockTransaction['run'];
-    } else if (autoresolve === TransactionStatus.Succeeded) {
-      instance.run = (sinon.stub().resolves(receipt) as unknown) as MockTransaction['run'];
-    } else {
-      const runStub = sinon.stub().returns(
-        new Promise((resolve, reject) => {
-          updateStatusStub.callsFake((newStatus: TransactionStatus) => {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            const { statusChangeListener } = transactionMocksData.get(instance)!;
+  const instances = specs.map(
+    ({ isCritical, autoresolve, fees = null, paidByThirdParty = false }) => {
+      const instance = {} as MockTransaction;
+      if (autoresolve === TransactionStatus.Failed) {
+        instance.run = (sinon
+          .stub()
+          .rejects(new Error(error)) as unknown) as MockTransaction['run'];
+      } else if (autoresolve === TransactionStatus.Succeeded) {
+        instance.run = (sinon.stub().resolves(receipt) as unknown) as MockTransaction['run'];
+      } else {
+        const runStub = sinon.stub().returns(
+          new Promise((resolve, reject) => {
+            updateStatusStub.callsFake((newStatus: TransactionStatus) => {
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              const { statusChangeListener } = transactionMocksData.get(instance)!;
 
-            statusChangeListener(instance);
+              statusChangeListener(instance);
 
-            if (newStatus === TransactionStatus.Succeeded) {
-              resolve(receipt);
-            }
-            if (
-              [
-                TransactionStatus.Aborted,
-                TransactionStatus.Failed,
-                TransactionStatus.Rejected,
-              ].includes(newStatus)
-            ) {
-              reject(new Error(error));
-            }
-          });
-        })
-      );
-      instance.run = (runStub as unknown) as MockTransaction['run'];
-    }
+              if (newStatus === TransactionStatus.Succeeded) {
+                resolve(receipt);
+              }
+              if (
+                [
+                  TransactionStatus.Aborted,
+                  TransactionStatus.Failed,
+                  TransactionStatus.Rejected,
+                ].includes(newStatus)
+              ) {
+                reject(new Error(error));
+              }
+            });
+          })
+        );
+        instance.run = (runStub as unknown) as MockTransaction['run'];
+      }
 
-    instance.isCritical = isCritical;
-    instance.onStatusChange = (sinon.stub().callsFake(listener => {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const mockData = transactionMocksData.get(instance)!;
+      instance.isCritical = isCritical;
+      instance.onStatusChange = (sinon.stub().callsFake(listener => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const mockData = transactionMocksData.get(instance)!;
+
+        transactionMocksData.set(instance, {
+          ...mockData,
+          statusChangeListener: listener,
+        });
+      }) as unknown) as MockTransaction['onStatusChange'];
+
+      instance.status = autoresolve || TransactionStatus.Idle;
+      instance.paidByThirdParty = paidByThirdParty;
+      instance.getFees = sinon.stub().resolves(fees) as MockTransaction['getFees'];
 
       transactionMocksData.set(instance, {
-        ...mockData,
-        statusChangeListener: listener,
+        updateStatusStub,
+        resolved: !!autoresolve,
+        statusChangeListener: sinon.stub(),
       });
-    }) as unknown) as MockTransaction['onStatusChange'];
 
-    instance.status = autoresolve || TransactionStatus.Idle;
-    instance.getFees = sinon.stub().resolves(fees) as MockTransaction['getFees'];
-
-    transactionMocksData.set(instance, {
-      updateStatusStub,
-      resolved: !!autoresolve,
-      statusChangeListener: sinon.stub(),
-    });
-
-    return instance;
-  });
+      return instance;
+    }
+  );
 
   polymeshTransactionConstructorStub = sinon.stub();
 

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -98,6 +98,10 @@ export interface TransactionSpec<
    * number of elements in the batch (only applicable to batch transactions)
    */
   batchSize: number | null;
+  /**
+   * whether the transaction fees are paid by a third party (for example when joining an identity as a secondary key)
+   */
+  paidByThirdParty: boolean;
 }
 
 export enum SignerType {


### PR DESCRIPTION
Adjusted how we handle third party fees

BREAKING CHANGE: `PolymeshTransaction.getFees` no longer returns fees as 0 when they are paid by a
third party. This is now reflected by a `paidByThirdParty` flag