### PR TITLE
feat: add `modifyTimes` to the STO entity

### DIFF
--- a/src/api/entities/Portfolio/types.ts
+++ b/src/api/entities/Portfolio/types.ts
@@ -1,11 +1,11 @@
 import BigNumber from 'bignumber.js';
 
-import { Leg } from '~/api/entities/Instruction/types';
 import { Account, SecurityToken } from '~/internal';
 import {
   SettlementDirectionEnum as SettlementDirection,
   SettlementResultEnum as SettlementResult,
 } from '~/middleware/types';
+import { Leg } from '~/types';
 
 export interface PortfolioBalance {
   token: SecurityToken;

--- a/src/api/entities/SecurityToken/TokenHolders.ts
+++ b/src/api/entities/SecurityToken/TokenHolders.ts
@@ -1,9 +1,8 @@
 import BigNumber from 'bignumber.js';
 import { IdentityId } from 'polymesh-types/types';
 
-import { IdentityBalance } from '~/api/entities/types';
 import { Identity, Namespace, SecurityToken } from '~/internal';
-import { PaginationOptions, ResultSet } from '~/types';
+import { IdentityBalance, PaginationOptions, ResultSet } from '~/types';
 import { balanceToBigNumber, identityIdToString, stringToTicker } from '~/utils/conversion';
 import { requestPaginated } from '~/utils/internal';
 

--- a/src/api/entities/Sto/__tests__/index.ts
+++ b/src/api/entities/Sto/__tests__/index.ts
@@ -2,11 +2,12 @@ import BigNumber from 'bignumber.js';
 import sinon from 'sinon';
 
 import {
-  cancelSto,
+  closeSto,
   Context,
   DefaultPortfolio,
   Entity,
   Identity,
+  modifyStoTimes,
   SecurityToken,
   Sto,
   TransactionQueue,
@@ -196,9 +197,39 @@ describe('Sto class', () => {
 
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<void>;
 
-      sinon.stub(cancelSto, 'prepare').withArgs(args, context).resolves(expectedQueue);
+      sinon.stub(closeSto, 'prepare').withArgs(args, context).resolves(expectedQueue);
 
-      const queue = await sto.close(args);
+      const queue = await sto.close();
+
+      expect(queue).toBe(expectedQueue);
+    });
+  });
+
+  describe('method: modifyTimes', () => {
+    test('should prepare the procedure with the correct arguments and context, and return the resulting transaction queue', async () => {
+      const ticker = 'SOMETICKER';
+      const id = new BigNumber(1);
+      const sto = new Sto({ id, ticker }, context);
+
+      const now = new Date();
+      const start = new Date(now.getTime() + 100000);
+      const end = new Date(start.getTime() + 100000);
+
+      const args = {
+        ticker,
+        id,
+        start,
+        end,
+      };
+
+      const expectedQueue = ('someQueue' as unknown) as TransactionQueue<void>;
+
+      sinon.stub(modifyStoTimes, 'prepare').withArgs(args, context).resolves(expectedQueue);
+
+      const queue = await sto.modifyTimes({
+        start,
+        end,
+      });
 
       expect(queue).toBe(expectedQueue);
     });

--- a/src/api/entities/Sto/index.ts
+++ b/src/api/entities/Sto/index.ts
@@ -1,7 +1,14 @@
 import { Option } from '@polkadot/types';
 import BigNumber from 'bignumber.js';
 
-import { cancelSto, CancelStoParams, Context, Entity, PolymeshError } from '~/internal';
+import {
+  closeSto,
+  Context,
+  Entity,
+  modifyStoTimes,
+  ModifyStoTimesParams,
+  PolymeshError,
+} from '~/internal';
 import { Fundraiser } from '~/polkadot/polymesh/types';
 import { ErrorCode, StoDetails, SubCallback, UnsubCallback } from '~/types';
 import { ProcedureMethod } from '~/types/internal';
@@ -48,7 +55,11 @@ export class Sto extends Entity<UniqueIdentifiers> {
     this.id = id;
     this.ticker = ticker;
 
-    this.close = createProcedureMethod(args => [cancelSto, { ticker, ...args }], context);
+    this.close = createProcedureMethod(() => [closeSto, { ticker, id }], context);
+    this.modifyTimes = createProcedureMethod(
+      args => [modifyStoTimes, { ticker, id, ...args }],
+      context
+    );
   }
 
   /**
@@ -100,5 +111,18 @@ export class Sto extends Entity<UniqueIdentifiers> {
   /**
    * Close the STO
    */
-  public close: ProcedureMethod<CancelStoParams, void>;
+  public close: ProcedureMethod<void, void>;
+
+  /**
+   * Modify the start/end time of the STO
+   *
+   * @param args.start - new start time (optional, will be left the same if not passed)
+   * @param args.end - new end time (optional, will be left th same if not passed). A null value means the STO doesn't end
+   *
+   * @throws if:
+   *   - Trying to modify the start time on an STO that already started
+   *   - Trying to modify anything on an STO that already ended
+   *   - Trying to change start or end time to a past date
+   */
+  public modifyTimes: ProcedureMethod<ModifyStoTimesParams, void>;
 }

--- a/src/api/procedures/__tests__/closeSto.ts
+++ b/src/api/procedures/__tests__/closeSto.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 import sinon from 'sinon';
 
-import { getAuthorization, Params, prepareCancelSto } from '~/api/procedures/cancelSto';
+import { getAuthorization, Params, prepareCloseSto } from '~/api/procedures/closeSto';
 import { Context } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
@@ -18,7 +18,7 @@ jest.mock(
   require('~/testUtils/mocks/entities').mockSecurityTokenModule('~/api/entities/SecurityToken')
 );
 
-describe('cancelOffering procedure', () => {
+describe('closeSto procedure', () => {
   const ticker = 'SOMETICKER';
   const id = new BigNumber(1);
 
@@ -30,6 +30,13 @@ describe('cancelOffering procedure', () => {
   let stopStoTransaction: PolymeshTx<unknown[]>;
 
   beforeAll(() => {
+    entityMockUtils.initMocks({
+      stoOptions: {
+        details: {
+          status: StoStatus.Live,
+        },
+      },
+    });
     dsMockUtils.initMocks();
     procedureMockUtils.initMocks();
 
@@ -56,17 +63,9 @@ describe('cancelOffering procedure', () => {
   });
 
   test('should add a stop sto transaction to the queue', async () => {
-    entityMockUtils.initMocks({
-      stoOptions: {
-        details: {
-          status: StoStatus.Live,
-        },
-      },
-    });
-
     const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
 
-    await prepareCancelSto.call(proc, { ticker, id });
+    await prepareCloseSto.call(proc, { ticker, id });
 
     sinon.assert.calledWith(addTransactionStub, stopStoTransaction, {}, rawTicker, rawId);
   });
@@ -82,7 +81,7 @@ describe('cancelOffering procedure', () => {
 
     const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
 
-    return expect(prepareCancelSto.call(proc, { ticker, id })).rejects.toThrow(
+    return expect(prepareCloseSto.call(proc, { ticker, id })).rejects.toThrow(
       'The STO is already closed'
     );
   });

--- a/src/api/procedures/__tests__/modifyStoTimes.ts
+++ b/src/api/procedures/__tests__/modifyStoTimes.ts
@@ -1,0 +1,307 @@
+import BigNumber from 'bignumber.js';
+import sinon from 'sinon';
+
+import { getAuthorization, Params, prepareModifyStoTimes } from '~/api/procedures/modifyStoTimes';
+import { Context } from '~/internal';
+import { Moment } from '~/polkadot';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import { RoleType, StoStatus, TxTags } from '~/types';
+import { PolymeshTx } from '~/types/internal';
+import * as utilsConversionModule from '~/utils/conversion';
+
+jest.mock(
+  '~/api/entities/Sto',
+  require('~/testUtils/mocks/entities').mockStoModule('~/api/entities/Sto')
+);
+jest.mock(
+  '~/api/entities/SecurityToken',
+  require('~/testUtils/mocks/entities').mockSecurityTokenModule('~/api/entities/SecurityToken')
+);
+
+describe('modifyStoTimes procedure', () => {
+  const ticker = 'SOMETICKER';
+  const id = new BigNumber(1);
+  const now = new Date();
+  const newStart = new Date(now.getTime() + 700000);
+  const newEnd = new Date(newStart.getTime() + 700000);
+  const start = new Date(now.getTime() + 500000);
+  const end = new Date(start.getTime() + 500000);
+
+  const rawTicker = dsMockUtils.createMockTicker(ticker);
+  const rawId = dsMockUtils.createMockU64(id.toNumber());
+  const rawNewStart = dsMockUtils.createMockMoment(newStart.getTime());
+  const rawNewEnd = dsMockUtils.createMockMoment(newEnd.getTime());
+  const rawStart = dsMockUtils.createMockMoment(start.getTime());
+  const rawEnd = dsMockUtils.createMockMoment(end.getTime());
+
+  let mockContext: Mocked<Context>;
+  let addTransactionStub: sinon.SinonStub;
+  let modifyFundraiserWindowTransaction: PolymeshTx<unknown[]>;
+
+  let dateToMomentStub: sinon.SinonStub<[Date, Context], Moment>;
+
+  const args = {
+    ticker,
+    id,
+    start: newStart,
+    end: newEnd,
+  };
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+    entityMockUtils.initMocks({
+      stoOptions: {
+        details: {
+          status: StoStatus.Live,
+          start,
+          end,
+        },
+      },
+    });
+
+    sinon.stub(utilsConversionModule, 'stringToTicker').returns(rawTicker);
+    sinon.stub(utilsConversionModule, 'numberToU64').returns(rawId);
+    dateToMomentStub = sinon.stub(utilsConversionModule, 'dateToMoment');
+  });
+
+  beforeEach(() => {
+    addTransactionStub = procedureMockUtils.getAddTransactionStub();
+    mockContext = dsMockUtils.getContextInstance();
+
+    dateToMomentStub.withArgs(newStart, mockContext).returns(rawNewStart);
+    dateToMomentStub.withArgs(newEnd, mockContext).returns(rawNewEnd);
+    dateToMomentStub.withArgs(start, mockContext).returns(rawStart);
+    dateToMomentStub.withArgs(end, mockContext).returns(rawEnd);
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    entityMockUtils.cleanup();
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  test('should add a modify fundraiser window transaction to the queue', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+    modifyFundraiserWindowTransaction = dsMockUtils.createTxStub('sto', 'modifyFundraiserWindow');
+
+    await prepareModifyStoTimes.call(proc, args);
+
+    sinon.assert.calledWith(
+      addTransactionStub,
+      modifyFundraiserWindowTransaction,
+      {},
+      rawTicker,
+      rawId,
+      rawNewStart,
+      rawNewEnd
+    );
+
+    await prepareModifyStoTimes.call(proc, { ...args, start: undefined });
+
+    sinon.assert.calledWith(
+      addTransactionStub,
+      modifyFundraiserWindowTransaction,
+      {},
+      rawTicker,
+      rawId,
+      rawStart,
+      rawNewEnd
+    );
+
+    await prepareModifyStoTimes.call(proc, { ...args, end: null });
+
+    sinon.assert.calledWith(
+      addTransactionStub,
+      modifyFundraiserWindowTransaction,
+      {},
+      rawTicker,
+      rawId,
+      rawNewStart,
+      null
+    );
+
+    await prepareModifyStoTimes.call(proc, { ...args, end: undefined });
+
+    sinon.assert.calledWith(
+      addTransactionStub,
+      modifyFundraiserWindowTransaction,
+      {},
+      rawTicker,
+      rawId,
+      rawNewStart,
+      rawEnd
+    );
+
+    entityMockUtils.configureMocks({
+      stoOptions: {
+        details: {
+          start,
+          end: null,
+          status: StoStatus.Live,
+        },
+      },
+    });
+
+    await prepareModifyStoTimes.call(proc, { ...args, end: undefined });
+
+    sinon.assert.calledWith(
+      addTransactionStub,
+      modifyFundraiserWindowTransaction,
+      {},
+      rawTicker,
+      rawId,
+      rawNewStart,
+      null
+    );
+  });
+
+  test('should throw an error if nothing is being modified', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    let err: Error | undefined;
+
+    const message = 'Nothing to modify';
+
+    try {
+      await prepareModifyStoTimes.call(proc, { ...args, start, end });
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err?.message).toBe(message);
+
+    err = undefined;
+
+    try {
+      await prepareModifyStoTimes.call(proc, { ...args, start: undefined, end });
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err?.message).toBe(message);
+
+    try {
+      await prepareModifyStoTimes.call(proc, { ...args, start, end: undefined });
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err?.message).toBe(message);
+  });
+
+  test('should throw an error if the sto is already closed', async () => {
+    entityMockUtils.configureMocks({
+      stoOptions: {
+        details: {
+          status: StoStatus.Closed,
+        },
+      },
+    });
+
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    return expect(prepareModifyStoTimes.call(proc, args)).rejects.toThrow(
+      'The STO is already closed'
+    );
+  });
+
+  test('should throw an error if the STO has already ended', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    entityMockUtils.configureMocks({
+      stoOptions: {
+        details: {
+          start: now,
+          end: now,
+          status: StoStatus.Live,
+        },
+      },
+    });
+
+    let err: Error | undefined;
+
+    try {
+      await prepareModifyStoTimes.call(proc, args);
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err?.message).toBe('The STO has already ended');
+  });
+
+  test('should throw an error if attempting to modify the start time of an STO that has already started', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    entityMockUtils.configureMocks({
+      stoOptions: {
+        details: {
+          start: new Date(now.getTime() - 1000),
+          end,
+          status: StoStatus.Live,
+        },
+      },
+    });
+
+    let err: Error | undefined;
+
+    try {
+      await prepareModifyStoTimes.call(proc, args);
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err?.message).toBe('Cannot modify the start time of an STO that already started');
+  });
+
+  test('should throw an error if the new times are in the past', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    let err: Error | undefined;
+
+    const past = new Date(now.getTime() - 1000);
+
+    const message = 'New dates are in the past';
+
+    try {
+      await prepareModifyStoTimes.call(proc, { ...args, start: past });
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err?.message).toBe(message);
+
+    err = undefined;
+
+    try {
+      await prepareModifyStoTimes.call(proc, { ...args, end: past });
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err?.message).toBe(message);
+  });
+
+  describe('getAuthorization', () => {
+    test('should return the appropriate roles and permissions', () => {
+      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+      const boundFunc = getAuthorization.bind(proc);
+
+      expect(boundFunc(args)).toEqual({
+        identityRoles: [{ type: RoleType.TokenPia, ticker }],
+        signerPermissions: {
+          transactions: [TxTags.sto.ModifyFundraiserWindow],
+          tokens: [entityMockUtils.getSecurityTokenInstance({ ticker })],
+          portfolios: [],
+        },
+      });
+    });
+  });
+});

--- a/src/api/procedures/addInstruction.ts
+++ b/src/api/procedures/addInstruction.ts
@@ -6,7 +6,6 @@ import P from 'bluebird';
 import { compact, flatten } from 'lodash';
 import { PortfolioId, Ticker, TxTag, TxTags } from 'polymesh-types/types';
 
-import { Venue } from '~/api/entities/Venue';
 import { assertPortfolioExists } from '~/api/procedures/utils';
 import {
   Context,
@@ -17,6 +16,7 @@ import {
   PostTransactionValue,
   Procedure,
   SecurityToken,
+  Venue,
 } from '~/internal';
 import { ErrorCode, InstructionType, PortfolioLike, RoleType } from '~/types';
 import { ProcedureAuthorization } from '~/types/internal';

--- a/src/api/procedures/closeSto.ts
+++ b/src/api/procedures/closeSto.ts
@@ -5,21 +5,18 @@ import { ErrorCode, RoleType, StoStatus, TxTags } from '~/types';
 import { ProcedureAuthorization } from '~/types/internal';
 import { numberToU64, stringToTicker } from '~/utils/conversion';
 
-export interface CancelStoParams {
+/**
+ * @hidden
+ */
+export interface Params {
+  ticker: string;
   id: BigNumber;
 }
 
 /**
  * @hidden
  */
-export type Params = CancelStoParams & {
-  ticker: string;
-};
-
-/**
- * @hidden
- */
-export async function prepareCancelSto(this: Procedure<Params, void>, args: Params): Promise<void> {
+export async function prepareCloseSto(this: Procedure<Params, void>, args: Params): Promise<void> {
   const {
     context: {
       polymeshApi: {
@@ -36,7 +33,7 @@ export async function prepareCancelSto(this: Procedure<Params, void>, args: Para
 
   if (status === StoStatus.Closed) {
     throw new PolymeshError({
-      code: ErrorCode.FatalError,
+      code: ErrorCode.ValidationError,
       message: 'The STO is already closed',
     });
   }
@@ -68,4 +65,4 @@ export function getAuthorization(
 /**
  * @hidden
  */
-export const cancelSto = new Procedure(prepareCancelSto, getAuthorization);
+export const closeSto = new Procedure(prepareCloseSto, getAuthorization);

--- a/src/api/procedures/modifyStoTimes.ts
+++ b/src/api/procedures/modifyStoTimes.ts
@@ -1,0 +1,124 @@
+import BigNumber from 'bignumber.js';
+
+import { PolymeshError, Procedure, SecurityToken, Sto } from '~/internal';
+import { Moment } from '~/polkadot';
+import { ErrorCode, RoleType, StoStatus, TxTags } from '~/types';
+import { ProcedureAuthorization } from '~/types/internal';
+import { dateToMoment, numberToU64, stringToTicker } from '~/utils/conversion';
+
+export type ModifyStoTimesParams =
+  | {
+      start?: Date;
+      end: Date | null;
+    }
+  | {
+      start: Date;
+      end?: Date | null;
+    }
+  | { start: Date; end: Date | null };
+
+/**
+ * @hidden
+ */
+export type Params = ModifyStoTimesParams & {
+  id: BigNumber;
+  ticker: string;
+};
+
+/**
+ * @hidden
+ */
+export async function prepareModifyStoTimes(
+  this: Procedure<Params, void>,
+  args: Params
+): Promise<void> {
+  const {
+    context: {
+      polymeshApi: {
+        tx: { sto: txSto },
+      },
+    },
+    context,
+  } = this;
+  const { ticker, id, start: newStart, end: newEnd } = args;
+
+  const sto = new Sto({ ticker, id }, context);
+
+  const { status, end, start } = await sto.details();
+
+  if (status === StoStatus.Closed) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'The STO is already closed',
+    });
+  }
+
+  if ((!newStart || start === newStart) && (newEnd === undefined || end === newEnd)) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'Nothing to modify',
+    });
+  }
+
+  const now = new Date();
+
+  if (end && now > end) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'The STO has already ended',
+    });
+  }
+
+  if (now > start && newStart) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'Cannot modify the start time of an STO that already started',
+    });
+  }
+
+  if ((newStart && now > newStart) || (newEnd && now > newEnd)) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'New dates are in the past',
+    });
+  }
+
+  const rawTicker = stringToTicker(ticker, context);
+  const rawId = numberToU64(id, context);
+  const rawStart = newStart ? dateToMoment(newStart, context) : dateToMoment(start, context);
+  let rawEnd: Moment | null;
+
+  if (newEnd === null) {
+    rawEnd = null;
+  } else if (!newEnd) {
+    console.log('END', end);
+    rawEnd = end ? dateToMoment(end, context) : null;
+  } else {
+    rawEnd = dateToMoment(newEnd, context);
+  }
+
+  this.addTransaction(txSto.modifyFundraiserWindow, {}, rawTicker, rawId, rawStart, rawEnd);
+}
+
+/**
+ * @hidden
+ */
+export function getAuthorization(
+  this: Procedure<Params, void>,
+  { ticker }: Params
+): ProcedureAuthorization {
+  const { context } = this;
+  return {
+    identityRoles: [{ type: RoleType.TokenPia, ticker }],
+    signerPermissions: {
+      transactions: [TxTags.sto.ModifyFundraiserWindow],
+      tokens: [new SecurityToken({ ticker }, context)],
+      portfolios: [],
+    },
+  };
+}
+
+/**
+ * @hidden
+ */
+export const modifyStoTimes = new Procedure(prepareModifyStoTimes, getAuthorization);

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -98,7 +98,8 @@ export {
   SetPercentageTransferRestrictionsParams,
   Storage as SetTransferRestrictionsStorage,
 } from '~/api/procedures/setTransferRestrictions';
-export { cancelSto, CancelStoParams } from '~/api/procedures/cancelSto';
+export { closeSto } from '~/api/procedures/closeSto';
+export { modifyStoTimes, ModifyStoTimesParams } from '~/api/procedures/modifyStoTimes';
 export { Identity } from '~/api/entities/Identity';
 export { CurrentIdentity } from '~/api/entities/CurrentIdentity';
 export { Account } from '~/api/entities/Account';


### PR DESCRIPTION
Also remove redundant parameter from `close` method

BREAKING CHANGE: `sto.close` now takes no parameters