### PR TITLE
chore(polkadot): upgrade types and polkadot API version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@commitlint/config-conventional": "^7.6.0",
     "@graphql-codegen/cli": "1.17.7",
     "@graphql-codegen/typescript": "1.17.7",
-    "@polkadot/typegen": "2.3.1",
+    "@polkadot/typegen": "2.6.1",
     "@semantic-release/changelog": "^3.0.4",
     "@types/bluebird": "^3.5.30",
     "@types/jest": "^23.3.10",
@@ -84,9 +84,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@polkadot/api": "2.3.1",
-    "@polkadot/util": "3.6.1",
-    "@polkadot/util-crypto": "3.6.1",
+    "@polkadot/api": "2.6.1",
+    "@polkadot/util": "4.0",
+    "@polkadot/util-crypto": "4.0",
     "@types/bignumber.js": "^5.0.0",
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",

--- a/src/api/entities/SecurityToken/Compliance/Requirements.ts
+++ b/src/api/entities/SecurityToken/Compliance/Requirements.ts
@@ -9,9 +9,9 @@ import {
   togglePauseRequirements,
 } from '~/api/procedures';
 import { TransactionQueue } from '~/base';
-import { Requirement, RequirementCompliance, SubCallback, UnsubCallback } from '~/types';
+import { Compliance, Requirement, SubCallback, UnsubCallback } from '~/types';
 import {
-  assetComplianceResultToRequirementCompliance,
+  assetComplianceResultToCompliance,
   boolToBoolean,
   complianceRequirementToRequirement,
   identityIdToString,
@@ -149,7 +149,7 @@ export class Requirements extends Namespace<SecurityToken> {
   public async checkSettle(args: {
     from?: string | Identity;
     to: string | Identity;
-  }): Promise<RequirementCompliance> {
+  }): Promise<Compliance> {
     const {
       parent: { ticker },
       context: {
@@ -174,7 +174,7 @@ export class Requirements extends Namespace<SecurityToken> {
       primaryIssuanceAgent ? stringToIdentityId(primaryIssuanceAgent.did, context) : null
     );
 
-    return assetComplianceResultToRequirementCompliance(res, context);
+    return assetComplianceResultToCompliance(res, context);
   }
 
   /**

--- a/src/api/entities/SecurityToken/Compliance/__tests__/Requirements.ts
+++ b/src/api/entities/SecurityToken/Compliance/__tests__/Requirements.ts
@@ -367,7 +367,7 @@ describe('Requirements class', () => {
       stringToIdentityIdStub = sinon.stub(utilsModule, 'stringToIdentityId');
       assetComplianceResultToRequirementComplianceStub = sinon.stub(
         utilsModule,
-        'assetComplianceResultToRequirementCompliance'
+        'assetComplianceResultToCompliance'
       );
       stringToTickerStub = sinon.stub(utilsModule, 'stringToTicker');
     });

--- a/src/base/Context.ts
+++ b/src/base/Context.ts
@@ -177,6 +177,7 @@ export class Context {
     }
 
     context.isArchiveNode = await context.isCurrentNodeArchive();
+    // context.isArchiveNode = true;
 
     return context;
   }

--- a/src/polkadot/augment-api-tx.ts
+++ b/src/polkadot/augment-api-tx.ts
@@ -5,7 +5,7 @@ import { AnyNumber, ITuple } from '@polkadot/types/types';
 import { Compact, Option, Vec } from '@polkadot/types/codec';
 import { Bytes, bool, u128, u16, u32, u64 } from '@polkadot/types/primitive';
 import { BabeEquivocationProof } from '@polkadot/types/interfaces/babe';
-import { ProposalIndex } from '@polkadot/types/interfaces/collective';
+import { MemberCount, ProposalIndex } from '@polkadot/types/interfaces/collective';
 import { CodeHash, Gas, Schedule } from '@polkadot/types/interfaces/contracts';
 import { Proposal } from '@polkadot/types/interfaces/democracy';
 import { EcdsaSignature, Extrinsic, Signature } from '@polkadot/types/interfaces/extrinsics';
@@ -77,7 +77,9 @@ import {
   SecondaryKeyWithAuth,
   SettlementType,
   Signatory,
+  SkippedCount,
   SmartExtension,
+  SnapshotResult,
   TargetIdAuthorization,
   Ticker,
   UniqueCall,
@@ -865,6 +867,15 @@ declare module '@polkadot/api/types/submittable' {
         ) => SubmittableExtrinsic<ApiType>
       >;
       /**
+       * Change this group's limit for how many concurrent active members they may be.
+       *
+       * # Arguments
+       * * `limit` - the numer of active members there may be concurrently.
+       **/
+      setActiveMembersLimit: AugmentedSubmittable<
+        (limit: MemberCount | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
        * Swaps out one member `remove` for another member `add`.
        *
        * May only be called from `SwapOrigin` or root.
@@ -957,6 +968,15 @@ declare module '@polkadot/api/types/submittable' {
         (
           members: Vec<IdentityId> | (IdentityId | string | Uint8Array)[]
         ) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Change this group's limit for how many concurrent active members they may be.
+       *
+       * # Arguments
+       * * `limit` - the numer of active members there may be concurrently.
+       **/
+      setActiveMembersLimit: AugmentedSubmittable<
+        (limit: MemberCount | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
       >;
       /**
        * Swaps out one member `remove` for another member `add`.
@@ -2271,18 +2291,17 @@ declare module '@polkadot/api/types/submittable' {
         ) => SubmittableExtrinsic<ApiType>
       >;
       /**
-       * Id bonds an additional deposit to proposal with id `id`.
-       * That amount is added to the current deposit.
+       * Approves the pending non-cooling committee PIP given by the `id`.
        *
        * # Errors
-       * * `BadOrigin`: Only the owner of the proposal can bond an additional deposit.
-       * * `ProposalIsImmutable`: A Proposal is mutable only during its cool off period.
+       * * `BadOrigin` unless a GC voting majority executes this function.
+       * * `NoSuchProposal` if the PIP with `id` doesn't exist.
+       * * `IncorrectProposalState` if the proposal isn't pending.
+       * * `ProposalOnCoolOffPeriod` if the proposal is cooling off.
+       * * `NotByCommittee` if the proposal isn't by a committee.
        **/
-      bondAdditionalDeposit: AugmentedSubmittable<
-        (
-          id: PipId | AnyNumber | Uint8Array,
-          additionalDeposit: BalanceOf | AnyNumber | Uint8Array
-        ) => SubmittableExtrinsic<ApiType>
+      approveCommitteeProposal: AugmentedSubmittable<
+        (id: PipId | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
       >;
       /**
        * It cancels the proposal of the id `id`.
@@ -2297,52 +2316,39 @@ declare module '@polkadot/api/types/submittable' {
         (id: PipId | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
       >;
       /**
-       * Governance committee can make a proposal that automatically becomes a referendum on
-       * which the committee can vote on.
-       **/
-      emergencyReferendum: AugmentedSubmittable<
-        (
-          proposal: Proposal | { callIndex?: any; args?: any } | string | Uint8Array,
-          url: Option<Url> | null | object | string | Uint8Array,
-          description: Option<PipDescription> | null | object | string | Uint8Array,
-          beneficiaries: Option<Vec<Beneficiary>> | null | object | string | Uint8Array
-        ) => SubmittableExtrinsic<ApiType>
-      >;
-      /**
-       * Moves a referendum instance into dispatch queue.
-       **/
-      enactReferendum: AugmentedSubmittable<
-        (id: PipId | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
-      >;
-      /**
-       * Any governance committee member can fast track a proposal and turn it into a referendum
-       * that will be voted on by the committee.
-       **/
-      fastTrackProposal: AugmentedSubmittable<
-        (id: PipId | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
-      >;
-      /**
-       * An emergency stop measure to kill a proposal. Governance committee can kill
-       * a proposal at any time.
-       **/
-      killProposal: AugmentedSubmittable<
-        (id: PipId | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
-      >;
-      /**
-       * It updates the enactment period of a specific referendum.
-       *
-       * # Arguments
-       * * `until`, It defines the future block where the enactment period will finished.  A
-       * `None` value means that enactment period is going to finish in the next block.
+       * Clears the snapshot and emits the event `SnapshotCleared`.
        *
        * # Errors
-       * * `BadOrigin`, Only the release coordinator can update the enactment period.
-       * * ``,
+       * * `NotACommitteeMember` - triggered when a non-GC-member executes the function.
        **/
-      overrideReferendumEnactmentPeriod: AugmentedSubmittable<
+      clearSnapshot: AugmentedSubmittable<() => SubmittableExtrinsic<ApiType>>;
+      /**
+       * Enacts `results` for the PIPs in the snapshot queue.
+       * The snapshot will be available for further enactments until it is cleared.
+       *
+       * The `results` are encoded a list of `(id, result)` where `result` is applied to `id`.
+       * Note that the snapshot priority queue is encoded with the *lowest priority first*.
+       * so `results = [(id, Approve)]` will approve `SnapshotQueue[SnapshotQueue.len() - 1]`.
+       *
+       * # Errors
+       * * `BadOrigin` - unless a GC voting majority executes this function.
+       * * `CannotSkipPip` - a given PIP has already been skipped too many times.
+       * * `SnapshotResultTooLarge` - on len(results) > len(snapshot_queue).
+       * * `SnapshotIdMismatch` - if:
+       * ```
+       * ∃ (i ∈ 0..SnapshotQueue.len()).
+       * results[i].0 ≠ SnapshotQueue[SnapshotQueue.len() - i].id
+       * ```
+       * This is protects against clearing queue while GC is voting.
+       **/
+      enactSnapshotResults: AugmentedSubmittable<
         (
-          id: PipId | AnyNumber | Uint8Array,
-          until: Option<BlockNumber> | null | object | string | Uint8Array
+          results:
+            | Vec<ITuple<[PipId, SnapshotResult]>>
+            | [
+                PipId | AnyNumber | Uint8Array,
+                SnapshotResult | 'Approve' | 'Reject' | 'Skip' | number | Uint8Array
+              ][]
         ) => SubmittableExtrinsic<ApiType>
       >;
       /**
@@ -2350,8 +2356,10 @@ declare module '@polkadot/api/types/submittable' {
        * changes the network in someway. A minimum deposit is required to open a new proposal.
        *
        * # Arguments
+       * * `proposer` is either a signing key or committee.
+       * Used to understand whether this is a committee proposal and verified against `origin`.
        * * `proposal` a dispatchable call
-       * * `deposit` minimum deposit value
+       * * `deposit` minimum deposit value, which is ignored if `proposer` is a committee.
        * * `url` a link to a website for proposal discussion
        **/
       propose: AugmentedSubmittable<
@@ -2359,28 +2367,71 @@ declare module '@polkadot/api/types/submittable' {
           proposal: Proposal | { callIndex?: any; args?: any } | string | Uint8Array,
           deposit: BalanceOf | AnyNumber | Uint8Array,
           url: Option<Url> | null | object | string | Uint8Array,
-          description: Option<PipDescription> | null | object | string | Uint8Array,
-          beneficiaries: Option<Vec<Beneficiary>> | null | object | string | Uint8Array
+          description: Option<PipDescription> | null | object | string | Uint8Array
         ) => SubmittableExtrinsic<ApiType>
       >;
       /**
-       * An emergency stop measure to kill a proposal. Governance committee can kill
-       * a proposal at any time.
+       * Prune the PIP given by the `id`, refunding any funds not already refunded.
+       * The PIP may not be active
+       *
+       * This function is intended for storage garbage collection purposes.
+       *
+       * # Errors
+       * * `BadOrigin` unless a GC voting majority executes this function.
+       * * `NoSuchProposal` if the PIP with `id` doesn't exist.
+       * * `IncorrectProposalState` if the proposal is active.
        **/
       pruneProposal: AugmentedSubmittable<
         (id: PipId | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
       >;
       /**
-       * Moves a referendum instance into rejected state.
+       * Rejects the PIP given by the `id`, refunding any bonded funds,
+       * assuming it hasn't been cancelled or executed.
+       * Note that cooling-off and proposals scheduled-for-execution can also be rejected.
+       *
+       * # Errors
+       * * `BadOrigin` unless a GC voting majority executes this function.
+       * * `NoSuchProposal` if the PIP with `id` doesn't exist.
+       * * `IncorrectProposalState` if the proposal was cancelled or executed.
        **/
-      rejectReferendum: AugmentedSubmittable<
+      rejectProposal: AugmentedSubmittable<
         (id: PipId | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Updates the execution schedule of the PIP given by `id`.
+       *
+       * # Arguments
+       * * `until` defines the future block where the enactment period will finished.
+       * `None` value means that enactment period is going to finish in the next block.
+       *
+       * # Errors
+       * * `BadOrigin` unless triggered by release coordinator.
+       * * `IncorrectProposalState` unless the proposal was in a scheduled state.
+       **/
+      rescheduleExecution: AugmentedSubmittable<
+        (
+          id: PipId | AnyNumber | Uint8Array,
+          until: Option<BlockNumber> | null | object | string | Uint8Array
+        ) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Change the maximum number of active PIPs before community members cannot propose anything.
+       **/
+      setActivePipLimit: AugmentedSubmittable<
+        (newMax: u32 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
       >;
       /**
        * Change the default enact period.
        **/
       setDefaultEnactmentPeriod: AugmentedSubmittable<
         (duration: BlockNumber | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Change the maximum skip count (`max_pip_skip_count`).
+       * New values only
+       **/
+      setMaxPipSkipCount: AugmentedSubmittable<
+        (newMax: SkippedCount | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
       >;
       /**
        * Change the minimum proposal deposit amount required to start a proposal. Only Governance
@@ -2403,16 +2454,6 @@ declare module '@polkadot/api/types/submittable' {
         (duration: BlockNumber | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
       >;
       /**
-       * Change the proposal duration value. This is the number of blocks for which votes are
-       * accepted on a proposal. Only Governance committee is allowed to change this value.
-       *
-       * # Arguments
-       * * `duration` proposal duration in blocks
-       **/
-      setProposalDuration: AugmentedSubmittable<
-        (duration: BlockNumber | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
-      >;
-      /**
        * Change whether completed PIPs are pruned. Can only be called by governance council
        *
        * # Arguments
@@ -2422,40 +2463,33 @@ declare module '@polkadot/api/types/submittable' {
         (newValue: bool | boolean | Uint8Array) => SubmittableExtrinsic<ApiType>
       >;
       /**
-       * Change the quorum threshold amount. This is the amount which a proposal must gather so
-       * as to be considered by a committee. Only Governance committee is allowed to change
-       * this value.
-       *
-       * # Arguments
-       * * `threshold` the new quorum threshold amount value
-       **/
-      setQuorumThreshold: AugmentedSubmittable<
-        (threshold: BalanceOf | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
-      >;
-      /**
-       * It unbonds any amount from the deposit of the proposal with id `id`.
+       * Takes a new snapshot of the current list of active && pending PIPs.
+       * The PIPs are then sorted into a priority queue based on each PIP's weight.
        *
        * # Errors
-       * * `BadOrigin`: Only the owner of the proposal can release part of the deposit.
-       * * `ProposalIsImmutable`: A Proposal is mutable only during its cool off period.
-       * * `InsufficientDeposit`: If the final deposit will be less that the minimum deposit for
-       * a proposal.
+       * * `NotACommitteeMember` - triggered when a non-GC-member executes the function.
        **/
-      unbondDeposit: AugmentedSubmittable<
-        (
-          id: PipId | AnyNumber | Uint8Array,
-          amount: BalanceOf | AnyNumber | Uint8Array
-        ) => SubmittableExtrinsic<ApiType>
-      >;
+      snapshot: AugmentedSubmittable<() => SubmittableExtrinsic<ApiType>>;
       /**
-       * A network member can vote on any PIP by selecting the id that
-       * corresponds ot the dispatchable action and vote with some balance.
+       * Vote either in favor (`aye_or_nay` == true) or against a PIP with `id`.
+       * The "convinction" or strength of the vote is given by `deposit`, which is reserved.
+       *
+       * Note that `vote` is *not* additive.
+       * That is, `vote(id, true, 50)` followed by `vote(id, true, 40)`
+       * will first reserve `50` and then refund `50 - 10`, ending up with `40` in deposit.
+       * To add atop of existing votes, you'll need `existing_deposit + addition`.
        *
        * # Arguments
-       * * `proposal` a dispatchable call
-       * * `id` proposal id
-       * * `aye_or_nay` a bool representing for or against vote
-       * * `deposit` minimum deposit value
+       * * `id`, proposal id
+       * * `aye_or_nay`, a bool representing for or against vote
+       * * `deposit`, the "conviction" with which the vote is made.
+       *
+       * # Errors
+       * * `NoSuchProposal` if `id` doesn't reference a valid PIP.
+       * * `NotFromCommunity` if proposal was made by a committee.
+       * * `ProposalOnCoolOffPeriod` if non-owner is voting and PIP is cooling off.
+       * * `IncorrectProposalState` if PIP isn't pending.
+       * * `InsufficientDeposit` if `origin` cannot reserve `deposit - old_deposit`.
        **/
       vote: AugmentedSubmittable<
         (
@@ -2519,22 +2553,48 @@ declare module '@polkadot/api/types/submittable' {
         ) => SubmittableExtrinsic<ApiType>
       >;
       /**
-       * Enact the referendum
+       * Votes `approve`ingly (or not, if `false`)
+       * on an existing `proposal` given by its hash, `index`.
        *
        * # Arguments
-       * * `id` - Pip Id that need to be enacted
+       * * `proposal` - A hash of the proposal to be voted on.
+       * * `index` - The proposal index.
+       * * `approve` - If `true` than this is a `for` vote, and `against` otherwise.
+       *
+       * # Errors
+       * * `BadOrigin`, if the `origin` is not a member of this committee.
        **/
-      voteEnactReferendum: AugmentedSubmittable<
-        (id: PipId | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
+      vote: AugmentedSubmittable<
+        (
+          proposal: Hash | string | Uint8Array,
+          index: ProposalIndex | AnyNumber | Uint8Array,
+          approve: bool | boolean | Uint8Array
+        ) => SubmittableExtrinsic<ApiType>
       >;
       /**
-       * Reject the referendum
+       * Proposes to the committee that `call` should be executed in its name.
+       * Alternatively, if the hash of `call` has already been recorded, i.e., already proposed,
+       * then this call counts as a vote, i.e., as if `vote_by_hash` was called.
+       *
+       * # Weight
+       *
+       * The weight of this dispatchable is that of `call` as well as the complexity
+       * for recording the vote itself.
        *
        * # Arguments
-       * * `id` - Pip Id that need to be rejected
+       * * `approve` - is this an approving vote?
+       * If the proposal doesn't exist, passing `false` will result in error `FirstVoteReject`.
+       * * `call` - the call to propose for execution.
+       *
+       * # Errors
+       * * `FirstVoteReject`, if `call` hasn't been proposed and `approve == false`.
+       * * `BadOrigin`, if the `origin` is not a member of this committee.
        **/
-      voteRejectReferendum: AugmentedSubmittable<
-        (id: PipId | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
+      voteOrPropose: AugmentedSubmittable<
+        (
+          approve: bool | boolean | Uint8Array,
+          call: Proposal | { callIndex?: any; args?: any } | string | Uint8Array
+        ) => SubmittableExtrinsic<ApiType>
       >;
     };
     portfolio: {
@@ -3912,6 +3972,207 @@ declare module '@polkadot/api/types/submittable' {
        **/
       suicide: AugmentedSubmittable<() => SubmittableExtrinsic<ApiType>>;
     };
+    technicalCommittee: {
+      /**
+       * May be called by any signed account after the voting duration has ended in order to
+       * finish voting and close the proposal.
+       *
+       * Abstentions are counted as rejections.
+       *
+       * # Arguments
+       * * `proposal` - A hash of the proposal to be closed.
+       * * `index` - The proposal index.
+       *
+       * # Complexity
+       * - the weight of `proposal` preimage.
+       * - up to three events deposited.
+       * - one read, two removals, one mutation. (plus three static reads.)
+       * - computation and i/o `O(P + L + M)` where:
+       * - `M` is number of members,
+       * - `P` is number of active proposals,
+       * - `L` is the encoded length of `proposal` preimage.
+       **/
+      close: AugmentedSubmittable<
+        (
+          proposal: Hash | string | Uint8Array,
+          index: Compact<ProposalIndex> | AnyNumber | Uint8Array
+        ) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Changes the release coordinator.
+       *
+       * # Arguments
+       * * `id` - The DID of the new release coordinator.
+       *
+       * # Errors
+       * * `MemberNotFound`, If the new coordinator `id` is not part of the committee.
+       **/
+      setReleaseCoordinator: AugmentedSubmittable<
+        (id: IdentityId | string | Uint8Array) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Change the vote threshold the determines the winning proposal. For e.g., for a simple
+       * majority use (1, 2) which represents the in-equation ">= 1/2"
+       *
+       * # Arguments
+       * * `match_criteria` - One of {AtLeast, MoreThan}.
+       * * `n` - Numerator of the fraction representing vote threshold.
+       * * `d` - Denominator of the fraction representing vote threshold.
+       **/
+      setVoteThreshold: AugmentedSubmittable<
+        (
+          n: u32 | AnyNumber | Uint8Array,
+          d: u32 | AnyNumber | Uint8Array
+        ) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Votes `approve`ingly (or not, if `false`)
+       * on an existing `proposal` given by its hash, `index`.
+       *
+       * # Arguments
+       * * `proposal` - A hash of the proposal to be voted on.
+       * * `index` - The proposal index.
+       * * `approve` - If `true` than this is a `for` vote, and `against` otherwise.
+       *
+       * # Errors
+       * * `BadOrigin`, if the `origin` is not a member of this committee.
+       **/
+      vote: AugmentedSubmittable<
+        (
+          proposal: Hash | string | Uint8Array,
+          index: ProposalIndex | AnyNumber | Uint8Array,
+          approve: bool | boolean | Uint8Array
+        ) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Proposes to the committee that `call` should be executed in its name.
+       * Alternatively, if the hash of `call` has already been recorded, i.e., already proposed,
+       * then this call counts as a vote, i.e., as if `vote_by_hash` was called.
+       *
+       * # Weight
+       *
+       * The weight of this dispatchable is that of `call` as well as the complexity
+       * for recording the vote itself.
+       *
+       * # Arguments
+       * * `approve` - is this an approving vote?
+       * If the proposal doesn't exist, passing `false` will result in error `FirstVoteReject`.
+       * * `call` - the call to propose for execution.
+       *
+       * # Errors
+       * * `FirstVoteReject`, if `call` hasn't been proposed and `approve == false`.
+       * * `BadOrigin`, if the `origin` is not a member of this committee.
+       **/
+      voteOrPropose: AugmentedSubmittable<
+        (
+          approve: bool | boolean | Uint8Array,
+          call: Proposal | { callIndex?: any; args?: any } | string | Uint8Array
+        ) => SubmittableExtrinsic<ApiType>
+      >;
+    };
+    technicalCommitteeMembership: {
+      /**
+       * Allows the calling member to *unilaterally quit* without this being subject to a GC
+       * vote.
+       *
+       * # Arguments
+       * * `origin` - Member of committee who wants to quit.
+       *
+       * # Error
+       *
+       * * Only primary key can abdicate.
+       * * Last member of a group cannot abdicate.
+       **/
+      abdicateMembership: AugmentedSubmittable<() => SubmittableExtrinsic<ApiType>>;
+      /**
+       * Adds a member `who` to the group. May only be called from `AddOrigin` or root.
+       *
+       * # Arguments
+       * * `origin` - Origin representing `AddOrigin` or root
+       * * `who` - IdentityId to be added to the group.
+       **/
+      addMember: AugmentedSubmittable<
+        (who: IdentityId | string | Uint8Array) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Disables a member at specific moment.
+       *
+       * Please note that if member is already revoked (a "valid member"), its revocation
+       * time-stamp will be updated.
+       *
+       * Any disabled member should NOT allow to act like an active member of the group. For
+       * instance, a disabled CDD member should NOT be able to generate a CDD claim. However any
+       * generated claim issued before `at` would be considered as a valid one.
+       *
+       * If you want to invalidate any generated claim, you should use `Self::remove_member`.
+       *
+       * # Arguments
+       * * `at` - Revocation time-stamp.
+       * * `who` - Target member of the group.
+       * * `expiry` - Time-stamp when `who` is removed from CDD. As soon as it is expired, the
+       * generated claims will be "invalid" as `who` is not considered a member of the group.
+       **/
+      disableMember: AugmentedSubmittable<
+        (
+          who: IdentityId | string | Uint8Array,
+          expiry: Option<Moment> | null | object | string | Uint8Array,
+          at: Option<Moment> | null | object | string | Uint8Array
+        ) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Removes a member `who` from the set. May only be called from `RemoveOrigin` or root.
+       *
+       * Any claim previously generated by this member is not valid as a group claim. For
+       * instance, if a CDD member group generated a claim for a target identity and then it is
+       * removed, that claim will be invalid.  In case you want to keep the validity of generated
+       * claims, you have to use `Self::disable_member` function
+       *
+       * # Arguments
+       * * `origin` - Origin representing `RemoveOrigin` or root
+       * * `who` - IdentityId to be removed from the group.
+       **/
+      removeMember: AugmentedSubmittable<
+        (who: IdentityId | string | Uint8Array) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Changes the membership to a new set, disregarding the existing membership.
+       * May only be called from `ResetOrigin` or root.
+       *
+       * # Arguments
+       * * `origin` - Origin representing `ResetOrigin` or root
+       * * `members` - New set of identities
+       **/
+      resetMembers: AugmentedSubmittable<
+        (
+          members: Vec<IdentityId> | (IdentityId | string | Uint8Array)[]
+        ) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Change this group's limit for how many concurrent active members they may be.
+       *
+       * # Arguments
+       * * `limit` - the numer of active members there may be concurrently.
+       **/
+      setActiveMembersLimit: AugmentedSubmittable<
+        (limit: MemberCount | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Swaps out one member `remove` for another member `add`.
+       *
+       * May only be called from `SwapOrigin` or root.
+       *
+       * # Arguments
+       * * `origin` - Origin representing `SwapOrigin` or root
+       * * `remove` - IdentityId to be removed from the group.
+       * * `add` - IdentityId to be added in place of `remove`.
+       **/
+      swapMember: AugmentedSubmittable<
+        (
+          remove: IdentityId | string | Uint8Array,
+          add: IdentityId | string | Uint8Array
+        ) => SubmittableExtrinsic<ApiType>
+      >;
+    };
     timestamp: {
       /**
        * Set the current time.
@@ -3957,6 +4218,207 @@ declare module '@polkadot/api/types/submittable' {
        **/
       reimbursement: AugmentedSubmittable<
         (amount: BalanceOf | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
+      >;
+    };
+    upgradeCommittee: {
+      /**
+       * May be called by any signed account after the voting duration has ended in order to
+       * finish voting and close the proposal.
+       *
+       * Abstentions are counted as rejections.
+       *
+       * # Arguments
+       * * `proposal` - A hash of the proposal to be closed.
+       * * `index` - The proposal index.
+       *
+       * # Complexity
+       * - the weight of `proposal` preimage.
+       * - up to three events deposited.
+       * - one read, two removals, one mutation. (plus three static reads.)
+       * - computation and i/o `O(P + L + M)` where:
+       * - `M` is number of members,
+       * - `P` is number of active proposals,
+       * - `L` is the encoded length of `proposal` preimage.
+       **/
+      close: AugmentedSubmittable<
+        (
+          proposal: Hash | string | Uint8Array,
+          index: Compact<ProposalIndex> | AnyNumber | Uint8Array
+        ) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Changes the release coordinator.
+       *
+       * # Arguments
+       * * `id` - The DID of the new release coordinator.
+       *
+       * # Errors
+       * * `MemberNotFound`, If the new coordinator `id` is not part of the committee.
+       **/
+      setReleaseCoordinator: AugmentedSubmittable<
+        (id: IdentityId | string | Uint8Array) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Change the vote threshold the determines the winning proposal. For e.g., for a simple
+       * majority use (1, 2) which represents the in-equation ">= 1/2"
+       *
+       * # Arguments
+       * * `match_criteria` - One of {AtLeast, MoreThan}.
+       * * `n` - Numerator of the fraction representing vote threshold.
+       * * `d` - Denominator of the fraction representing vote threshold.
+       **/
+      setVoteThreshold: AugmentedSubmittable<
+        (
+          n: u32 | AnyNumber | Uint8Array,
+          d: u32 | AnyNumber | Uint8Array
+        ) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Votes `approve`ingly (or not, if `false`)
+       * on an existing `proposal` given by its hash, `index`.
+       *
+       * # Arguments
+       * * `proposal` - A hash of the proposal to be voted on.
+       * * `index` - The proposal index.
+       * * `approve` - If `true` than this is a `for` vote, and `against` otherwise.
+       *
+       * # Errors
+       * * `BadOrigin`, if the `origin` is not a member of this committee.
+       **/
+      vote: AugmentedSubmittable<
+        (
+          proposal: Hash | string | Uint8Array,
+          index: ProposalIndex | AnyNumber | Uint8Array,
+          approve: bool | boolean | Uint8Array
+        ) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Proposes to the committee that `call` should be executed in its name.
+       * Alternatively, if the hash of `call` has already been recorded, i.e., already proposed,
+       * then this call counts as a vote, i.e., as if `vote_by_hash` was called.
+       *
+       * # Weight
+       *
+       * The weight of this dispatchable is that of `call` as well as the complexity
+       * for recording the vote itself.
+       *
+       * # Arguments
+       * * `approve` - is this an approving vote?
+       * If the proposal doesn't exist, passing `false` will result in error `FirstVoteReject`.
+       * * `call` - the call to propose for execution.
+       *
+       * # Errors
+       * * `FirstVoteReject`, if `call` hasn't been proposed and `approve == false`.
+       * * `BadOrigin`, if the `origin` is not a member of this committee.
+       **/
+      voteOrPropose: AugmentedSubmittable<
+        (
+          approve: bool | boolean | Uint8Array,
+          call: Proposal | { callIndex?: any; args?: any } | string | Uint8Array
+        ) => SubmittableExtrinsic<ApiType>
+      >;
+    };
+    upgradeCommitteeMembership: {
+      /**
+       * Allows the calling member to *unilaterally quit* without this being subject to a GC
+       * vote.
+       *
+       * # Arguments
+       * * `origin` - Member of committee who wants to quit.
+       *
+       * # Error
+       *
+       * * Only primary key can abdicate.
+       * * Last member of a group cannot abdicate.
+       **/
+      abdicateMembership: AugmentedSubmittable<() => SubmittableExtrinsic<ApiType>>;
+      /**
+       * Adds a member `who` to the group. May only be called from `AddOrigin` or root.
+       *
+       * # Arguments
+       * * `origin` - Origin representing `AddOrigin` or root
+       * * `who` - IdentityId to be added to the group.
+       **/
+      addMember: AugmentedSubmittable<
+        (who: IdentityId | string | Uint8Array) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Disables a member at specific moment.
+       *
+       * Please note that if member is already revoked (a "valid member"), its revocation
+       * time-stamp will be updated.
+       *
+       * Any disabled member should NOT allow to act like an active member of the group. For
+       * instance, a disabled CDD member should NOT be able to generate a CDD claim. However any
+       * generated claim issued before `at` would be considered as a valid one.
+       *
+       * If you want to invalidate any generated claim, you should use `Self::remove_member`.
+       *
+       * # Arguments
+       * * `at` - Revocation time-stamp.
+       * * `who` - Target member of the group.
+       * * `expiry` - Time-stamp when `who` is removed from CDD. As soon as it is expired, the
+       * generated claims will be "invalid" as `who` is not considered a member of the group.
+       **/
+      disableMember: AugmentedSubmittable<
+        (
+          who: IdentityId | string | Uint8Array,
+          expiry: Option<Moment> | null | object | string | Uint8Array,
+          at: Option<Moment> | null | object | string | Uint8Array
+        ) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Removes a member `who` from the set. May only be called from `RemoveOrigin` or root.
+       *
+       * Any claim previously generated by this member is not valid as a group claim. For
+       * instance, if a CDD member group generated a claim for a target identity and then it is
+       * removed, that claim will be invalid.  In case you want to keep the validity of generated
+       * claims, you have to use `Self::disable_member` function
+       *
+       * # Arguments
+       * * `origin` - Origin representing `RemoveOrigin` or root
+       * * `who` - IdentityId to be removed from the group.
+       **/
+      removeMember: AugmentedSubmittable<
+        (who: IdentityId | string | Uint8Array) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Changes the membership to a new set, disregarding the existing membership.
+       * May only be called from `ResetOrigin` or root.
+       *
+       * # Arguments
+       * * `origin` - Origin representing `ResetOrigin` or root
+       * * `members` - New set of identities
+       **/
+      resetMembers: AugmentedSubmittable<
+        (
+          members: Vec<IdentityId> | (IdentityId | string | Uint8Array)[]
+        ) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Change this group's limit for how many concurrent active members they may be.
+       *
+       * # Arguments
+       * * `limit` - the numer of active members there may be concurrently.
+       **/
+      setActiveMembersLimit: AugmentedSubmittable<
+        (limit: MemberCount | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>
+      >;
+      /**
+       * Swaps out one member `remove` for another member `add`.
+       *
+       * May only be called from `SwapOrigin` or root.
+       *
+       * # Arguments
+       * * `origin` - Origin representing `SwapOrigin` or root
+       * * `remove` - IdentityId to be removed from the group.
+       * * `add` - IdentityId to be added in place of `remove`.
+       **/
+      swapMember: AugmentedSubmittable<
+        (
+          remove: IdentityId | string | Uint8Array,
+          add: IdentityId | string | Uint8Array
+        ) => SubmittableExtrinsic<ApiType>
       >;
     };
     utility: {

--- a/src/polkadot/augment-types.ts
+++ b/src/polkadot/augment-types.ts
@@ -1,7 +1,7 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
-import { Compact, Option, Raw, Vec } from '@polkadot/types/codec';
+import { Compact, Json, Option, Raw, Vec } from '@polkadot/types/codec';
 import {
   BitVec,
   Bytes,
@@ -85,9 +85,14 @@ import {
   CodeHash,
   ContractCallRequest,
   ContractExecResult,
-  ContractExecResultSuccess,
+  ContractExecResultErr,
+  ContractExecResultErrModule,
+  ContractExecResultOk,
+  ContractExecResultResult,
   ContractExecResultSuccessTo255,
+  ContractExecResultSuccessTo260,
   ContractExecResultTo255,
+  ContractExecResultTo260,
   ContractInfo,
   ContractStorageKey,
   Gas,
@@ -404,6 +409,7 @@ import {
   LookupTarget,
   ModuleId,
   Moment,
+  MultiAddress,
   OpaqueCall,
   Origin,
   OriginCaller,
@@ -570,6 +576,7 @@ import {
   RawOrigin,
   RefCount,
   RefCountTo259,
+  SyncState,
   SystemOrigin,
   TransactionValidityError,
   UnknownTransaction,
@@ -621,6 +628,7 @@ import {
   ClaimType,
   ClassicTickerRegistration,
   Commission,
+  Committee,
   ComplianceRequirement,
   ComplianceRequirementResult,
   Condition,
@@ -648,7 +656,6 @@ import {
   IdentityClaimKey,
   IdentityId,
   IdentityRole,
-  ImplicitRequirementStatus,
   InactiveMember,
   Instruction,
   InstructionStatus,
@@ -686,6 +693,7 @@ import {
   ProposalDetails,
   ProposalState,
   ProposalStatus,
+  Proposer,
   ProtocolOp,
   ProverTickerKey,
   Receipt,
@@ -703,9 +711,14 @@ import {
   SettlementType,
   Signatory,
   SimpleTokenRecord,
+  SkippedCount,
   SmartExtension,
   SmartExtensionName,
   SmartExtensionType,
+  SnapshotId,
+  SnapshotMetadata,
+  SnapshotResult,
+  SnapshottedPip,
   TargetIdAuthorization,
   TargetIdentity,
   Ticker,
@@ -803,6 +816,9 @@ declare module '@polkadot/types/types/registry' {
     'Compact<usize>': Compact<usize>;
     'Option<usize>': Option<usize>;
     'Vec<usize>': Vec<usize>;
+    Json: Json;
+    'Option<Json>': Option<Json>;
+    'Vec<Json>': Vec<Json>;
     Raw: Raw;
     'Option<Raw>': Option<Raw>;
     'Vec<Raw>': Vec<Raw>;
@@ -954,6 +970,9 @@ declare module '@polkadot/types/types/registry' {
     ModuleId: ModuleId;
     'Option<ModuleId>': Option<ModuleId>;
     'Vec<ModuleId>': Vec<ModuleId>;
+    MultiAddress: MultiAddress;
+    'Option<MultiAddress>': Option<MultiAddress>;
+    'Vec<MultiAddress>': Vec<MultiAddress>;
     Moment: Moment;
     'Compact<Moment>': Compact<Moment>;
     'Option<Moment>': Option<Moment>;
@@ -1158,9 +1177,24 @@ declare module '@polkadot/types/types/registry' {
     ContractExecResultTo255: ContractExecResultTo255;
     'Option<ContractExecResultTo255>': Option<ContractExecResultTo255>;
     'Vec<ContractExecResultTo255>': Vec<ContractExecResultTo255>;
-    ContractExecResultSuccess: ContractExecResultSuccess;
-    'Option<ContractExecResultSuccess>': Option<ContractExecResultSuccess>;
-    'Vec<ContractExecResultSuccess>': Vec<ContractExecResultSuccess>;
+    ContractExecResultSuccessTo260: ContractExecResultSuccessTo260;
+    'Option<ContractExecResultSuccessTo260>': Option<ContractExecResultSuccessTo260>;
+    'Vec<ContractExecResultSuccessTo260>': Vec<ContractExecResultSuccessTo260>;
+    ContractExecResultTo260: ContractExecResultTo260;
+    'Option<ContractExecResultTo260>': Option<ContractExecResultTo260>;
+    'Vec<ContractExecResultTo260>': Vec<ContractExecResultTo260>;
+    ContractExecResultErrModule: ContractExecResultErrModule;
+    'Option<ContractExecResultErrModule>': Option<ContractExecResultErrModule>;
+    'Vec<ContractExecResultErrModule>': Vec<ContractExecResultErrModule>;
+    ContractExecResultErr: ContractExecResultErr;
+    'Option<ContractExecResultErr>': Option<ContractExecResultErr>;
+    'Vec<ContractExecResultErr>': Vec<ContractExecResultErr>;
+    ContractExecResultOk: ContractExecResultOk;
+    'Option<ContractExecResultOk>': Option<ContractExecResultOk>;
+    'Vec<ContractExecResultOk>': Vec<ContractExecResultOk>;
+    ContractExecResultResult: ContractExecResultResult;
+    'Option<ContractExecResultResult>': Option<ContractExecResultResult>;
+    'Vec<ContractExecResultResult>': Vec<ContractExecResultResult>;
     ContractExecResult: ContractExecResult;
     'Option<ContractExecResult>': Option<ContractExecResult>;
     'Vec<ContractExecResult>': Vec<ContractExecResult>;
@@ -1863,6 +1897,9 @@ declare module '@polkadot/types/types/registry' {
     'Compact<RefCountTo259>': Compact<RefCountTo259>;
     'Option<RefCountTo259>': Option<RefCountTo259>;
     'Vec<RefCountTo259>': Vec<RefCountTo259>;
+    SyncState: SyncState;
+    'Option<SyncState>': Option<SyncState>;
+    'Vec<SyncState>': Vec<SyncState>;
     SystemOrigin: SystemOrigin;
     'Option<SystemOrigin>': Option<SystemOrigin>;
     'Vec<SystemOrigin>': Vec<SystemOrigin>;
@@ -2550,9 +2587,6 @@ declare module '@polkadot/types/types/registry' {
     ConditionType: ConditionType;
     'Option<ConditionType>': Option<ConditionType>;
     'Vec<ConditionType>': Vec<ConditionType>;
-    ImplicitRequirementStatus: ImplicitRequirementStatus;
-    'Option<ImplicitRequirementStatus>': Option<ImplicitRequirementStatus>;
-    'Vec<ImplicitRequirementStatus>': Vec<ImplicitRequirementStatus>;
     Condition: Condition;
     'Option<Condition>': Option<Condition>;
     'Vec<Condition>': Vec<Condition>;
@@ -2569,6 +2603,7 @@ declare module '@polkadot/types/types/registry' {
     'Option<SimpleTokenRecord>': Option<SimpleTokenRecord>;
     'Vec<SimpleTokenRecord>': Vec<SimpleTokenRecord>;
     FeeOf: FeeOf;
+    'Compact<FeeOf>': Compact<FeeOf>;
     'Option<FeeOf>': Option<FeeOf>;
     'Vec<FeeOf>': Vec<FeeOf>;
     Dividend: Dividend;
@@ -2607,6 +2642,29 @@ declare module '@polkadot/types/types/registry' {
     PipsMetadata: PipsMetadata;
     'Option<PipsMetadata>': Option<PipsMetadata>;
     'Vec<PipsMetadata>': Vec<PipsMetadata>;
+    Proposer: Proposer;
+    'Option<Proposer>': Option<Proposer>;
+    'Vec<Proposer>': Vec<Proposer>;
+    Committee: Committee;
+    'Option<Committee>': Option<Committee>;
+    'Vec<Committee>': Vec<Committee>;
+    SkippedCount: SkippedCount;
+    'Compact<SkippedCount>': Compact<SkippedCount>;
+    'Option<SkippedCount>': Option<SkippedCount>;
+    'Vec<SkippedCount>': Vec<SkippedCount>;
+    SnapshottedPip: SnapshottedPip;
+    'Option<SnapshottedPip>': Option<SnapshottedPip>;
+    'Vec<SnapshottedPip>': Vec<SnapshottedPip>;
+    SnapshotId: SnapshotId;
+    'Compact<SnapshotId>': Compact<SnapshotId>;
+    'Option<SnapshotId>': Option<SnapshotId>;
+    'Vec<SnapshotId>': Vec<SnapshotId>;
+    SnapshotMetadata: SnapshotMetadata;
+    'Option<SnapshotMetadata>': Option<SnapshotMetadata>;
+    'Vec<SnapshotMetadata>': Vec<SnapshotMetadata>;
+    SnapshotResult: SnapshotResult;
+    'Option<SnapshotResult>': Option<SnapshotResult>;
+    'Vec<SnapshotResult>': Vec<SnapshotResult>;
     Beneficiary: Beneficiary;
     'Option<Beneficiary>': Option<Beneficiary>;
     'Vec<Beneficiary>': Vec<Beneficiary>;

--- a/src/polkadot/polymesh/definitions.ts
+++ b/src/polkadot/polymesh/definitions.ts
@@ -409,8 +409,8 @@ export default {
       id: 'u32',
     },
     ComplianceRequirementResult: {
-      sender_conditions: 'Vec<Condition>',
-      receiver_conditions: 'Vec<Condition>',
+      sender_conditions: 'Vec<ConditionResult>',
+      receiver_conditions: 'Vec<ConditionResult>',
       id: 'u32',
       result: 'bool',
     },
@@ -421,13 +421,6 @@ export default {
         IsAnyOf: 'Vec<Claim>',
         IsNoneOf: 'Vec<Claim>',
         IsIdentity: 'TargetIdentity',
-        HasValidProofOfInvestor: 'Ticker',
-      },
-    },
-    ImplicitRequirementStatus: {
-      _enum: {
-        Active: '',
-        Inactive: '',
       },
     },
     Condition: {
@@ -502,13 +495,41 @@ export default {
     Url: 'Text',
     PipDescription: 'Text',
     PipsMetadata: {
-      proposer: 'AccountId',
       id: 'PipId',
-      end: 'u32',
       url: 'Option<Url>',
       description: 'Option<PipDescription>',
-      cool_off_until: 'u32',
-      beneficiaries: 'Vec<Beneficiary>',
+      created_at: 'BlockNumber',
+      transaction_version: 'u32',
+    },
+    Proposer: {
+      _enum: {
+        Community: 'AccountId',
+        Committee: 'Committee',
+      },
+    },
+    Committee: {
+      _enum: {
+        Technical: '',
+        Upgrade: '',
+      },
+    },
+    SkippedCount: 'u8',
+    SnapshottedPip: {
+      id: 'PipId',
+      weight: '(bool, Balance)',
+    },
+    SnapshotId: 'u32',
+    SnapshotMetadata: {
+      created_at: 'BlockNumber',
+      made_by: 'AccountId',
+      id: 'SnapshotId',
+    },
+    SnapshotResult: {
+      _enum: {
+        Approve: '',
+        Reject: '',
+        Skip: '',
+      },
     },
     Beneficiary: {
       id: 'IdentityId',
@@ -525,7 +546,7 @@ export default {
     },
     PipId: 'u32',
     ProposalState: {
-      _enum: ['Pending', 'Cancelled', 'Killed', 'Rejected', 'Referendum'],
+      _enum: ['Pending', 'Cancelled', 'Rejected', 'Scheduled', 'Failed', 'Executed'],
     },
     ReferendumState: {
       _enum: ['Pending', 'Scheduled', 'Rejected', 'Failed', 'Executed'],
@@ -537,6 +558,8 @@ export default {
       id: 'PipId',
       proposal: 'Call',
       state: 'ProposalState',
+      proposer: 'Proposer',
+      cool_off_until: 'u32',
     },
     ProposalData: {
       _enum: {

--- a/src/polkadot/polymesh/types.ts
+++ b/src/polkadot/polymesh/types.ts
@@ -275,6 +275,12 @@ export interface Commission extends Enum {
   readonly asGlobal: u32;
 }
 
+/** @name Committee */
+export interface Committee extends Enum {
+  readonly isTechnical: boolean;
+  readonly isUpgrade: boolean;
+}
+
 /** @name ComplianceRequirement */
 export interface ComplianceRequirement extends Struct {
   readonly sender_conditions: Vec<Condition>;
@@ -284,8 +290,8 @@ export interface ComplianceRequirement extends Struct {
 
 /** @name ComplianceRequirementResult */
 export interface ComplianceRequirementResult extends Struct {
-  readonly sender_conditions: Vec<Condition>;
-  readonly receiver_conditions: Vec<Condition>;
+  readonly sender_conditions: Vec<ConditionResult>;
+  readonly receiver_conditions: Vec<ConditionResult>;
   readonly id: u32;
   readonly result: bool;
 }
@@ -314,8 +320,6 @@ export interface ConditionType extends Enum {
   readonly asIsNoneOf: Vec<Claim>;
   readonly isIsIdentity: boolean;
   readonly asIsIdentity: TargetIdentity;
-  readonly isHasValidProofOfInvestor: boolean;
-  readonly asHasValidProofOfInvestor: Ticker;
 }
 
 /** @name Counter */
@@ -696,12 +700,6 @@ export interface IdentityRole extends Enum {
   readonly isVerifiedIdentityClaimIssuer: boolean;
 }
 
-/** @name ImplicitRequirementStatus */
-export interface ImplicitRequirementStatus extends Enum {
-  readonly isActive: boolean;
-  readonly isInactive: boolean;
-}
-
 /** @name InactiveMember */
 export interface InactiveMember extends Struct {
   readonly id: IdentityId;
@@ -841,6 +839,8 @@ export interface Pip extends Struct {
   readonly id: PipId;
   readonly proposal: Call;
   readonly state: ProposalState;
+  readonly proposer: Proposer;
+  readonly cool_off_until: u32;
 }
 
 /** @name PipDescription */
@@ -851,13 +851,11 @@ export interface PipId extends u32 {}
 
 /** @name PipsMetadata */
 export interface PipsMetadata extends Struct {
-  readonly proposer: AccountId;
   readonly id: PipId;
-  readonly end: u32;
   readonly url: Option<Url>;
   readonly description: Option<PipDescription>;
-  readonly cool_off_until: u32;
-  readonly beneficiaries: Vec<Beneficiary>;
+  readonly created_at: BlockNumber;
+  readonly transaction_version: u32;
 }
 
 /** @name PolymeshVotes */
@@ -922,9 +920,10 @@ export interface ProposalDetails extends Struct {
 export interface ProposalState extends Enum {
   readonly isPending: boolean;
   readonly isCancelled: boolean;
-  readonly isKilled: boolean;
   readonly isRejected: boolean;
-  readonly isReferendum: boolean;
+  readonly isScheduled: boolean;
+  readonly isFailed: boolean;
+  readonly isExecuted: boolean;
 }
 
 /** @name ProposalStatus */
@@ -934,6 +933,14 @@ export interface ProposalStatus extends Enum {
   readonly isExecutionSuccessful: boolean;
   readonly isExecutionFailed: boolean;
   readonly isRejected: boolean;
+}
+
+/** @name Proposer */
+export interface Proposer extends Enum {
+  readonly isCommunity: boolean;
+  readonly asCommunity: AccountId;
+  readonly isCommittee: boolean;
+  readonly asCommittee: Committee;
 }
 
 /** @name ProtocolOp */
@@ -1064,6 +1071,9 @@ export interface SimpleTokenRecord extends Struct {
   readonly owner_did: IdentityId;
 }
 
+/** @name SkippedCount */
+export interface SkippedCount extends u8 {}
+
 /** @name SmartExtension */
 export interface SmartExtension extends Struct {
   readonly extension_type: SmartExtensionType;
@@ -1081,6 +1091,29 @@ export interface SmartExtensionType extends Enum {
   readonly isOfferings: boolean;
   readonly isCustom: boolean;
   readonly asCustom: Bytes;
+}
+
+/** @name SnapshotId */
+export interface SnapshotId extends u32 {}
+
+/** @name SnapshotMetadata */
+export interface SnapshotMetadata extends Struct {
+  readonly created_at: BlockNumber;
+  readonly made_by: AccountId;
+  readonly id: SnapshotId;
+}
+
+/** @name SnapshotResult */
+export interface SnapshotResult extends Enum {
+  readonly isApprove: boolean;
+  readonly isReject: boolean;
+  readonly isSkip: boolean;
+}
+
+/** @name SnapshottedPip */
+export interface SnapshottedPip extends Struct {
+  readonly id: PipId;
+  readonly weight: ITuple<[bool, Balance]>;
 }
 
 /** @name STO */

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -47,6 +47,7 @@ import {
   ComplianceRequirement,
   ComplianceRequirementResult,
   Condition,
+  ConditionResult,
   ConditionType,
   CountryCode,
   DidRecord,
@@ -1706,6 +1707,26 @@ export const createMockCondition = (condition?: {
  * @hidden
  * NOTE: `isEmpty` will be set to true if no value is passed
  */
+export const createMockConditionResult = (conditionResult?: {
+  condition: Condition;
+  result: bool;
+}): ConditionResult => {
+  const auxConditionResult = conditionResult || {
+    condition: createMockCondition(),
+    result: createMockBool(),
+  };
+  return createMockCodec(
+    {
+      ...auxConditionResult,
+    },
+    !conditionResult
+  ) as ConditionResult;
+};
+
+/**
+ * @hidden
+ * NOTE: `isEmpty` will be set to true if no value is passed
+ */
 export const createMockComplianceRequirement = (complianceRequirement?: {
   sender_conditions: Condition[];
   receiver_conditions: Condition[];
@@ -1730,8 +1751,8 @@ export const createMockComplianceRequirement = (complianceRequirement?: {
  * NOTE: `isEmpty` will be set to true if no value is passed
  */
 export const createMockComplianceRequirementResult = (complianceRequirementResult?: {
-  sender_conditions: Condition[];
-  receiver_conditions: Condition[];
+  sender_conditions: ConditionResult[];
+  receiver_conditions: ConditionResult[];
   id: u32;
   result: bool;
 }): ComplianceRequirementResult => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -341,10 +341,19 @@ export interface Requirement {
   conditions: Condition[];
 }
 
+export interface ConditionCompliance {
+  condition: Condition;
+  complies: boolean;
+}
+
 export interface RequirementCompliance {
-  requirements: (Requirement & {
-    complies: boolean;
-  })[];
+  id: number;
+  conditions: ConditionCompliance[];
+  complies: boolean;
+}
+
+export interface Compliance {
+  requirements: RequirementCompliance[];
   complies: boolean;
 }
 

--- a/src/utils/__tests__/index.ts
+++ b/src/utils/__tests__/index.ts
@@ -54,6 +54,7 @@ import {
   Claim,
   ClaimType,
   Condition,
+  ConditionCompliance,
   ConditionTarget,
   ConditionType,
   CountryCode,
@@ -82,7 +83,7 @@ import {
 import {
   accountIdToString,
   addressToKey,
-  assetComplianceResultToRequirementCompliance,
+  assetComplianceResultToCompliance,
   assetIdentifierToTokenIdentifier,
   assetNameToString,
   assetTypeToString,
@@ -101,6 +102,7 @@ import {
   cddIdToString,
   cddStatusToBoolean,
   claimToMeshClaim,
+  complianceRequirementResultToRequirementCompliance,
   complianceRequirementToRequirement,
   createClaim,
   dateToMoment,
@@ -2223,6 +2225,210 @@ describe('scopeToMeshScope and meshScopeToScope', () => {
   });
 });
 
+describe('complianceRequirementResultToRequirementCompliance', () => {
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+  });
+
+  test('complianceRequirementResultToRequirementCompliance should convert a polkadot Compliance Requirement Result object to a RequirementCompliance', () => {
+    const id = 1;
+    const tokenDid = 'someTokenDid';
+    const cddId = 'someCddId';
+    const issuerDids = ['someDid', 'otherDid'];
+    const targetIdentityDid = 'someDid';
+    const context = dsMockUtils.getContextInstance();
+    const conditions: ConditionCompliance[] = [
+      {
+        condition: {
+          type: ConditionType.IsPresent,
+          target: ConditionTarget.Both,
+          claim: {
+            type: ClaimType.KnowYourCustomer,
+            scope: { type: ScopeType.Identity, value: tokenDid },
+          },
+          trustedClaimIssuers: issuerDids,
+        },
+        complies: true,
+      },
+      {
+        condition: {
+          type: ConditionType.IsAbsent,
+          target: ConditionTarget.Receiver,
+          claim: {
+            type: ClaimType.BuyLockup,
+            scope: { type: ScopeType.Identity, value: tokenDid },
+          },
+          trustedClaimIssuers: issuerDids,
+        },
+        complies: false,
+      },
+      {
+        condition: {
+          type: ConditionType.IsNoneOf,
+          target: ConditionTarget.Sender,
+          claims: [
+            {
+              type: ClaimType.Blocked,
+              scope: { type: ScopeType.Identity, value: tokenDid },
+            },
+            {
+              type: ClaimType.SellLockup,
+              scope: { type: ScopeType.Identity, value: tokenDid },
+            },
+          ],
+          trustedClaimIssuers: issuerDids,
+        },
+        complies: true,
+      },
+      {
+        condition: {
+          type: ConditionType.IsAnyOf,
+          target: ConditionTarget.Both,
+          claims: [
+            {
+              type: ClaimType.Exempted,
+              scope: { type: ScopeType.Identity, value: tokenDid },
+            },
+            {
+              type: ClaimType.CustomerDueDiligence,
+              id: cddId,
+            },
+          ],
+          trustedClaimIssuers: issuerDids,
+        },
+        complies: false,
+      },
+      {
+        condition: {
+          type: ConditionType.IsIdentity,
+          target: ConditionTarget.Sender,
+          identity: new Identity({ did: targetIdentityDid }, context),
+          trustedClaimIssuers: issuerDids,
+        },
+        complies: true,
+      },
+      {
+        condition: {
+          type: ConditionType.IsPrimaryIssuanceAgent,
+          target: ConditionTarget.Receiver,
+          trustedClaimIssuers: issuerDids,
+        },
+        complies: false,
+      },
+    ];
+    const fakeResult = {
+      id,
+      conditions,
+      complies: false,
+    };
+
+    const scope = dsMockUtils.createMockScope({
+      Identity: dsMockUtils.createMockIdentityId(tokenDid),
+    });
+    const issuers = issuerDids.map(dsMockUtils.createMockIdentityId);
+    const rawConditions = [
+      /* eslint-disable @typescript-eslint/camelcase */
+      dsMockUtils.createMockConditionResult({
+        condition: dsMockUtils.createMockCondition({
+          condition_type: dsMockUtils.createMockConditionType({
+            IsPresent: dsMockUtils.createMockClaim({ KnowYourCustomer: scope }),
+          }),
+          issuers,
+        }),
+        result: dsMockUtils.createMockBool(true),
+      }),
+      dsMockUtils.createMockConditionResult({
+        condition: dsMockUtils.createMockCondition({
+          condition_type: dsMockUtils.createMockConditionType({
+            IsAbsent: dsMockUtils.createMockClaim({ BuyLockup: scope }),
+          }),
+          issuers,
+        }),
+        result: dsMockUtils.createMockBool(false),
+      }),
+      dsMockUtils.createMockConditionResult({
+        condition: dsMockUtils.createMockCondition({
+          condition_type: dsMockUtils.createMockConditionType({
+            IsNoneOf: [
+              dsMockUtils.createMockClaim({ Blocked: scope }),
+              dsMockUtils.createMockClaim({ SellLockup: scope }),
+            ],
+          }),
+          issuers,
+        }),
+        result: dsMockUtils.createMockBool(true),
+      }),
+      dsMockUtils.createMockConditionResult({
+        condition: dsMockUtils.createMockCondition({
+          condition_type: dsMockUtils.createMockConditionType({
+            IsAnyOf: [
+              dsMockUtils.createMockClaim({ Exempted: scope }),
+              dsMockUtils.createMockClaim({
+                CustomerDueDiligence: dsMockUtils.createMockCddId(cddId),
+              }),
+            ],
+          }),
+          issuers,
+        }),
+        result: dsMockUtils.createMockBool(false),
+      }),
+      dsMockUtils.createMockConditionResult({
+        condition: dsMockUtils.createMockCondition({
+          condition_type: dsMockUtils.createMockConditionType({
+            IsIdentity: dsMockUtils.createMockTargetIdentity({
+              Specific: dsMockUtils.createMockIdentityId(targetIdentityDid),
+            }),
+          }),
+          issuers,
+        }),
+        result: dsMockUtils.createMockBool(true),
+      }),
+      dsMockUtils.createMockConditionResult({
+        condition: dsMockUtils.createMockCondition({
+          condition_type: dsMockUtils.createMockConditionType({
+            IsIdentity: dsMockUtils.createMockTargetIdentity('PrimaryIssuanceAgent'),
+          }),
+          issuers,
+        }),
+        result: dsMockUtils.createMockBool(false),
+      }),
+    ];
+    const complianceRequirement = dsMockUtils.createMockComplianceRequirementResult({
+      sender_conditions: [
+        rawConditions[0],
+        rawConditions[2],
+        rawConditions[2],
+        rawConditions[3],
+        rawConditions[4],
+      ],
+      receiver_conditions: [
+        rawConditions[0],
+        rawConditions[1],
+        rawConditions[1],
+        rawConditions[3],
+        rawConditions[5],
+      ],
+      id: dsMockUtils.createMockU32(1),
+      result: dsMockUtils.createMockBool(false),
+    });
+    /* eslint-enable @typescript-eslint/camelcase */
+
+    const result = complianceRequirementResultToRequirementCompliance(
+      complianceRequirement,
+      dsMockUtils.getContextInstance()
+    );
+    expect(result.conditions).toEqual(expect.arrayContaining(fakeResult.conditions));
+  });
+});
+
 describe('requirementToComplianceRequirement and complianceRequirementToRequirement', () => {
   beforeAll(() => {
     dsMockUtils.initMocks();
@@ -2480,7 +2686,7 @@ describe('requirementToComplianceRequirement and complianceRequirementToRequirem
   });
 });
 
-describe('assetComplianceResultToRequirementCompliance', () => {
+describe('assetComplianceResultToCompliance', () => {
   beforeAll(() => {
     dsMockUtils.initMocks();
   });
@@ -2493,60 +2699,72 @@ describe('assetComplianceResultToRequirementCompliance', () => {
     dsMockUtils.cleanup();
   });
 
-  test('assetComplianceResultToRequirementCompliance should convert a polkadot AssetComplianceResult object to a RequirementCompliance', () => {
+  test('assetComplianceResultToCompliance should convert a polkadot AssetComplianceResult object to a RequirementCompliance', () => {
     const id = 1;
     const tokenDid = 'someTokenDid';
     const cddId = 'someCddId';
     const issuerDids = ['someDid', 'otherDid'];
     const context = dsMockUtils.getContextInstance();
-    const conditions: Condition[] = [
+    const conditions: ConditionCompliance[] = [
       {
-        type: ConditionType.IsPresent,
-        target: ConditionTarget.Both,
-        claim: {
-          type: ClaimType.KnowYourCustomer,
-          scope: { type: ScopeType.Identity, value: tokenDid },
+        condition: {
+          type: ConditionType.IsPresent,
+          target: ConditionTarget.Both,
+          claim: {
+            type: ClaimType.KnowYourCustomer,
+            scope: { type: ScopeType.Identity, value: tokenDid },
+          },
+          trustedClaimIssuers: issuerDids,
         },
-        trustedClaimIssuers: issuerDids,
+        complies: true,
       },
       {
-        type: ConditionType.IsAbsent,
-        target: ConditionTarget.Receiver,
-        claim: {
-          type: ClaimType.BuyLockup,
-          scope: { type: ScopeType.Identity, value: tokenDid },
+        condition: {
+          type: ConditionType.IsAbsent,
+          target: ConditionTarget.Receiver,
+          claim: {
+            type: ClaimType.BuyLockup,
+            scope: { type: ScopeType.Identity, value: tokenDid },
+          },
+          trustedClaimIssuers: issuerDids,
         },
-        trustedClaimIssuers: issuerDids,
+        complies: false,
       },
       {
-        type: ConditionType.IsNoneOf,
-        target: ConditionTarget.Sender,
-        claims: [
-          {
-            type: ClaimType.Blocked,
-            scope: { type: ScopeType.Identity, value: tokenDid },
-          },
-          {
-            type: ClaimType.SellLockup,
-            scope: { type: ScopeType.Identity, value: tokenDid },
-          },
-        ],
-        trustedClaimIssuers: issuerDids,
+        condition: {
+          type: ConditionType.IsNoneOf,
+          target: ConditionTarget.Sender,
+          claims: [
+            {
+              type: ClaimType.Blocked,
+              scope: { type: ScopeType.Identity, value: tokenDid },
+            },
+            {
+              type: ClaimType.SellLockup,
+              scope: { type: ScopeType.Identity, value: tokenDid },
+            },
+          ],
+          trustedClaimIssuers: issuerDids,
+        },
+        complies: true,
       },
       {
-        type: ConditionType.IsAnyOf,
-        target: ConditionTarget.Both,
-        claims: [
-          {
-            type: ClaimType.Exempted,
-            scope: { type: ScopeType.Identity, value: tokenDid },
-          },
-          {
-            type: ClaimType.CustomerDueDiligence,
-            id: cddId,
-          },
-        ],
-        trustedClaimIssuers: issuerDids,
+        condition: {
+          type: ConditionType.IsAnyOf,
+          target: ConditionTarget.Both,
+          claims: [
+            {
+              type: ClaimType.Exempted,
+              scope: { type: ScopeType.Identity, value: tokenDid },
+            },
+            {
+              type: ClaimType.CustomerDueDiligence,
+              id: cddId,
+            },
+          ],
+          trustedClaimIssuers: issuerDids,
+        },
+        complies: false,
       },
     ];
     const fakeResult = {
@@ -2560,37 +2778,50 @@ describe('assetComplianceResultToRequirementCompliance', () => {
     const issuers = issuerDids.map(dsMockUtils.createMockIdentityId);
     /* eslint-disable @typescript-eslint/camelcase */
     const rawConditions = [
-      dsMockUtils.createMockCondition({
-        condition_type: dsMockUtils.createMockConditionType({
-          IsPresent: dsMockUtils.createMockClaim({ KnowYourCustomer: scope }),
+      /* eslint-disable @typescript-eslint/camelcase */
+      dsMockUtils.createMockConditionResult({
+        condition: dsMockUtils.createMockCondition({
+          condition_type: dsMockUtils.createMockConditionType({
+            IsPresent: dsMockUtils.createMockClaim({ KnowYourCustomer: scope }),
+          }),
+          issuers,
         }),
-        issuers,
+        result: dsMockUtils.createMockBool(true),
       }),
-      dsMockUtils.createMockCondition({
-        condition_type: dsMockUtils.createMockConditionType({
-          IsAbsent: dsMockUtils.createMockClaim({ BuyLockup: scope }),
+      dsMockUtils.createMockConditionResult({
+        condition: dsMockUtils.createMockCondition({
+          condition_type: dsMockUtils.createMockConditionType({
+            IsAbsent: dsMockUtils.createMockClaim({ BuyLockup: scope }),
+          }),
+          issuers,
         }),
-        issuers,
+        result: dsMockUtils.createMockBool(false),
       }),
-      dsMockUtils.createMockCondition({
-        condition_type: dsMockUtils.createMockConditionType({
-          IsNoneOf: [
-            dsMockUtils.createMockClaim({ Blocked: scope }),
-            dsMockUtils.createMockClaim({ SellLockup: scope }),
-          ],
+      dsMockUtils.createMockConditionResult({
+        condition: dsMockUtils.createMockCondition({
+          condition_type: dsMockUtils.createMockConditionType({
+            IsNoneOf: [
+              dsMockUtils.createMockClaim({ Blocked: scope }),
+              dsMockUtils.createMockClaim({ SellLockup: scope }),
+            ],
+          }),
+          issuers,
         }),
-        issuers,
+        result: dsMockUtils.createMockBool(true),
       }),
-      dsMockUtils.createMockCondition({
-        condition_type: dsMockUtils.createMockConditionType({
-          IsAnyOf: [
-            dsMockUtils.createMockClaim({ Exempted: scope }),
-            dsMockUtils.createMockClaim({
-              CustomerDueDiligence: dsMockUtils.createMockCddId(cddId),
-            }),
-          ],
+      dsMockUtils.createMockConditionResult({
+        condition: dsMockUtils.createMockCondition({
+          condition_type: dsMockUtils.createMockConditionType({
+            IsAnyOf: [
+              dsMockUtils.createMockClaim({ Exempted: scope }),
+              dsMockUtils.createMockClaim({
+                CustomerDueDiligence: dsMockUtils.createMockCddId(cddId),
+              }),
+            ],
+          }),
+          issuers,
         }),
-        issuers,
+        result: dsMockUtils.createMockBool(false),
       }),
     ];
 
@@ -2608,7 +2839,7 @@ describe('assetComplianceResultToRequirementCompliance', () => {
       result: dsMockUtils.createMockBool(true),
     });
 
-    let result = assetComplianceResultToRequirementCompliance(assetComplianceResult, context);
+    let result = assetComplianceResultToCompliance(assetComplianceResult, context);
     expect(result.requirements[0].conditions).toEqual(
       expect.arrayContaining(fakeResult.conditions)
     );
@@ -2620,7 +2851,7 @@ describe('assetComplianceResultToRequirementCompliance', () => {
       result: dsMockUtils.createMockBool(true),
     });
 
-    result = assetComplianceResultToRequirementCompliance(assetComplianceResult, context);
+    result = assetComplianceResultToCompliance(assetComplianceResult, context);
     expect(result.complies).toBeTruthy();
   });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -40,6 +40,7 @@ import {
   CddStatus,
   Claim as MeshClaim,
   ComplianceRequirement,
+  ComplianceRequirementResult,
   Condition as MeshCondition,
   ConditionType as MeshConditionType,
   Document,
@@ -86,7 +87,9 @@ import {
   AuthorizationType,
   Claim,
   ClaimType,
+  Compliance,
   Condition,
+  ConditionCompliance,
   ConditionTarget,
   ConditionType,
   CountryCode,
@@ -1324,59 +1327,143 @@ export function requirementToComplianceRequirement(
 /**
  * @hidden
  */
-export function complianceRequirementToRequirement(
-  complianceRequirement: ComplianceRequirement,
+function meshConditionTypeToCondition(
+  meshConditionType: MeshConditionType,
   context: Context
-): Requirement {
-  const meshConditionTypeToCondition = (
-    meshConditionType: MeshConditionType
-  ):
-    | Pick<SingleClaimCondition, 'type' | 'claim'>
-    | Pick<MultiClaimCondition, 'type' | 'claims'>
-    | Pick<IdentityCondition, 'type' | 'identity'>
-    | Pick<PrimaryIssuanceAgentCondition, 'type'> => {
-    if (meshConditionType.isIsPresent) {
+):
+  | Pick<SingleClaimCondition, 'type' | 'claim'>
+  | Pick<MultiClaimCondition, 'type' | 'claims'>
+  | Pick<IdentityCondition, 'type' | 'identity'>
+  | Pick<PrimaryIssuanceAgentCondition, 'type'> {
+  if (meshConditionType.isIsPresent) {
+    return {
+      type: ConditionType.IsPresent,
+      claim: meshClaimToClaim(meshConditionType.asIsPresent),
+    };
+  }
+
+  if (meshConditionType.isIsAbsent) {
+    return {
+      type: ConditionType.IsAbsent,
+      claim: meshClaimToClaim(meshConditionType.asIsAbsent),
+    };
+  }
+
+  if (meshConditionType.isIsAnyOf) {
+    return {
+      type: ConditionType.IsAnyOf,
+      claims: meshConditionType.asIsAnyOf.map(claim => meshClaimToClaim(claim)),
+    };
+  }
+
+  if (meshConditionType.isIsIdentity) {
+    const target = meshConditionType.asIsIdentity;
+
+    if (target.isPrimaryIssuanceAgent) {
       return {
-        type: ConditionType.IsPresent,
-        claim: meshClaimToClaim(meshConditionType.asIsPresent),
-      };
-    }
-
-    if (meshConditionType.isIsAbsent) {
-      return {
-        type: ConditionType.IsAbsent,
-        claim: meshClaimToClaim(meshConditionType.asIsAbsent),
-      };
-    }
-
-    if (meshConditionType.isIsAnyOf) {
-      return {
-        type: ConditionType.IsAnyOf,
-        claims: meshConditionType.asIsAnyOf.map(claim => meshClaimToClaim(claim)),
-      };
-    }
-
-    if (meshConditionType.isIsIdentity) {
-      const target = meshConditionType.asIsIdentity;
-
-      if (target.isPrimaryIssuanceAgent) {
-        return {
-          type: ConditionType.IsPrimaryIssuanceAgent,
-        };
-      }
-
-      return {
-        type: ConditionType.IsIdentity,
-        identity: new Identity({ did: identityIdToString(target.asSpecific) }, context),
+        type: ConditionType.IsPrimaryIssuanceAgent,
       };
     }
 
     return {
-      type: ConditionType.IsNoneOf,
-      claims: meshConditionType.asIsNoneOf.map(claim => meshClaimToClaim(claim)),
+      type: ConditionType.IsIdentity,
+      identity: new Identity({ did: identityIdToString(target.asSpecific) }, context),
     };
+  }
+
+  return {
+    type: ConditionType.IsNoneOf,
+    claims: meshConditionType.asIsNoneOf.map(claim => meshClaimToClaim(claim)),
+  };
+}
+
+/**
+ * @hidden
+ */
+export function complianceRequirementResultToRequirementCompliance(
+  complianceRequirement: ComplianceRequirementResult,
+  context: Context
+): RequirementCompliance {
+  const conditions: ConditionCompliance[] = [];
+
+  const conditionCompliancesAreEqual = (
+    { condition: aCondition, complies: aComplies }: ConditionCompliance,
+    { condition: bCondition, complies: bComplies }: ConditionCompliance
+  ): boolean => {
+    let equalClaims = false;
+
+    if (isSingleClaimCondition(aCondition) && isSingleClaimCondition(bCondition)) {
+      equalClaims = isEqual(aCondition.claim, bCondition.claim);
+    }
+
+    if (isMultiClaimCondition(aCondition) && isMultiClaimCondition(bCondition)) {
+      equalClaims = isEqual(aCondition.claims, bCondition.claims);
+    }
+
+    return (
+      equalClaims &&
+      isEqual(aCondition.trustedClaimIssuers, bCondition.trustedClaimIssuers) &&
+      aComplies === bComplies
+    );
   };
 
+  complianceRequirement.sender_conditions.forEach(
+    ({ condition: { condition_type: conditionType, issuers }, result }) => {
+      const newCondition = {
+        condition: {
+          ...meshConditionTypeToCondition(conditionType, context),
+          target: ConditionTarget.Sender,
+          trustedClaimIssuers: issuers.map(issuer => identityIdToString(issuer)),
+        },
+        complies: boolToBoolean(result),
+      };
+      const existingCondition = conditions.find(condition =>
+        conditionCompliancesAreEqual(condition, newCondition)
+      );
+
+      if (!existingCondition) {
+        conditions.push(newCondition);
+      }
+    }
+  );
+
+  complianceRequirement.receiver_conditions.forEach(
+    ({ condition: { condition_type: conditionType, issuers }, result }) => {
+      const newCondition = {
+        condition: {
+          ...meshConditionTypeToCondition(conditionType, context),
+          target: ConditionTarget.Receiver,
+          trustedClaimIssuers: issuers.map(issuer => identityIdToString(issuer)),
+        },
+        complies: boolToBoolean(result),
+      };
+
+      const existingCondition = conditions.find(condition =>
+        conditionCompliancesAreEqual(condition, newCondition)
+      );
+
+      if (existingCondition && existingCondition.condition.target === ConditionTarget.Sender) {
+        existingCondition.condition.target = ConditionTarget.Both;
+      } else {
+        conditions.push(newCondition);
+      }
+    }
+  );
+
+  return {
+    id: u32ToBigNumber(complianceRequirement.id).toNumber(),
+    conditions,
+    complies: boolToBoolean(complianceRequirement.result),
+  };
+}
+
+/**
+ * @hidden
+ */
+export function complianceRequirementToRequirement(
+  complianceRequirement: ComplianceRequirement,
+  context: Context
+): Requirement {
   const conditions: Condition[] = [];
 
   const conditionsAreEqual = (a: Condition, b: Condition): boolean => {
@@ -1395,7 +1482,7 @@ export function complianceRequirementToRequirement(
 
   complianceRequirement.sender_conditions.forEach(({ condition_type: conditionType, issuers }) => {
     const newCondition = {
-      ...meshConditionTypeToCondition(conditionType),
+      ...meshConditionTypeToCondition(conditionType, context),
       target: ConditionTarget.Sender,
       trustedClaimIssuers: issuers.map(issuer => identityIdToString(issuer)),
     };
@@ -1411,7 +1498,7 @@ export function complianceRequirementToRequirement(
   complianceRequirement.receiver_conditions.forEach(
     ({ condition_type: conditionType, issuers }) => {
       const newCondition = {
-        ...meshConditionTypeToCondition(conditionType),
+        ...meshConditionTypeToCondition(conditionType, context),
         target: ConditionTarget.Receiver,
         trustedClaimIssuers: issuers.map(issuer => identityIdToString(issuer)),
       };
@@ -1524,15 +1611,14 @@ export function portfolioMovementToMovePortfolioItem(
 /**
  * @hidden
  */
-export function assetComplianceResultToRequirementCompliance(
+export function assetComplianceResultToCompliance(
   assetComplianceResult: AssetComplianceResult,
   context: Context
-): RequirementCompliance {
+): Compliance {
   const { requirements: rawRequirements, result, paused } = assetComplianceResult;
-  const requirements = rawRequirements.map(requirement => ({
-    ...complianceRequirementToRequirement(requirement, context),
-    complies: boolToBoolean(requirement.result),
-  }));
+  const requirements = rawRequirements.map(requirement =>
+    complianceRequirementResultToRequirementCompliance(requirement, context)
+  );
 
   return {
     requirements,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1675,151 +1675,150 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@polkadot/api-derive@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-2.3.1.tgz#7917035c087724782dc275411a256f5b8f747af4"
-  integrity sha512-FcDEx+/1Io7zOHPjbQAEzXB0KenA9emgY+96aHS4yPV/OVmAifU0IAxudZdMVp7uVC2dWq9iFvjxx84yCXgVRA==
+"@polkadot/api-derive@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-2.6.1.tgz#c6ae29ddd7942876feb757c229c37ba0369c0208"
+  integrity sha512-sEr1MsaLwJy31+yhuxclUHMbTsY5DDoCMEpX+HbplK6GHt0yC0SgpN47c1K8Jykp1aYJJLhAh8EmNfDd+gl0eQ==
   dependencies:
     "@babel/runtime" "^7.12.1"
-    "@polkadot/api" "2.3.1"
-    "@polkadot/rpc-core" "2.3.1"
-    "@polkadot/rpc-provider" "2.3.1"
-    "@polkadot/types" "2.3.1"
-    "@polkadot/util" "^3.6.1"
-    "@polkadot/util-crypto" "^3.6.1"
+    "@polkadot/api" "2.6.1"
+    "@polkadot/rpc-core" "2.6.1"
+    "@polkadot/types" "2.6.1"
+    "@polkadot/util" "^4.0.1"
+    "@polkadot/util-crypto" "^4.0.1"
     bn.js "^5.1.3"
     memoizee "^0.4.14"
     rxjs "^6.6.3"
 
-"@polkadot/api@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-2.3.1.tgz#70be0f4558b4cff85323ea36767bdacb51e8323c"
-  integrity sha512-B9ZOb1PiPaAlke4wQHoivVQ5ZCQWn5bgLjhVIGdcEZ4WjIcxApmzTV4ruSfqVoRKpRiVOyV3Dx/VUQDD/WgBFw==
+"@polkadot/api@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-2.6.1.tgz#ff526c2398429688f63616a312329562a1cca5e7"
+  integrity sha512-BvS87/VSOkGEMNhXuszxcQ4mEwSGbVABqfE6H1AVsLWtElOnmSa3dZpAaPeo7aO9dLUa/2mxBfvLFZLl+boJ8g==
   dependencies:
     "@babel/runtime" "^7.12.1"
-    "@polkadot/api-derive" "2.3.1"
-    "@polkadot/keyring" "^3.6.1"
-    "@polkadot/metadata" "2.3.1"
-    "@polkadot/rpc-core" "2.3.1"
-    "@polkadot/rpc-provider" "2.3.1"
-    "@polkadot/types" "2.3.1"
-    "@polkadot/types-known" "2.3.1"
-    "@polkadot/util" "^3.6.1"
-    "@polkadot/util-crypto" "^3.6.1"
+    "@polkadot/api-derive" "2.6.1"
+    "@polkadot/keyring" "^4.0.1"
+    "@polkadot/metadata" "2.6.1"
+    "@polkadot/rpc-core" "2.6.1"
+    "@polkadot/rpc-provider" "2.6.1"
+    "@polkadot/types" "2.6.1"
+    "@polkadot/types-known" "2.6.1"
+    "@polkadot/util" "^4.0.1"
+    "@polkadot/util-crypto" "^4.0.1"
     bn.js "^5.1.3"
     eventemitter3 "^4.0.7"
     rxjs "^6.6.3"
 
-"@polkadot/keyring@^3.6.1":
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-3.6.1.tgz#51a4a08e650f9717115b4ee6ccf8f6dccd273594"
-  integrity sha512-JbW4M5Ct3HaX3vgoa/UWAQVF/0sc1PbbA2D6v0KKaJkXl+EYVP9uyOYAoRCppB6ENZThz7CUJVQp8trs8WTrFQ==
+"@polkadot/keyring@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-4.0.1.tgz#07ec9e8bfb201a98b761e6f3dae83b60cba3bbaf"
+  integrity sha512-E65gy9WjH+tRys18VB37ilE0crKxmX78ycAq3gUVWfT7dS2XijJLcJnNWRQ3WBuWQ2r9umBcKVXSUQII5YEcpA==
   dependencies:
     "@babel/runtime" "^7.12.1"
-    "@polkadot/util" "3.6.1"
-    "@polkadot/util-crypto" "3.6.1"
+    "@polkadot/util" "4.0.1"
+    "@polkadot/util-crypto" "4.0.1"
 
-"@polkadot/metadata@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-2.3.1.tgz#c061ca73bfac65416f9717b6452794a5fb648948"
-  integrity sha512-F/QwDDR/d9mcqToDqndRTUYvMt/GYzjQ+kNGjQYBOIDRqF9zDbPHAXruqcHd0Y5MMpPMRBZGNaqPOb3BMrIdOQ==
+"@polkadot/metadata@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-2.6.1.tgz#e5595c52765931f978a4d731c58f63ee01efeaba"
+  integrity sha512-pgKjWc0pF/2CKb06vjLdXjWzX7vgLwI6vXgJ/k4bSLHPJIryYKDp0fp0W+B11dkSzwbjL99sJoiGue6UXfeMeg==
   dependencies:
     "@babel/runtime" "^7.12.1"
-    "@polkadot/types" "2.3.1"
-    "@polkadot/types-known" "2.3.1"
-    "@polkadot/util" "^3.6.1"
-    "@polkadot/util-crypto" "^3.6.1"
+    "@polkadot/types" "2.6.1"
+    "@polkadot/types-known" "2.6.1"
+    "@polkadot/util" "^4.0.1"
+    "@polkadot/util-crypto" "^4.0.1"
     bn.js "^5.1.3"
 
-"@polkadot/networks@3.6.1":
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-3.6.1.tgz#647858a03fd450014af453e72b66b812b027dc19"
-  integrity sha512-PEEw/vTZaKf32vuAUeFXYNJei+b/s3hr7msMKfvoYeKDU/otgt9Mgkqrh6VCaE6+lHHgX8vLbH70pCqQrGG/uA==
+"@polkadot/networks@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-4.0.1.tgz#1cab7001d8f5127e7047b83856021334d9638f42"
+  integrity sha512-GzEcVo+lWEdKZ6bK5R33zTGBMLQtf/9GwAf27Acxa23xk6aI5fpSHXcUm5ilUyD9vmNoRH3WnhfgVrTJ7uWe+Q==
   dependencies:
     "@babel/runtime" "^7.12.1"
 
-"@polkadot/rpc-core@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-2.3.1.tgz#aa89b13eb51c5919944c785cebfe9c1dbf57a7fe"
-  integrity sha512-SWYU6azxNwWkhz6bm/wpRPQZ/5KJ2hnEXPS4EN77q7EFH4c4k9mNtVyjUQFkKJsG7T85vxaCCWwhx60aYCZVeA==
+"@polkadot/rpc-core@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-2.6.1.tgz#152cf0bdc2f0a7fa5d9c29b9a9d70523a70144ac"
+  integrity sha512-j7sQHoIc74IrqLOAoNPaMAJuLA2/PG4Q+NoZ2/+CSyHSzNOHc03IDtEi7qkdeuhxnDIJrhTaihNWvC3yMQrPhg==
   dependencies:
     "@babel/runtime" "^7.12.1"
-    "@polkadot/metadata" "2.3.1"
-    "@polkadot/rpc-provider" "2.3.1"
-    "@polkadot/types" "2.3.1"
-    "@polkadot/util" "^3.6.1"
+    "@polkadot/metadata" "2.6.1"
+    "@polkadot/rpc-provider" "2.6.1"
+    "@polkadot/types" "2.6.1"
+    "@polkadot/util" "^4.0.1"
     memoizee "^0.4.14"
     rxjs "^6.6.3"
 
-"@polkadot/rpc-provider@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-2.3.1.tgz#1ba314027b2e9cd4bdf86b178b9ace598cb7befc"
-  integrity sha512-lRN68RosWvtBA844PWqhYEV2ifT3T9SUyAP2WvRYyWVPiMmXjw57qG1zHKQWgZk5aFzeaHKSYgsKTmkWz9IM4g==
+"@polkadot/rpc-provider@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-2.6.1.tgz#529206a949caabfcd94d6b625be25033858de5cd"
+  integrity sha512-9fionqVAXTE9zv9R8Ls9ewlKbnavIB1DikFipGXy9MZ+eonS8DiaOc1RjImLGx9Hf4GQxbMy73pcOvbUdNW2fg==
   dependencies:
     "@babel/runtime" "^7.12.1"
-    "@polkadot/metadata" "2.3.1"
-    "@polkadot/types" "2.3.1"
-    "@polkadot/util" "^3.6.1"
-    "@polkadot/util-crypto" "^3.6.1"
-    "@polkadot/x-fetch" "^0.3.3"
-    "@polkadot/x-ws" "^0.3.3"
+    "@polkadot/types" "2.6.1"
+    "@polkadot/util" "^4.0.1"
+    "@polkadot/util-crypto" "^4.0.1"
+    "@polkadot/x-fetch" "^4.0.1"
+    "@polkadot/x-ws" "^4.0.1"
     bn.js "^5.1.3"
     eventemitter3 "^4.0.7"
 
-"@polkadot/typegen@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/typegen/-/typegen-2.3.1.tgz#be2604a5558f2621db2f3a62a50b9d8fba42720f"
-  integrity sha512-iNpyShKpgyxM98izNZ4tU0/nwpq7z7kdQY5G6+d7HOBtORv3YXS/6AwfAKvTnH6MZPrZg8a0WO75hd/Nz8CQgQ==
+"@polkadot/typegen@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/typegen/-/typegen-2.6.1.tgz#adbaf9a6ec932518d9f453dc5c7d5c2487eed1e2"
+  integrity sha512-9doRV7o8UBe1Az+cD2YYHRJ3+ynZ34pwcAa+sRQ/AZqu6erhp2oqYi5H62mxm0/FgEU9sjAO5rx/dnA8qxBYdA==
   dependencies:
     "@babel/core" "^7.12.3"
     "@babel/register" "^7.12.1"
     "@babel/runtime" "^7.12.1"
-    "@polkadot/api" "2.3.1"
-    "@polkadot/metadata" "2.3.1"
-    "@polkadot/rpc-provider" "2.3.1"
-    "@polkadot/types" "2.3.1"
-    "@polkadot/util" "^3.6.1"
+    "@polkadot/api" "2.6.1"
+    "@polkadot/metadata" "2.6.1"
+    "@polkadot/rpc-provider" "2.6.1"
+    "@polkadot/types" "2.6.1"
+    "@polkadot/util" "^4.0.1"
     handlebars "^4.7.6"
     websocket "^1.0.32"
     yargs "^16.1.0"
 
-"@polkadot/types-known@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-2.3.1.tgz#4aa255bbe998ed8f0d10f344eb364d96b3cb6fb7"
-  integrity sha512-34yuvDraW9Sjy5ookQZf55sBKLOsTqos+WQdTu6DUxtRuwvMP9DEAGcs2m6AFvWxwZps+3zFGUvzn6SMHsSJ5Q==
+"@polkadot/types-known@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-2.6.1.tgz#ec9a07dbaa1dc274f72d6ba744f592e0e8144cfe"
+  integrity sha512-ZyWFzvuMS1umuhDYExqr9r0/69ME6QkIOgxfhXh9Ag4rkIlH+J0i+YO2H6F11zT+gqGPvqL8Vn2w8XlNjGNwcQ==
   dependencies:
     "@babel/runtime" "^7.12.1"
-    "@polkadot/types" "2.3.1"
-    "@polkadot/util" "^3.6.1"
+    "@polkadot/types" "2.6.1"
+    "@polkadot/util" "^4.0.1"
     bn.js "^5.1.3"
 
-"@polkadot/types@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-2.3.1.tgz#8a91678bf67f27c8e174dbf565ec5738bbd0d344"
-  integrity sha512-G3cyYYV+vYmpkMjPirwOA/zLreb1uBrKpEMWTvtTuCz/sNwcbCT5hI/KZCzNo1PueOQAowroKPe4yQ793dqVPw==
+"@polkadot/types@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-2.6.1.tgz#f9cb005fdd1788bc2942370f0f4ad5cb61b99c32"
+  integrity sha512-pb3VVOsEKaD7M3tFta9UtDL5zM+2/rsmstwBatA71b53Glr5XPxYtT8LI7dqjHZVLjHxKsYRKtTUhuNB7onQ8w==
   dependencies:
     "@babel/runtime" "^7.12.1"
-    "@polkadot/metadata" "2.3.1"
-    "@polkadot/util" "^3.6.1"
-    "@polkadot/util-crypto" "^3.6.1"
+    "@polkadot/metadata" "2.6.1"
+    "@polkadot/util" "^4.0.1"
+    "@polkadot/util-crypto" "^4.0.1"
     "@types/bn.js" "^4.11.6"
     bn.js "^5.1.3"
     memoizee "^0.4.14"
     rxjs "^6.6.3"
 
-"@polkadot/util-crypto@3.6.1", "@polkadot/util-crypto@^3.6.1":
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-3.6.1.tgz#827b679ef5c03bf1400d5fac942f4a0b59aa3acd"
-  integrity sha512-mRCijOXrxTa2JD5vpNvr1MHSj3NaSGaImg1yzAf3l7nw7zNGjLy1K3qQNcFgr8+0NHyPKk5lCIehtwGTRZYsiA==
+"@polkadot/util-crypto@4.0", "@polkadot/util-crypto@4.0.1", "@polkadot/util-crypto@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-4.0.1.tgz#536fcdb159232bc00ef16f0c35d0b41cc8cbb802"
+  integrity sha512-D5gzmvtsZPVZejkngQB4DpKF3WyFxhWtT8DpwkgIxIvOkbS0FvVXCISqSfauh8ZnfrAp4677Ha4YZ3sCKemS5g==
   dependencies:
     "@babel/runtime" "^7.12.1"
-    "@polkadot/networks" "3.6.1"
-    "@polkadot/util" "3.6.1"
-    "@polkadot/wasm-crypto" "^1.4.1"
+    "@polkadot/networks" "4.0.1"
+    "@polkadot/util" "4.0.1"
+    "@polkadot/wasm-crypto" "^2.0.1"
+    "@polkadot/x-randomvalues" "4.0.1"
     base-x "^3.0.8"
-    bip39 "^3.0.2"
     blakejs "^1.1.0"
     bn.js "^5.1.3"
+    create-hash "^1.2.0"
     elliptic "^6.5.3"
     js-sha3 "^0.8.0"
     pbkdf2 "^3.1.1"
@@ -1827,52 +1826,58 @@
     tweetnacl "^1.0.3"
     xxhashjs "^0.2.2"
 
-"@polkadot/util@3.6.1", "@polkadot/util@^3.6.1":
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-3.6.1.tgz#1f45651d3a1bb89da27fcb42cc1af1536d30abd0"
-  integrity sha512-ToGVghmTtC8s8cg8mCGG3I88UasrCg9VNm5JoUvBH4nTZCxc/dQEkU24nULXwHUpmd7d39p3RLpVbkLCVYIMZw==
+"@polkadot/util@4.0", "@polkadot/util@4.0.1", "@polkadot/util@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-4.0.1.tgz#6cc2958c9a4b188b899bf14b0585060aba375ec6"
+  integrity sha512-t8INPSJZI0eWhobpaR+Ul2h8dKtaw+P8UiAL1Q5WeSD0iaVA2IbJvYacdztvkN1AZEcNgbFSMSDKZmzIKBxHpg==
   dependencies:
     "@babel/runtime" "^7.12.1"
-    "@polkadot/x-textdecoder" "^0.3.3"
-    "@polkadot/x-textencoder" "^0.3.3"
+    "@polkadot/x-textdecoder" "4.0.1"
+    "@polkadot/x-textencoder" "4.0.1"
     "@types/bn.js" "^4.11.6"
     bn.js "^5.1.3"
     camelcase "^5.3.1"
-    chalk "^4.1.0"
     ip-regex "^4.2.0"
 
-"@polkadot/wasm-crypto@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-1.4.1.tgz#0a053d0c2587da30fb5313cef81f8d9a52029c68"
-  integrity sha512-GPBCh8YvQmA5bobI4rqRkUhrEHkEWU1+lcJVPbZYsa7jiHFaZpzCLrGQfiqW/vtbU1aBS2wmJ0x1nlt33B9QqQ==
+"@polkadot/wasm-crypto@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-2.0.1.tgz#cf7384385f832f6389520cc00e52a87fda6f29b6"
+  integrity sha512-Vb0q4NToCRHXYJwhLWc4NTy77+n1dtJmkiE1tt8j1pmY4IJ4UL25yBxaS8NCS1LGqofdUYK1wwgrHiq5A78PFA==
 
-"@polkadot/x-fetch@^0.3.3":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-0.3.4.tgz#3ad3a66825afdf34f18276f3e9609294ebb10491"
-  integrity sha512-sf/yzr/M6VpjXbSLtBgdJU7cLRVRYzHUX9IdLj+cBGaNKczn36DQHcWyIugWBBfRJpXpMOJat0nlPls6gTyF2g==
+"@polkadot/x-fetch@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-4.0.1.tgz#8053278fd8a77a81f5cb09f23ed7a46674610bd8"
+  integrity sha512-Ume+WJ2TWW+QFMKFqixFEr1w6dOPvubkmP+jCQVqWLra0D/uXPmpcgMtiuTIjPl92Q38p37N97xTJl1hP+Kzkw==
   dependencies:
     "@babel/runtime" "^7.12.1"
     "@types/node-fetch" "^2.5.7"
     node-fetch "^2.6.1"
 
-"@polkadot/x-textdecoder@^0.3.3":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-0.3.4.tgz#3427eb29c2aae84a54da4cbfe03c40f11ed20c80"
-  integrity sha512-MErN6Ludm6aiUyGU1tLCuChL1b9oW1PeoLEyKTlaTTpxLUQi/B7slNAt0tgqXCLcB4LOPG+9pB9kuyW0ZYVu+w==
+"@polkadot/x-randomvalues@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-4.0.1.tgz#30554ad963e80e7fe97a4bee86caacb35aab9fe0"
+  integrity sha512-Oe1LaoE2pQZGQweqRjF8TVXx+6K1Zxe1+IjvCUbwnDOSthn3Q+Tywf9S3Wn+yME6ul08J14GlGtyoHJMLgmqFQ==
   dependencies:
     "@babel/runtime" "^7.12.1"
 
-"@polkadot/x-textencoder@^0.3.3":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-0.3.4.tgz#ca204d5e025d6e2a64ea34811d6000a0af7361d0"
-  integrity sha512-RKBenRu2Zb7rJYjHMkx66YM3lFS59saNJpWODLX5G6CbyadzJuu3vJ2y2LaBqOZVmZMrwwzxCqr1+DqW7KrgDA==
+"@polkadot/x-textdecoder@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-4.0.1.tgz#04ca82d93d1ac80f5a74e897e072c6b8bb33ac7b"
+  integrity sha512-kRn9PY8Ffm8+g55UPbgEwGhVTDA9dFP3hmo9RD1DFXZkB0PyETDB37dr8YVC4C1LXAIBINBhrgjCMlSbJoUwuw==
   dependencies:
     "@babel/runtime" "^7.12.1"
 
-"@polkadot/x-ws@^0.3.3":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-0.3.4.tgz#d03ddc378b0418e2e17bb24bab5c76abe4bc15da"
-  integrity sha512-c7P2auMsCAJn/rSW/JpaOl1W7aeNW8HPJzeWMgTeDsOsQCJZbXD80hVL2cfMLc9zgRq0R3ZCNMYbzZ1aoSmc4Q==
+"@polkadot/x-textencoder@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-4.0.1.tgz#1d039416a54aea762e5e6ad2deebe94c08f057a7"
+  integrity sha512-2C1TpImfWDy6R7Bymq2luPo50VZioQE7ruM3pgKAr2ogZIu8KnlilI5V84qWkzVsqU3G3Dk0yqXUXPZqDdDA2g==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+
+"@polkadot/x-ws@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-4.0.1.tgz#7a3d708e27e63766c75df333f98ecc564a061d53"
+  integrity sha512-IHz+mCfnM47echcQTm5qDXMSN753guiz8FMzTzTLwr5/QUuQEkPuSok17GibAYjZBI48FTgp8xG4TLzj5+6Kug==
   dependencies:
     "@babel/runtime" "^7.12.1"
     "@types/websocket" "^1.0.1"
@@ -2142,11 +2147,6 @@
   version "13.5.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.5.0.tgz#4e498dbf355795a611a87ae5ef811a8660d42662"
   integrity sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ==
-
-"@types/node@11.11.6":
-  version "11.11.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
-  integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
 
 "@types/node@>=6":
   version "14.0.1"
@@ -3265,16 +3265,6 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bip39@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.0.2.tgz#2baf42ff3071fc9ddd5103de92e8f80d9257ee32"
-  integrity sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==
-  dependencies:
-    "@types/node" "11.11.6"
-    create-hash "^1.1.0"
-    pbkdf2 "^3.0.9"
-    randombytes "^2.0.1"
-
 bl@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
@@ -4374,7 +4364,7 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
-create-hash@^1.1.0, create-hash@^1.1.2:
+create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
   integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
@@ -10574,7 +10564,7 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-pbkdf2@^3.0.3, pbkdf2@^3.0.9:
+pbkdf2@^3.0.3:
   version "3.0.17"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
   integrity sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==


### PR DESCRIPTION
Also updated checkSettle compliance result types

BREAKING CHANGE: `RequirementCompliance` renamed to `Compliance`. There is now a new type called
`RequirementCompliance` which represents compliance to a specific asset requirement. Each condition
inside it has its own `complies` flag