### PR TITLE
feat(trusted claim issuers): require trusted claim types on claimissuers

### DIFF
--- a/src/api/entities/DefaultTrustedClaimIssuer.ts
+++ b/src/api/entities/DefaultTrustedClaimIssuer.ts
@@ -13,7 +13,7 @@ export interface UniqueIdentifiers {
 }
 
 export interface Params {
-  trustedFor?: ClaimType[];
+  trustedFor: ClaimType[] | null;
 }
 
 /**
@@ -36,7 +36,7 @@ export class DefaultTrustedClaimIssuer extends Entity<UniqueIdentifiers> {
   public identity: Identity;
 
   /**
-   * claim types for which this Claim Issuer is trusted. A null value means all claim types are trusted
+   * claim types for which this Claim Issuer is trusted. A null value means that the issuer is trusted for all claim types
    */
   public trustedFor: ClaimType[] | null;
 
@@ -49,7 +49,7 @@ export class DefaultTrustedClaimIssuer extends Entity<UniqueIdentifiers> {
    * @hidden
    */
   public constructor(args: UniqueIdentifiers & Params, context: Context) {
-    const { trustedFor = null, ...identifiers } = args;
+    const { trustedFor, ...identifiers } = args;
 
     super(identifiers, context);
 

--- a/src/api/entities/DefaultTrustedClaimIssuer.ts
+++ b/src/api/entities/DefaultTrustedClaimIssuer.ts
@@ -13,7 +13,7 @@ export interface UniqueIdentifiers {
 }
 
 export interface Params {
-  trustedFor: ClaimType[] | null;
+  trustedFor?: ClaimType[];
 }
 
 /**
@@ -36,9 +36,9 @@ export class DefaultTrustedClaimIssuer extends Entity<UniqueIdentifiers> {
   public identity: Identity;
 
   /**
-   * claim types for which this Claim Issuer is trusted. A null value means that the issuer is trusted for all claim types
+   * claim types for which this Claim Issuer is trusted. An undefined value means that the issuer is trusted for all claim types
    */
-  public trustedFor: ClaimType[] | null;
+  public trustedFor?: ClaimType[];
 
   /**
    * ticker of the Security Token

--- a/src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts
+++ b/src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts
@@ -3,7 +3,8 @@ import { TrustedIssuer } from 'polymesh-types/types';
 import {
   DefaultTrustedClaimIssuer,
   modifyTokenTrustedClaimIssuers,
-  ModifyTokenTrustedClaimIssuersParams,
+  ModifyTokenTrustedClaimIssuersAddSetParams,
+  ModifyTokenTrustedClaimIssuersRemoveParams,
   Namespace,
   SecurityToken,
   TransactionQueue,
@@ -23,7 +24,9 @@ export class TrustedClaimIssuers extends Namespace<SecurityToken> {
    *
    * @param args.claimIssuerDids - array of Identity IDs of the default Trusted Claim Issuers
    */
-  public set(args: ModifyTokenTrustedClaimIssuersParams): Promise<TransactionQueue<SecurityToken>> {
+  public set(
+    args: ModifyTokenTrustedClaimIssuersAddSetParams
+  ): Promise<TransactionQueue<SecurityToken>> {
     const {
       parent: { ticker },
       context,
@@ -37,9 +40,11 @@ export class TrustedClaimIssuers extends Namespace<SecurityToken> {
   /**
    * Add the supplied Identities to the Security Token's list of trusted claim issuers
    *
-   * @param args.claimIssuerDids - array of Identity IDs of the default claim issuers
+   * @param args.claimIssuers - array of [[TrustedClaimIssuer | Trusted Claim Issuers]]
    */
-  public add(args: ModifyTokenTrustedClaimIssuersParams): Promise<TransactionQueue<SecurityToken>> {
+  public add(
+    args: ModifyTokenTrustedClaimIssuersAddSetParams
+  ): Promise<TransactionQueue<SecurityToken>> {
     const {
       parent: { ticker },
       context,
@@ -53,10 +58,10 @@ export class TrustedClaimIssuers extends Namespace<SecurityToken> {
   /**
    * Remove the supplied Identities from the Security Token's list of trusted claim issuers   *
    *
-   * @param args.claimIssuerDids - array of Identity IDs of the default claim issuers
+   * @param args.claimIssuers - array of Identities (or DIDs) of the default claim issuers
    */
   public remove(
-    args: ModifyTokenTrustedClaimIssuersParams
+    args: ModifyTokenTrustedClaimIssuersRemoveParams
   ): Promise<TransactionQueue<SecurityToken>> {
     const {
       parent: { ticker },
@@ -95,7 +100,10 @@ export class TrustedClaimIssuers extends Namespace<SecurityToken> {
     const assembleResult = (issuers: TrustedIssuer[]): DefaultTrustedClaimIssuer[] =>
       issuers.map(
         ({ issuer }) =>
-          new DefaultTrustedClaimIssuer({ did: identityIdToString(issuer), ticker }, context)
+          new DefaultTrustedClaimIssuer(
+            { did: identityIdToString(issuer), ticker, trustedFor: null },
+            context
+          )
       );
 
     if (callback) {

--- a/src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts
+++ b/src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts
@@ -100,10 +100,7 @@ export class TrustedClaimIssuers extends Namespace<SecurityToken> {
     const assembleResult = (issuers: TrustedIssuer[]): DefaultTrustedClaimIssuer[] =>
       issuers.map(
         ({ issuer }) =>
-          new DefaultTrustedClaimIssuer(
-            { did: identityIdToString(issuer), ticker, trustedFor: null },
-            context
-          )
+          new DefaultTrustedClaimIssuer({ did: identityIdToString(issuer), ticker }, context)
       );
 
     if (callback) {

--- a/src/api/entities/SecurityToken/Compliance/__tests__/TrustedClaimIssuers.ts
+++ b/src/api/entities/SecurityToken/Compliance/__tests__/TrustedClaimIssuers.ts
@@ -51,8 +51,8 @@ describe('TrustedClaimIssuers class', () => {
 
       const args: ModifyTokenTrustedClaimIssuersAddSetParams = {
         claimIssuers: [
-          { identity: entityMockUtils.getIdentityInstance({ did: 'someDid' }), trustedFor: null },
-          { identity: entityMockUtils.getIdentityInstance({ did: 'otherDid' }), trustedFor: null },
+          { identity: entityMockUtils.getIdentityInstance({ did: 'someDid' }) },
+          { identity: entityMockUtils.getIdentityInstance({ did: 'otherDid' }) },
         ],
       };
 
@@ -86,8 +86,8 @@ describe('TrustedClaimIssuers class', () => {
 
       const args: ModifyTokenTrustedClaimIssuersAddSetParams = {
         claimIssuers: [
-          { identity: entityMockUtils.getIdentityInstance({ did: 'someDid' }), trustedFor: null },
-          { identity: entityMockUtils.getIdentityInstance({ did: 'otherDid' }), trustedFor: null },
+          { identity: entityMockUtils.getIdentityInstance({ did: 'someDid' }) },
+          { identity: entityMockUtils.getIdentityInstance({ did: 'otherDid' }) },
         ],
       };
 
@@ -168,9 +168,7 @@ describe('TrustedClaimIssuers class', () => {
       claimIssuers = [];
 
       expectedDids.forEach(did => {
-        expectedTrustedClaimIssuers.push(
-          new DefaultTrustedClaimIssuer({ did, ticker, trustedFor: null }, context)
-        );
+        expectedTrustedClaimIssuers.push(new DefaultTrustedClaimIssuer({ did, ticker }, context));
         claimIssuers.push(
           dsMockUtils.createMockTrustedIssuer({
             issuer: dsMockUtils.createMockIdentityId(did),

--- a/src/api/entities/SecurityToken/Compliance/__tests__/TrustedClaimIssuers.ts
+++ b/src/api/entities/SecurityToken/Compliance/__tests__/TrustedClaimIssuers.ts
@@ -1,6 +1,7 @@
 import { Ticker, TrustedIssuer } from 'polymesh-types/types';
 import sinon from 'sinon';
 
+import { ModifyTokenTrustedClaimIssuersAddSetParams } from '~/api/procedures/modifyTokenTrustedClaimIssuers';
 import {
   Context,
   DefaultTrustedClaimIssuer,
@@ -48,8 +49,11 @@ describe('TrustedClaimIssuers class', () => {
       const token = entityMockUtils.getSecurityTokenInstance();
       const trustedClaimIssuers = new TrustedClaimIssuers(token, context);
 
-      const args = {
-        claimIssuerIdentities: ['someDid', 'otherDid'],
+      const args: ModifyTokenTrustedClaimIssuersAddSetParams = {
+        claimIssuers: [
+          { identity: entityMockUtils.getIdentityInstance({ did: 'someDid' }), trustedFor: null },
+          { identity: entityMockUtils.getIdentityInstance({ did: 'otherDid' }), trustedFor: null },
+        ],
       };
 
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<SecurityToken>;
@@ -80,8 +84,11 @@ describe('TrustedClaimIssuers class', () => {
       const token = entityMockUtils.getSecurityTokenInstance();
       const trustedClaimIssuers = new TrustedClaimIssuers(token, context);
 
-      const args = {
-        claimIssuerIdentities: ['someDid', 'otherDid'],
+      const args: ModifyTokenTrustedClaimIssuersAddSetParams = {
+        claimIssuers: [
+          { identity: entityMockUtils.getIdentityInstance({ did: 'someDid' }), trustedFor: null },
+          { identity: entityMockUtils.getIdentityInstance({ did: 'otherDid' }), trustedFor: null },
+        ],
       };
 
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<SecurityToken>;
@@ -113,7 +120,7 @@ describe('TrustedClaimIssuers class', () => {
       const trustedClaimIssuers = new TrustedClaimIssuers(token, context);
 
       const args = {
-        claimIssuerIdentities: ['someDid', 'otherDid'],
+        claimIssuers: ['someDid', 'otherDid'],
       };
 
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<SecurityToken>;
@@ -161,7 +168,9 @@ describe('TrustedClaimIssuers class', () => {
       claimIssuers = [];
 
       expectedDids.forEach(did => {
-        expectedTrustedClaimIssuers.push(new DefaultTrustedClaimIssuer({ did, ticker }, context));
+        expectedTrustedClaimIssuers.push(
+          new DefaultTrustedClaimIssuer({ did, ticker, trustedFor: null }, context)
+        );
         claimIssuers.push(
           dsMockUtils.createMockTrustedIssuer({
             issuer: dsMockUtils.createMockIdentityId(did),

--- a/src/api/entities/__tests__/DefaultTrustedClaimIssuer.ts
+++ b/src/api/entities/__tests__/DefaultTrustedClaimIssuer.ts
@@ -35,7 +35,10 @@ describe('DefaultTrustedClaimIssuer class', () => {
       const did = 'someDid';
       const ticker = 'SOMETICKER';
       const identity = new Identity({ did }, context);
-      const trustedClaimIssuer = new DefaultTrustedClaimIssuer({ did, ticker }, context);
+      const trustedClaimIssuer = new DefaultTrustedClaimIssuer(
+        { did, ticker, trustedFor: null },
+        context
+      );
 
       expect(trustedClaimIssuer.ticker).toBe(ticker);
       expect(trustedClaimIssuer.identity).toEqual(identity);
@@ -68,7 +71,10 @@ describe('DefaultTrustedClaimIssuer class', () => {
       const blockDate = new Date('4/14/2020');
       const eventIdx = 1;
       const fakeResult = { blockNumber, blockDate, eventIndex: eventIdx };
-      const trustedClaimIssuer = new DefaultTrustedClaimIssuer({ did, ticker }, context);
+      const trustedClaimIssuer = new DefaultTrustedClaimIssuer(
+        { did, ticker, trustedFor: null },
+        context
+      );
 
       dsMockUtils.createApolloQueryStub(eventByIndexedArgs(variables), {
         /* eslint-disable @typescript-eslint/camelcase */
@@ -86,7 +92,10 @@ describe('DefaultTrustedClaimIssuer class', () => {
     });
 
     test('should return null if the query result is empty', async () => {
-      const trustedClaimIssuer = new DefaultTrustedClaimIssuer({ did, ticker }, context);
+      const trustedClaimIssuer = new DefaultTrustedClaimIssuer(
+        { did, ticker, trustedFor: null },
+        context
+      );
 
       dsMockUtils.createApolloQueryStub(eventByIndexedArgs(variables), {});
       const result = await trustedClaimIssuer.addedAt();

--- a/src/api/entities/__tests__/DefaultTrustedClaimIssuer.ts
+++ b/src/api/entities/__tests__/DefaultTrustedClaimIssuer.ts
@@ -35,10 +35,7 @@ describe('DefaultTrustedClaimIssuer class', () => {
       const did = 'someDid';
       const ticker = 'SOMETICKER';
       const identity = new Identity({ did }, context);
-      const trustedClaimIssuer = new DefaultTrustedClaimIssuer(
-        { did, ticker, trustedFor: null },
-        context
-      );
+      const trustedClaimIssuer = new DefaultTrustedClaimIssuer({ did, ticker }, context);
 
       expect(trustedClaimIssuer.ticker).toBe(ticker);
       expect(trustedClaimIssuer.identity).toEqual(identity);
@@ -71,10 +68,7 @@ describe('DefaultTrustedClaimIssuer class', () => {
       const blockDate = new Date('4/14/2020');
       const eventIdx = 1;
       const fakeResult = { blockNumber, blockDate, eventIndex: eventIdx };
-      const trustedClaimIssuer = new DefaultTrustedClaimIssuer(
-        { did, ticker, trustedFor: null },
-        context
-      );
+      const trustedClaimIssuer = new DefaultTrustedClaimIssuer({ did, ticker }, context);
 
       dsMockUtils.createApolloQueryStub(eventByIndexedArgs(variables), {
         /* eslint-disable @typescript-eslint/camelcase */
@@ -92,10 +86,7 @@ describe('DefaultTrustedClaimIssuer class', () => {
     });
 
     test('should return null if the query result is empty', async () => {
-      const trustedClaimIssuer = new DefaultTrustedClaimIssuer(
-        { did, ticker, trustedFor: null },
-        context
-      );
+      const trustedClaimIssuer = new DefaultTrustedClaimIssuer({ did, ticker }, context);
 
       dsMockUtils.createApolloQueryStub(eventByIndexedArgs(variables), {});
       const result = await trustedClaimIssuer.addedAt();

--- a/src/api/procedures/__tests__/modifyTokenTrustedClaimIssuers.ts
+++ b/src/api/procedures/__tests__/modifyTokenTrustedClaimIssuers.ts
@@ -24,10 +24,11 @@ describe('modifyTokenTrustedClaimIssuers procedure', () => {
   let identityIdToStringStub: sinon.SinonStub<[IdentityId], string>;
   let trustedClaimIssuerStub: sinon.SinonStub;
   let ticker: string;
-  let claimIssuerIdentities: string[];
+  let claimIssuerDids: string[];
+  let claimIssuers: TrustedClaimIssuer[];
   let rawTicker: Ticker;
   let rawClaimIssuers: TrustedIssuer[];
-  let args: Omit<Params, 'operation'>;
+  let args: Omit<Omit<Params, 'operation'>, 'claimIssuers'>;
 
   beforeAll(() => {
     dsMockUtils.initMocks();
@@ -40,9 +41,13 @@ describe('modifyTokenTrustedClaimIssuers procedure', () => {
     );
     identityIdToStringStub = sinon.stub(utilsConversionModule, 'identityIdToString');
     ticker = 'someTicker';
-    claimIssuerIdentities = ['aDid', 'otherDid', 'differentDid'];
+    claimIssuerDids = ['aDid', 'otherDid', 'differentDid'];
+    claimIssuers = claimIssuerDids.map(did => ({
+      identity: new Identity({ did }, mockContext),
+      trustedFor: null,
+    }));
     rawTicker = dsMockUtils.createMockTicker(ticker);
-    rawClaimIssuers = claimIssuerIdentities.map(did =>
+    rawClaimIssuers = claimIssuerDids.map(did =>
       dsMockUtils.createMockTrustedIssuer({
         issuer: dsMockUtils.createMockIdentityId(did),
         // eslint-disable-next-line @typescript-eslint/camelcase
@@ -51,7 +56,6 @@ describe('modifyTokenTrustedClaimIssuers procedure', () => {
     );
     args = {
       ticker,
-      claimIssuerIdentities,
     };
   });
 
@@ -83,11 +87,11 @@ describe('modifyTokenTrustedClaimIssuers procedure', () => {
     mockContext = dsMockUtils.getContextInstance();
 
     stringToTickerStub.withArgs(ticker, mockContext).returns(rawTicker);
-    claimIssuerIdentities.forEach((did, index) => {
+    claimIssuers.forEach((issuer, index) => {
       trustedClaimIssuerToTrustedIssuerStub
-        .withArgs({ identity: new Identity({ did }, mockContext) }, mockContext)
+        .withArgs(issuer, mockContext)
         .returns(rawClaimIssuers[index]);
-      identityIdToStringStub.withArgs(rawClaimIssuers[index].issuer).returns(did);
+      identityIdToStringStub.withArgs(rawClaimIssuers[index].issuer).returns(issuer.identity.did);
     });
   });
 
@@ -110,13 +114,14 @@ describe('modifyTokenTrustedClaimIssuers procedure', () => {
     return expect(
       prepareModifyTokenTrustedClaimIssuers.call(proc, {
         ...args,
+        claimIssuers,
         operation: TrustedClaimIssuerOperation.Set,
       })
     ).rejects.toThrow('The supplied claim issuer list is equal to the current one');
   });
 
   test("should throw an error if some of the supplied dids don't exist", async () => {
-    const nonExistentDid = claimIssuerIdentities[1];
+    const nonExistentDid = claimIssuerDids[1];
     dsMockUtils.configureMocks({ contextOptions: { invalidDids: [nonExistentDid] } });
     const proc = procedureMockUtils.getInstance<Params, SecurityToken>(mockContext);
 
@@ -125,6 +130,7 @@ describe('modifyTokenTrustedClaimIssuers procedure', () => {
     try {
       await prepareModifyTokenTrustedClaimIssuers.call(proc, {
         ...args,
+        claimIssuers,
         operation: TrustedClaimIssuerOperation.Set,
       });
     } catch (err) {
@@ -142,6 +148,7 @@ describe('modifyTokenTrustedClaimIssuers procedure', () => {
 
     const result = await prepareModifyTokenTrustedClaimIssuers.call(proc, {
       ...args,
+      claimIssuers,
       operation: TrustedClaimIssuerOperation.Set,
     });
 
@@ -165,6 +172,7 @@ describe('modifyTokenTrustedClaimIssuers procedure', () => {
 
     const result = await prepareModifyTokenTrustedClaimIssuers.call(proc, {
       ...args,
+      claimIssuers,
       operation: TrustedClaimIssuerOperation.Set,
     });
 
@@ -185,8 +193,8 @@ describe('modifyTokenTrustedClaimIssuers procedure', () => {
 
     const result = await prepareModifyTokenTrustedClaimIssuers.call(proc, {
       ...args,
+      claimIssuers: [],
       operation: TrustedClaimIssuerOperation.Set,
-      claimIssuerIdentities: [],
     });
 
     sinon.assert.calledWith(
@@ -209,6 +217,7 @@ describe('modifyTokenTrustedClaimIssuers procedure', () => {
     try {
       await prepareModifyTokenTrustedClaimIssuers.call(proc, {
         ...args,
+        claimIssuers: claimIssuerDids,
         operation: TrustedClaimIssuerOperation.Remove,
       });
     } catch (err) {
@@ -218,16 +227,22 @@ describe('modifyTokenTrustedClaimIssuers procedure', () => {
     expect(error.message).toBe(
       'One or more of the supplied Identities are not Trusted Claim Issuers'
     );
-    expect(error.data).toMatchObject({ notPresent: args.claimIssuerIdentities });
+    expect(error.data).toMatchObject({ notPresent: claimIssuerDids });
   });
 
   test('should add a transaction to remove the supplied Trusted Claim Issuers (remove)', async () => {
     const currentClaimIssuers = rawClaimIssuers;
     trustedClaimIssuerStub.withArgs(rawTicker).returns(currentClaimIssuers);
     const proc = procedureMockUtils.getInstance<Params, SecurityToken>(mockContext);
+    claimIssuerDids.forEach((did, index) => {
+      trustedClaimIssuerToTrustedIssuerStub
+        .withArgs(sinon.match({ identity: sinon.match({ did }) }), mockContext)
+        .returns(rawClaimIssuers[index]);
+    });
 
     const result = await prepareModifyTokenTrustedClaimIssuers.call(proc, {
       ...args,
+      claimIssuers: claimIssuerDids,
       operation: TrustedClaimIssuerOperation.Remove,
     });
 
@@ -250,6 +265,7 @@ describe('modifyTokenTrustedClaimIssuers procedure', () => {
     try {
       await prepareModifyTokenTrustedClaimIssuers.call(proc, {
         ...args,
+        claimIssuers,
         operation: TrustedClaimIssuerOperation.Add,
       });
     } catch (err) {
@@ -259,7 +275,7 @@ describe('modifyTokenTrustedClaimIssuers procedure', () => {
     expect(error.message).toBe(
       'One or more of the supplied Identities already are Trusted Claim Issuers'
     );
-    expect(error.data).toMatchObject({ present: args.claimIssuerIdentities });
+    expect(error.data).toMatchObject({ present: claimIssuerDids });
   });
 
   test('should add a transaction to add the supplied Trusted Claim Issuers (add)', async () => {
@@ -269,6 +285,7 @@ describe('modifyTokenTrustedClaimIssuers procedure', () => {
 
     const result = await prepareModifyTokenTrustedClaimIssuers.call(proc, {
       ...args,
+      claimIssuers,
       operation: TrustedClaimIssuerOperation.Add,
     });
 

--- a/src/api/procedures/__tests__/modifyTokenTrustedClaimIssuers.ts
+++ b/src/api/procedures/__tests__/modifyTokenTrustedClaimIssuers.ts
@@ -44,7 +44,6 @@ describe('modifyTokenTrustedClaimIssuers procedure', () => {
     claimIssuerDids = ['aDid', 'otherDid', 'differentDid'];
     claimIssuers = claimIssuerDids.map(did => ({
       identity: new Identity({ did }, mockContext),
-      trustedFor: null,
     }));
     rawTicker = dsMockUtils.createMockTicker(ticker);
     rawClaimIssuers = claimIssuerDids.map(did =>

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -40,7 +40,8 @@ export {
 } from '~/api/procedures/modifyPrimaryIssuanceAgent';
 export {
   modifyTokenTrustedClaimIssuers,
-  ModifyTokenTrustedClaimIssuersParams,
+  ModifyTokenTrustedClaimIssuersAddSetParams,
+  ModifyTokenTrustedClaimIssuersRemoveParams,
 } from '~/api/procedures/modifyTokenTrustedClaimIssuers';
 export { registerIdentity, RegisterIdentityParams } from '~/api/procedures/registerIdentity';
 export {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -310,9 +310,9 @@ export interface ClaimScope {
 export interface TrustedClaimIssuer {
   identity: Identity;
   /**
-   * a null value means that the issuer is trusted for all claim types
+   * an undefined value means that the issuer is trusted for all claim types.
    */
-  trustedFor: ClaimType[] | null;
+  trustedFor?: ClaimType[];
 }
 
 export enum ConditionType {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -309,7 +309,10 @@ export interface ClaimScope {
 
 export interface TrustedClaimIssuer {
   identity: Identity;
-  trustedFor?: ClaimType[];
+  /**
+   * a null value means that the issuer is trusted for all claim types
+   */
+  trustedFor: ClaimType[] | null;
 }
 
 export enum ConditionType {

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -3936,7 +3936,6 @@ describe('trustedClaimIssuerToTrustedIssuer and trustedIssuerToTrustedClaimIssue
 
     let issuer: TrustedClaimIssuer = {
       identity: entityMockUtils.getIdentityInstance({ did }),
-      trustedFor: null,
     };
 
     dsMockUtils
@@ -3972,7 +3971,6 @@ describe('trustedClaimIssuerToTrustedIssuer and trustedIssuerToTrustedClaimIssue
     const context = dsMockUtils.getContextInstance();
     let fakeResult: TrustedClaimIssuer = {
       identity: new Identity({ did }, context),
-      trustedFor: null,
     };
     let trustedIssuer = dsMockUtils.createMockTrustedIssuer({
       issuer: dsMockUtils.createMockIdentityId(did),

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -107,6 +107,7 @@ import {
   keyToAddress,
   meshAffirmationStatusToAffirmationStatus,
   meshClaimToClaim,
+  meshClaimTypeToClaimType,
   meshInstructionStatusToInstructionStatus,
   meshPermissionsToPermissions,
   meshScopeToScope,
@@ -157,6 +158,7 @@ import {
   transactionHexToTxTag,
   transactionToTxTag,
   trustedClaimIssuerToTrustedIssuer,
+  trustedIssuerToTrustedClaimIssuer,
   txTagToExtrinsicIdentifier,
   txTagToProtocolOp,
   u8ToTransferStatus,
@@ -2222,6 +2224,92 @@ describe('claimToMeshClaim and meshClaimToClaim', () => {
   });
 });
 
+describe('meshClaimTypeToClaimType', () => {
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+  });
+
+  test('meshClaimTypeToClaimType should convert a polkadot ClaimType object to a ClaimType', () => {
+    let fakeResult: ClaimType = ClaimType.Accredited;
+
+    let claimType = dsMockUtils.createMockClaimType(fakeResult);
+
+    let result = meshClaimTypeToClaimType(claimType);
+    expect(result).toEqual(fakeResult);
+
+    fakeResult = ClaimType.Affiliate;
+
+    claimType = dsMockUtils.createMockClaimType(fakeResult);
+
+    result = meshClaimTypeToClaimType(claimType);
+    expect(result).toEqual(fakeResult);
+
+    fakeResult = ClaimType.Blocked;
+
+    claimType = dsMockUtils.createMockClaimType(fakeResult);
+
+    result = meshClaimTypeToClaimType(claimType);
+    expect(result).toEqual(fakeResult);
+
+    fakeResult = ClaimType.BuyLockup;
+
+    claimType = dsMockUtils.createMockClaimType(fakeResult);
+
+    result = meshClaimTypeToClaimType(claimType);
+    expect(result).toEqual(fakeResult);
+
+    fakeResult = ClaimType.CustomerDueDiligence;
+
+    claimType = dsMockUtils.createMockClaimType(fakeResult);
+
+    result = meshClaimTypeToClaimType(claimType);
+    expect(result).toEqual(fakeResult);
+
+    fakeResult = ClaimType.Exempted;
+
+    claimType = dsMockUtils.createMockClaimType(fakeResult);
+
+    result = meshClaimTypeToClaimType(claimType);
+    expect(result).toEqual(fakeResult);
+
+    fakeResult = ClaimType.Jurisdiction;
+
+    claimType = dsMockUtils.createMockClaimType(fakeResult);
+
+    result = meshClaimTypeToClaimType(claimType);
+    expect(result).toEqual(fakeResult);
+
+    fakeResult = ClaimType.KnowYourCustomer;
+
+    claimType = dsMockUtils.createMockClaimType(fakeResult);
+
+    result = meshClaimTypeToClaimType(claimType);
+    expect(result).toEqual(fakeResult);
+
+    fakeResult = ClaimType.NoData;
+
+    claimType = dsMockUtils.createMockClaimType(fakeResult);
+
+    result = meshClaimTypeToClaimType(claimType);
+    expect(result).toEqual(fakeResult);
+
+    fakeResult = ClaimType.SellLockup;
+
+    claimType = dsMockUtils.createMockClaimType(fakeResult);
+
+    result = meshClaimTypeToClaimType(claimType);
+    expect(result).toEqual(fakeResult);
+  });
+});
+
 describe('middlewareScopeToScope and scopeToMiddlewareScope', () => {
   test('should convert a MiddlewareScope object to a Scope', () => {
     let result = middlewareScopeToScope({
@@ -3825,7 +3913,7 @@ describe('toIdentityWithClaimsArray', () => {
   });
 });
 
-describe('trustedClaimIssuerToTrustedIssuer and identityIdToString', () => {
+describe('trustedClaimIssuerToTrustedIssuer and trustedIssuerToTrustedClaimIssuer', () => {
   beforeAll(() => {
     dsMockUtils.initMocks();
     entityMockUtils.initMocks();
@@ -3848,6 +3936,7 @@ describe('trustedClaimIssuerToTrustedIssuer and identityIdToString', () => {
 
     let issuer: TrustedClaimIssuer = {
       identity: entityMockUtils.getIdentityInstance({ did }),
+      trustedFor: null,
     };
 
     dsMockUtils
@@ -3876,5 +3965,32 @@ describe('trustedClaimIssuerToTrustedIssuer and identityIdToString', () => {
 
     result = trustedClaimIssuerToTrustedIssuer(issuer, context);
     expect(result).toBe(fakeResult);
+  });
+
+  test('trustedIssuerToTrustedClaimIssuer should convert an IdentityId to a did string', () => {
+    const did = 'someDid';
+    const context = dsMockUtils.getContextInstance();
+    let fakeResult: TrustedClaimIssuer = {
+      identity: new Identity({ did }, context),
+      trustedFor: null,
+    };
+    let trustedIssuer = dsMockUtils.createMockTrustedIssuer({
+      issuer: dsMockUtils.createMockIdentityId(did),
+      trusted_for: dsMockUtils.createMockTrustedFor('Any'),
+    });
+
+    let result = trustedIssuerToTrustedClaimIssuer(trustedIssuer, context);
+    expect(result).toEqual(fakeResult);
+
+    fakeResult = { identity: new Identity({ did }, context), trustedFor: [ClaimType.SellLockup] };
+    trustedIssuer = dsMockUtils.createMockTrustedIssuer({
+      issuer: dsMockUtils.createMockIdentityId(did),
+      trusted_for: dsMockUtils.createMockTrustedFor({
+        Specific: [dsMockUtils.createMockClaimType(ClaimType.SellLockup)],
+      }),
+    });
+
+    result = trustedIssuerToTrustedClaimIssuer(trustedIssuer, context);
+    expect(result).toEqual(fakeResult);
   });
 });

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -26,6 +26,7 @@ import {
   CddId,
   CddStatus,
   Claim as MeshClaim,
+  ClaimType as MeshClaimType,
   ComplianceRequirement,
   ComplianceRequirementResult,
   Condition as MeshCondition,
@@ -1968,4 +1969,70 @@ export function trustedClaimIssuerToTrustedIssuer(
     // eslint-disable-next-line @typescript-eslint/camelcase
     trusted_for: trustedFor,
   });
+}
+
+/**
+ * @hidden
+ */
+export function meshClaimTypeToClaimType(claimType: MeshClaimType): ClaimType {
+  if (claimType.isJurisdiction) {
+    return ClaimType.Jurisdiction;
+  }
+
+  if (claimType.isNoData) {
+    return ClaimType.NoData;
+  }
+
+  if (claimType.isAccredited) {
+    return ClaimType.Accredited;
+  }
+
+  if (claimType.isAffiliate) {
+    return ClaimType.Affiliate;
+  }
+
+  if (claimType.isBuyLockup) {
+    return ClaimType.BuyLockup;
+  }
+
+  if (claimType.isSellLockup) {
+    return ClaimType.SellLockup;
+  }
+
+  if (claimType.isCustomerDueDiligence) {
+    return ClaimType.CustomerDueDiligence;
+  }
+
+  if (claimType.isKnowYourCustomer) {
+    return ClaimType.KnowYourCustomer;
+  }
+
+  if (claimType.isExempted) {
+    return ClaimType.Exempted;
+  }
+
+  return ClaimType.Blocked;
+}
+
+/**
+ * @hidden
+ */
+export function trustedIssuerToTrustedClaimIssuer(
+  trustedIssuer: TrustedIssuer,
+  context: Context
+): TrustedClaimIssuer {
+  const { issuer, trusted_for: claimTypes } = trustedIssuer;
+
+  const identity = new Identity({ did: identityIdToString(issuer) }, context);
+
+  let trustedFor: ClaimType[] | null = null;
+
+  if (claimTypes.isSpecific) {
+    trustedFor = claimTypes.asSpecific.map(meshClaimTypeToClaimType);
+  }
+
+  return {
+    identity,
+    trustedFor,
+  };
 }

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -2025,7 +2025,7 @@ export function trustedIssuerToTrustedClaimIssuer(
 
   const identity = new Identity({ did: identityIdToString(issuer) }, context);
 
-  let trustedFor: ClaimType[] | null = null;
+  let trustedFor: ClaimType[] | undefined;
 
   if (claimTypes.isSpecific) {
     trustedFor = claimTypes.asSpecific.map(meshClaimTypeToClaimType);


### PR DESCRIPTION
Methods that modify default trusted claim issuers for a token now require passing Claim Types for
which that issuer is trusted

BREAKING CHANGE: - `TrustedClaimIssuers.set` and `TrustedClaimIssuers.add` now require an array of
`TrustedClaimIssuer` objects (each with an identity and an array of ClaimTypes)