### PR TITLE
fix(permissions): order permissions alphabetically before setting them

### DIFF
--- a/src/api/entities/__tests__/CurrentAccount.ts
+++ b/src/api/entities/__tests__/CurrentAccount.ts
@@ -136,5 +136,27 @@ describe('CurrentAccount class', () => {
 
       expect(result).toEqual(false);
     });
+
+    test('should exempt certain transactions from requiring permissions', async () => {
+      const address = 'someAddress';
+
+      context = dsMockUtils.getContextInstance({ primaryKey: address });
+
+      const account = new CurrentAccount({ address }, context);
+
+      const result = await account.hasPermissions({
+        tokens: [],
+        portfolios: [],
+        transactions: [
+          TxTags.balances.Transfer,
+          TxTags.balances.TransferWithMemo,
+          TxTags.staking.AddPermissionedValidator,
+          TxTags.sudo.SetKey,
+          TxTags.session.PurgeKeys,
+        ],
+      });
+
+      expect(result).toEqual(true);
+    });
   });
 });

--- a/src/api/procedures/modifySignerPermissions.ts
+++ b/src/api/procedures/modifySignerPermissions.ts
@@ -1,5 +1,3 @@
-import P from 'bluebird';
-
 import { assertSecondaryKeys } from '~/api/procedures/utils';
 import { Procedure } from '~/internal';
 import { PermissionsLike, Signer, TxTags } from '~/types';
@@ -47,16 +45,13 @@ export async function prepareModifySignerPermissions(
     secondaryKeys
   );
 
-  const signersList = await P.map(
-    signerValues,
-    async ({ signer, permissions: permissionsLike }) => {
-      const permissions = await permissionsLikeToPermissions(permissionsLike, context);
+  const signersList = signerValues.map(({ signer, permissions: permissionsLike }) => {
+    const permissions = permissionsLikeToPermissions(permissionsLike, context);
 
-      const rawPermissions = permissionsToMeshPermissions(permissions, context);
+    const rawPermissions = permissionsToMeshPermissions(permissions, context);
 
-      return tuple(signerValueToSignatory(signer, context), rawPermissions);
-    }
-  );
+    return tuple(signerValueToSignatory(signer, context), rawPermissions);
+  });
 
   this.addBatchTransaction(tx.identity.setPermissionToSigner, {}, signersList);
 }

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -1013,7 +1013,7 @@ describe('permissionsToMeshPermissions and meshPermissionsToPermissions', () => 
     entityMockUtils.cleanup();
   });
 
-  test('permissionsToMeshPermissions should convert a Permissions to a polkadot Permissions object', () => {
+  test('permissionsToMeshPermissions should convert a Permissions to a polkadot Permissions object (ordering tx alphabetically)', () => {
     let value: Permissions = {
       tokens: null,
       transactions: null,
@@ -1039,7 +1039,7 @@ describe('permissionsToMeshPermissions and meshPermissionsToPermissions', () => 
     const did = 'someDid';
     value = {
       tokens: [entityMockUtils.getSecurityTokenInstance({ ticker })],
-      transactions: [TxTags.identity.AddClaim],
+      transactions: [TxTags.sto.Invest, TxTags.identity.AddClaim, TxTags.sto.CreateFundraiser],
       portfolios: [entityMockUtils.getDefaultPortfolioInstance({ did })],
     };
 
@@ -1052,12 +1052,16 @@ describe('permissionsToMeshPermissions and meshPermissionsToPermissions', () => 
       .withArgs('Permissions', {
         asset: [rawTicker],
         extrinsic: [
+          /* eslint-disable @typescript-eslint/camelcase */
           {
-            /* eslint-disable @typescript-eslint/camelcase */
             pallet_name: 'Identity',
             dispatchable_names: ['add_claim'],
-            /* eslint-enable @typescript-eslint/camelcase */
           },
+          {
+            pallet_name: 'Sto',
+            dispatchable_names: ['create_fundraiser', 'invest'],
+          },
+          /* eslint-enable @typescript-eslint/camelcase */
         ],
         portfolio: [rawPortfolioId],
       })

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -11,7 +11,6 @@ import {
 } from '@polkadot/util';
 import { blake2AsHex, decodeAddress, encodeAddress } from '@polkadot/util-crypto';
 import BigNumber from 'bignumber.js';
-import P from 'bluebird';
 import { computeWithoutCheck } from 'iso-7064';
 import { camelCase, isEqual, map, padEnd, range, rangeRight, snakeCase, values } from 'lodash';
 import {
@@ -514,7 +513,7 @@ export function permissionsToMeshPermissions(
   let extrinsic: { pallet_name: string; dispatchable_names: string[] }[] | null = null;
 
   if (transactions) {
-    transactions.forEach(tag => {
+    transactions.sort().forEach(tag => {
       const [modName, txName] = tag.split('.');
 
       const palletName = stringUpperFirst(modName);
@@ -2223,10 +2222,10 @@ export function stoTierToPriceTier(tier: StoTier, context: Context): PriceTier {
 /**
  * @hidden
  */
-export async function permissionsLikeToPermissions(
+export function permissionsLikeToPermissions(
   permissionsLike: PermissionsLike,
   context: Context
-): Promise<Permissions> {
+): Permissions {
   let tokenPermissions: SecurityToken[] | null = [];
   let transactionPermissions: TxTag[] | null = [];
   let portfolioPermissions: (DefaultPortfolio | NumberedPortfolio)[] | null = [];
@@ -2248,7 +2247,7 @@ export async function permissionsLikeToPermissions(
   if (portfolios === null) {
     portfolioPermissions = null;
   } else if (portfolios) {
-    portfolioPermissions = await P.map(portfolios, portfolio =>
+    portfolioPermissions = portfolios.map(portfolio =>
       portfolioLikeToPortfolio(portfolio, context)
     );
   }


### PR DESCRIPTION
Also exempted some transactions from requiring permissions (most of balances, all of staking, sudo
and session)