### PR TITLE
feat(sto): improve offering details

### DIFF
--- a/src/api/entities/SecurityToken/Offerings.ts
+++ b/src/api/entities/SecurityToken/Offerings.ts
@@ -46,9 +46,9 @@ export class Offerings extends Namespace<SecurityToken> {
   /**
    * Retrieve all of the Token's Offerings. Can be filtered using parameters
    *
-   * @param opts.status - status of the offerings to fetch
+   * @param opts.status - status of the offerings to fetch. As long as the STO has one of the passed statuses, it will be returned
    */
-  public async get(opts: { status?: StoStatus } = {}): Promise<StoWithDetails[]> {
+  public async get(opts: { status?: Partial<StoStatus> } = {}): Promise<StoWithDetails[]> {
     const {
       parent: { ticker },
       context: {
@@ -57,7 +57,9 @@ export class Offerings extends Namespace<SecurityToken> {
       context,
     } = this;
 
-    const { status: statusFilter } = opts;
+    const {
+      status: { timing: timingFilter, balance: balanceFilter, sale: saleFilter } = {},
+    } = opts;
 
     const entries = await query.sto.fundraisers.entries(stringToTicker(ticker, context));
 
@@ -66,10 +68,15 @@ export class Offerings extends Namespace<SecurityToken> {
       details: fundraiserToStoDetails(fundraiser.unwrap(), context),
     }));
 
-    if (statusFilter) {
-      return stos.filter(({ details: { status } }) => status === statusFilter);
-    }
-
-    return stos;
+    return stos.filter(
+      ({
+        details: {
+          status: { timing, sale, balance },
+        },
+      }) =>
+        (!timingFilter || timingFilter === timing) &&
+        (!saleFilter || saleFilter === sale) &&
+        (!balanceFilter || balanceFilter === balance)
+    );
   }
 }

--- a/src/api/entities/SecurityToken/Offerings.ts
+++ b/src/api/entities/SecurityToken/Offerings.ts
@@ -46,7 +46,7 @@ export class Offerings extends Namespace<SecurityToken> {
   /**
    * Retrieve all of the Token's Offerings. Can be filtered using parameters
    *
-   * @param opts.status - status of the offerings to fetch. As long as the STO has one of the passed statuses, it will be returned
+   * @param opts.status - status of the offerings to fetch. If defined, only STOs that have all passed statuses will be returned
    */
   public async get(opts: { status?: Partial<StoStatus> } = {}): Promise<StoWithDetails[]> {
     const {

--- a/src/api/entities/SecurityToken/__tests__/Offerings.ts
+++ b/src/api/entities/SecurityToken/__tests__/Offerings.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { Context, launchSto, Namespace, SecurityToken, Sto, TransactionQueue } from '~/internal';
 import { Fundraiser, Ticker } from '~/polkadot';
 import { dsMockUtils, entityMockUtils } from '~/testUtils/mocks';
-import { StoDetails, StoStatus } from '~/types';
+import { StoBalanceStatus, StoDetails, StoSaleStatus, StoTimingStatus } from '~/types';
 import { tuple } from '~/types/utils';
 import * as utilsConversionModule from '~/utils/conversion';
 
@@ -121,7 +121,13 @@ describe('Offerings class', () => {
           tiers,
           minInvestment,
           venue,
-          status: StoStatus.Closed,
+          status: {
+            sale: StoSaleStatus.Closed,
+            timing: StoTimingStatus.Started,
+            balance: StoBalanceStatus.Available,
+          },
+          totalAmount: tiers[0].amount,
+          totalRemaining: tiers[0].remaining,
         },
         {
           creator,
@@ -133,7 +139,13 @@ describe('Offerings class', () => {
           tiers,
           minInvestment,
           venue,
-          status: StoStatus.Live,
+          status: {
+            sale: StoSaleStatus.Live,
+            timing: StoTimingStatus.Started,
+            balance: StoBalanceStatus.Available,
+          },
+          totalAmount: tiers[0].amount,
+          totalRemaining: tiers[0].remaining,
         },
       ];
       fundraisers = [
@@ -227,7 +239,13 @@ describe('Offerings class', () => {
     });
 
     test('should return offerings associated to the token filtered by status', async () => {
-      const result = await offerings.get({ status: StoStatus.Live });
+      const result = await offerings.get({
+        status: {
+          sale: StoSaleStatus.Live,
+          timing: StoTimingStatus.Started,
+          balance: StoBalanceStatus.Available,
+        },
+      });
 
       expect(result[0].sto.id).toEqual(new BigNumber(2));
       expect(result[0].details).toEqual(details[1]);

--- a/src/api/entities/Sto/__tests__/index.ts
+++ b/src/api/entities/Sto/__tests__/index.ts
@@ -18,7 +18,7 @@ import {
 import { heartbeat, investments } from '~/middleware/queries';
 import { InvestmentResult } from '~/middleware/types';
 import { dsMockUtils, entityMockUtils } from '~/testUtils/mocks';
-import { StoDetails, StoStatus } from '~/types';
+import { StoBalanceStatus, StoDetails, StoSaleStatus, StoTimingStatus } from '~/types';
 import * as utilsConversionModule from '~/utils/conversion';
 
 jest.mock(
@@ -97,7 +97,9 @@ describe('Sto class', () => {
     const someDid = 'someDid';
     const otherDid = 'otherDid';
     const raisingCurrency = 'USD';
-    const tierNumber = new BigNumber(10);
+    const amount = new BigNumber(1000);
+    const price = new BigNumber(100);
+    const remaining = new BigNumber(700);
     const date = new Date();
     const minInvestmentValue = new BigNumber(1);
 
@@ -117,9 +119,9 @@ describe('Sto class', () => {
         raising_asset: dsMockUtils.createMockTicker(raisingCurrency),
         tiers: [
           dsMockUtils.createMockFundraiserTier({
-            total: dsMockUtils.createMockBalance(tierNumber.toNumber()),
-            price: dsMockUtils.createMockBalance(tierNumber.toNumber()),
-            remaining: dsMockUtils.createMockBalance(tierNumber.toNumber()),
+            total: dsMockUtils.createMockBalance(amount.toNumber()),
+            price: dsMockUtils.createMockBalance(price.toNumber()),
+            remaining: dsMockUtils.createMockBalance(remaining.toNumber()),
           }),
         ],
         venue_id: dsMockUtils.createMockU64(1),
@@ -146,16 +148,22 @@ describe('Sto class', () => {
         raisingCurrency,
         tiers: [
           {
-            amount: tierNumber.div(Math.pow(10, 6)),
-            price: tierNumber.div(Math.pow(10, 6)),
-            remaining: tierNumber.div(Math.pow(10, 6)),
+            amount: amount.shiftedBy(-6),
+            price: price.shiftedBy(-6),
+            remaining: remaining.shiftedBy(-6),
           },
         ],
         venue: new Venue({ id: new BigNumber(1) }, context),
         start: date,
         end: date,
-        status: StoStatus.Live,
-        minInvestment: minInvestmentValue.div(Math.pow(10, 6)),
+        status: {
+          sale: StoSaleStatus.Live,
+          timing: StoTimingStatus.Expired,
+          balance: StoBalanceStatus.Residual,
+        },
+        minInvestment: minInvestmentValue.shiftedBy(-6),
+        totalAmount: amount.shiftedBy(-6),
+        totalRemaining: remaining.shiftedBy(-6),
       };
 
       dsMockUtils.createQueryStub('sto', 'fundraisers', {

--- a/src/api/entities/Sto/types.ts
+++ b/src/api/entities/Sto/types.ts
@@ -2,10 +2,61 @@ import BigNumber from 'bignumber.js';
 
 import { DefaultPortfolio, Identity, NumberedPortfolio, Venue } from '~/internal';
 
-export enum StoStatus {
-  Live = 'Live',
+export enum StoTimingStatus {
+  /**
+   * Start date not reached yet
+   */
+  NotStarted = 'NotStarted',
+  /**
+   * Between start and end date
+   */
+  Started = 'Started',
+  /**
+   * End date reached
+   */
+  Expired = 'Expired',
+}
+
+export enum StoBalanceStatus {
+  /**
+   * There still are Security Tokens available for purchase
+   */
+  Available = 'Available',
+  /**
+   * All Security Tokens in the offering have been sold
+   */
+  SoldOut = 'SoldOut',
+  /**
+   * There are remaining tokens, but their added value is lower than the Offering's
+   *   minimum investment, so they cannot be purchased. The offering should be manually closed
+   *   to retrieve them
+   */
+  Residual = 'Residual',
+}
+
+export enum StoSaleStatus {
+  /**
+   * Sale temporarily paused, can be resumed (unfrozen) by the PIA
+   */
   Frozen = 'Frozen',
+  /**
+   * Investments can be made
+   */
+  Live = 'Live',
+  /**
+   * Sale was manually closed before the end date was reached
+   */
+  ClosedEarly = 'ClosedEarly',
+  /**
+   * Sale was manually closed after the end date was reached
+   */
   Closed = 'Closed',
+}
+
+export interface StoStatus {
+  timing: StoTimingStatus;
+  balance: StoBalanceStatus;
+  sale: StoSaleStatus;
 }
 
 export interface StoTier {
@@ -28,6 +79,8 @@ export interface StoDetails {
   end: Date | null;
   status: StoStatus;
   minInvestment: BigNumber;
+  totalAmount: BigNumber;
+  totalRemaining: BigNumber;
 }
 
 export interface Investment {

--- a/src/api/procedures/__tests__/closeSto.ts
+++ b/src/api/procedures/__tests__/closeSto.ts
@@ -5,7 +5,7 @@ import { getAuthorization, Params, prepareCloseSto } from '~/api/procedures/clos
 import { Context } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
-import { RoleType, StoStatus, TxTags } from '~/types';
+import { RoleType, StoBalanceStatus, StoSaleStatus, StoTimingStatus, TxTags } from '~/types';
 import { PolymeshTx } from '~/types/internal';
 import * as utilsConversionModule from '~/utils/conversion';
 
@@ -33,7 +33,11 @@ describe('closeSto procedure', () => {
     entityMockUtils.initMocks({
       stoOptions: {
         details: {
-          status: StoStatus.Live,
+          status: {
+            sale: StoSaleStatus.Live,
+            timing: StoTimingStatus.Started,
+            balance: StoBalanceStatus.Available,
+          },
         },
       },
     });
@@ -70,11 +74,15 @@ describe('closeSto procedure', () => {
     sinon.assert.calledWith(addTransactionStub, stopStoTransaction, {}, rawTicker, rawId);
   });
 
-  test('should throw an error if the sto is already closed', async () => {
+  test('should throw an error if the STO is already closed', async () => {
     entityMockUtils.configureMocks({
       stoOptions: {
         details: {
-          status: StoStatus.Closed,
+          status: {
+            sale: StoSaleStatus.Closed,
+            timing: StoTimingStatus.Started,
+            balance: StoBalanceStatus.Available,
+          },
         },
       },
     });

--- a/src/api/procedures/__tests__/investInSto.ts
+++ b/src/api/procedures/__tests__/investInSto.ts
@@ -14,7 +14,14 @@ import {
 import { Context, DefaultPortfolio } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
-import { PortfolioBalance, PortfolioLike, RoleType, StoStatus } from '~/types';
+import {
+  PortfolioBalance,
+  PortfolioLike,
+  RoleType,
+  StoBalanceStatus,
+  StoSaleStatus,
+  StoTimingStatus,
+} from '~/types';
 import { PortfolioId } from '~/types/internal';
 import * as utilsConversionModule from '~/utils/conversion';
 
@@ -128,11 +135,15 @@ describe('investInSto procedure', () => {
     dsMockUtils.cleanup();
   });
 
-  test('should throw an error if the STO is not live', async () => {
+  test('should throw an error if the STO is not accepting investments', async () => {
     entityMockUtils.configureMocks({
       stoOptions: {
         details: {
-          status: StoStatus.Closed,
+          status: {
+            sale: StoSaleStatus.Frozen,
+            timing: StoTimingStatus.Started,
+            balance: StoBalanceStatus.Available,
+          },
         },
       },
     });
@@ -141,31 +152,20 @@ describe('investInSto procedure', () => {
       fundingPortfolioId,
     });
 
-    return expect(prepareInvestInSto.call(proc, args)).rejects.toThrow('The STO is not live');
-  });
-
-  test('should throw an error if the STO has already ended', async () => {
-    entityMockUtils.configureMocks({
-      stoOptions: {
-        details: {
-          status: StoStatus.Live,
-          end: new Date('1/1/2020'),
-        },
-      },
-    });
-    const proc = procedureMockUtils.getInstance<Params, void, Storage>(mockContext, {
-      purchasePortfolioId,
-      fundingPortfolioId,
-    });
-
-    return expect(prepareInvestInSto.call(proc, args)).rejects.toThrow('The STO has already ended');
+    return expect(prepareInvestInSto.call(proc, args)).rejects.toThrow(
+      'The STO is not accepting investments at the moment'
+    );
   });
 
   test('should throw an error if the minimum investment is not reached', async () => {
     entityMockUtils.configureMocks({
       stoOptions: {
         details: {
-          status: StoStatus.Live,
+          status: {
+            sale: StoSaleStatus.Live,
+            timing: StoTimingStatus.Started,
+            balance: StoBalanceStatus.Available,
+          },
           end: new Date('12/12/2030'),
           minInvestment: new BigNumber(10),
           tiers: [
@@ -203,7 +203,11 @@ describe('investInSto procedure', () => {
     entityMockUtils.configureMocks({
       stoOptions: {
         details: {
-          status: StoStatus.Live,
+          status: {
+            sale: StoSaleStatus.Live,
+            timing: StoTimingStatus.Started,
+            balance: StoBalanceStatus.Available,
+          },
           end: new Date('12/12/2030'),
           minInvestment: new BigNumber(25),
           tiers: [
@@ -241,7 +245,11 @@ describe('investInSto procedure', () => {
     entityMockUtils.configureMocks({
       stoOptions: {
         details: {
-          status: StoStatus.Live,
+          status: {
+            sale: StoSaleStatus.Live,
+            timing: StoTimingStatus.Started,
+            balance: StoBalanceStatus.Available,
+          },
           end: new Date('12/12/2030'),
           minInvestment: new BigNumber(10),
           tiers: [
@@ -281,7 +289,11 @@ describe('investInSto procedure', () => {
     entityMockUtils.configureMocks({
       stoOptions: {
         details: {
-          status: StoStatus.Live,
+          status: {
+            sale: StoSaleStatus.Live,
+            timing: StoTimingStatus.Started,
+            balance: StoBalanceStatus.Available,
+          },
           end: new Date('12/12/2030'),
           minInvestment: new BigNumber(10),
           tiers: [

--- a/src/api/procedures/__tests__/modifyStoTimes.ts
+++ b/src/api/procedures/__tests__/modifyStoTimes.ts
@@ -6,7 +6,7 @@ import { Context } from '~/internal';
 import { Moment } from '~/polkadot';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
-import { RoleType, StoStatus, TxTags } from '~/types';
+import { RoleType, StoBalanceStatus, StoSaleStatus, StoTimingStatus, TxTags } from '~/types';
 import { PolymeshTx } from '~/types/internal';
 import * as utilsConversionModule from '~/utils/conversion';
 
@@ -51,15 +51,7 @@ describe('modifyStoTimes procedure', () => {
   beforeAll(() => {
     dsMockUtils.initMocks();
     procedureMockUtils.initMocks();
-    entityMockUtils.initMocks({
-      stoOptions: {
-        details: {
-          status: StoStatus.Live,
-          start,
-          end,
-        },
-      },
-    });
+    entityMockUtils.initMocks();
 
     sinon.stub(utilsConversionModule, 'stringToTicker').returns(rawTicker);
     sinon.stub(utilsConversionModule, 'numberToU64').returns(rawId);
@@ -67,6 +59,19 @@ describe('modifyStoTimes procedure', () => {
   });
 
   beforeEach(() => {
+    entityMockUtils.configureMocks({
+      stoOptions: {
+        details: {
+          status: {
+            sale: StoSaleStatus.Live,
+            timing: StoTimingStatus.NotStarted,
+            balance: StoBalanceStatus.Available,
+          },
+          start,
+          end,
+        },
+      },
+    });
     addTransactionStub = procedureMockUtils.getAddTransactionStub();
     mockContext = dsMockUtils.getContextInstance();
 
@@ -145,7 +150,11 @@ describe('modifyStoTimes procedure', () => {
         details: {
           start,
           end: null,
-          status: StoStatus.Live,
+          status: {
+            sale: StoSaleStatus.Live,
+            timing: StoTimingStatus.NotStarted,
+            balance: StoBalanceStatus.Available,
+          },
         },
       },
     });
@@ -201,7 +210,11 @@ describe('modifyStoTimes procedure', () => {
     entityMockUtils.configureMocks({
       stoOptions: {
         details: {
-          status: StoStatus.Closed,
+          status: {
+            sale: StoSaleStatus.Closed,
+            timing: StoTimingStatus.Started,
+            balance: StoBalanceStatus.Available,
+          },
         },
       },
     });
@@ -221,7 +234,11 @@ describe('modifyStoTimes procedure', () => {
         details: {
           start: now,
           end: now,
-          status: StoStatus.Live,
+          status: {
+            sale: StoSaleStatus.Live,
+            timing: StoTimingStatus.Expired,
+            balance: StoBalanceStatus.Available,
+          },
         },
       },
     });
@@ -245,7 +262,11 @@ describe('modifyStoTimes procedure', () => {
         details: {
           start: new Date(now.getTime() - 1000),
           end,
-          status: StoStatus.Live,
+          status: {
+            sale: StoSaleStatus.Live,
+            timing: StoTimingStatus.Started,
+            balance: StoBalanceStatus.Available,
+          },
         },
       },
     });
@@ -262,6 +283,18 @@ describe('modifyStoTimes procedure', () => {
   });
 
   test('should throw an error if the new times are in the past', async () => {
+    entityMockUtils.configureMocks({
+      stoOptions: {
+        details: {
+          status: {
+            timing: StoTimingStatus.NotStarted,
+            balance: StoBalanceStatus.Available,
+            sale: StoSaleStatus.Live,
+          },
+        },
+      },
+    });
+
     const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
 
     let err: Error | undefined;

--- a/src/api/procedures/__tests__/toggleFreezeSto.ts
+++ b/src/api/procedures/__tests__/toggleFreezeSto.ts
@@ -11,7 +11,7 @@ import {
 import { Context, Sto } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
-import { RoleType, StoStatus } from '~/types';
+import { RoleType, StoBalanceStatus, StoSaleStatus, StoTimingStatus } from '~/types';
 import * as utilsConversionModule from '~/utils/conversion';
 
 jest.mock(
@@ -71,7 +71,11 @@ describe('toggleFreezeSto procedure', () => {
     entityMockUtils.configureMocks({
       stoOptions: {
         details: {
-          end: new Date(),
+          status: {
+            timing: StoTimingStatus.Expired,
+            balance: StoBalanceStatus.Available,
+            sale: StoSaleStatus.Closed,
+          },
         },
       },
     });
@@ -91,7 +95,11 @@ describe('toggleFreezeSto procedure', () => {
     entityMockUtils.configureMocks({
       stoOptions: {
         details: {
-          status: StoStatus.Frozen,
+          status: {
+            sale: StoSaleStatus.Frozen,
+            timing: StoTimingStatus.Started,
+            balance: StoBalanceStatus.Available,
+          },
         },
       },
     });
@@ -113,7 +121,11 @@ describe('toggleFreezeSto procedure', () => {
     entityMockUtils.configureMocks({
       stoOptions: {
         details: {
-          status: StoStatus.Live,
+          status: {
+            sale: StoSaleStatus.Live,
+            timing: StoTimingStatus.Started,
+            balance: StoBalanceStatus.Available,
+          },
         },
       },
     });
@@ -129,7 +141,11 @@ describe('toggleFreezeSto procedure', () => {
     entityMockUtils.configureMocks({
       stoOptions: {
         details: {
-          status: StoStatus.Closed,
+          status: {
+            sale: StoSaleStatus.Closed,
+            timing: StoTimingStatus.Started,
+            balance: StoBalanceStatus.Available,
+          },
         },
       },
     });
@@ -161,8 +177,14 @@ describe('toggleFreezeSto procedure', () => {
 
   test('should add a unfreeze transaction to the queue', async () => {
     entityMockUtils.configureMocks({
-      securityTokenOptions: {
-        isFrozen: true,
+      stoOptions: {
+        details: {
+          status: {
+            timing: StoTimingStatus.Started,
+            balance: StoBalanceStatus.Available,
+            sale: StoSaleStatus.Frozen,
+          },
+        },
       },
     });
 

--- a/src/api/procedures/closeSto.ts
+++ b/src/api/procedures/closeSto.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 
 import { PolymeshError, Procedure, SecurityToken, Sto } from '~/internal';
-import { ErrorCode, RoleType, StoStatus, TxTags } from '~/types';
+import { ErrorCode, RoleType, StoSaleStatus, TxTags } from '~/types';
 import { ProcedureAuthorization } from '~/types/internal';
 import { numberToU64, stringToTicker } from '~/utils/conversion';
 
@@ -29,9 +29,11 @@ export async function prepareCloseSto(this: Procedure<Params, void>, args: Param
 
   const sto = new Sto({ ticker, id }, context);
 
-  const { status } = await sto.details();
+  const {
+    status: { sale },
+  } = await sto.details();
 
-  if (status === StoStatus.Closed) {
+  if ([StoSaleStatus.Closed, StoSaleStatus.ClosedEarly].includes(sale)) {
     throw new PolymeshError({
       code: ErrorCode.ValidationError,
       message: 'The STO is already closed',

--- a/src/api/procedures/toggleFreezeSto.ts
+++ b/src/api/procedures/toggleFreezeSto.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 
 import { PolymeshError, Procedure, SecurityToken, Sto } from '~/internal';
-import { ErrorCode, RoleType, StoStatus, TxTags } from '~/types';
+import { ErrorCode, RoleType, StoSaleStatus, StoTimingStatus, TxTags } from '~/types';
 import { ProcedureAuthorization } from '~/types/internal';
 import { numberToU64, stringToTicker } from '~/utils/conversion';
 
@@ -33,11 +33,11 @@ export async function prepareToggleFreezeSto(
 
   const sto = new Sto({ ticker, id }, context);
 
-  const { status, end } = await sto.details();
+  const {
+    status: { timing, sale },
+  } = await sto.details();
 
-  const now = new Date();
-
-  if (end && end < now) {
+  if (timing === StoTimingStatus.Expired) {
     throw new PolymeshError({
       code: ErrorCode.ValidationError,
       message: 'The STO has already ended',
@@ -45,7 +45,7 @@ export async function prepareToggleFreezeSto(
   }
 
   if (freeze) {
-    if (status === StoStatus.Frozen) {
+    if (sale === StoSaleStatus.Frozen) {
       throw new PolymeshError({
         code: ErrorCode.ValidationError,
         message: 'The STO is already frozen',
@@ -54,17 +54,17 @@ export async function prepareToggleFreezeSto(
 
     this.addTransaction(txSto.freezeFundraiser, {}, rawTicker, rawId);
   } else {
-    if (status === StoStatus.Live) {
-      throw new PolymeshError({
-        code: ErrorCode.ValidationError,
-        message: 'The STO is already unfrozen',
-      });
-    }
-
-    if (status === StoStatus.Closed) {
+    if ([StoSaleStatus.Closed, StoSaleStatus.ClosedEarly].includes(sale)) {
       throw new PolymeshError({
         code: ErrorCode.ValidationError,
         message: 'The STO is already closed',
+      });
+    }
+
+    if (sale !== StoSaleStatus.Frozen) {
+      throw new PolymeshError({
+        code: ErrorCode.ValidationError,
+        message: 'The STO is already unfrozen',
       });
     }
 

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -2328,7 +2328,7 @@ export const createMockFundraiserTier = (fundraiserTier?: {
  * NOTE: `isEmpty` will be set to true if no value is passed
  */
 export const createMockFundraiserStatus = (
-  fundraiserStatus?: 'Live' | 'Frozen' | 'Closed'
+  fundraiserStatus?: 'Live' | 'Frozen' | 'Closed' | 'ClosedEarly'
 ): FundraiserStatus => {
   return createMockEnum(fundraiserStatus) as FundraiserStatus;
 };

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -38,7 +38,10 @@ import {
   ResultSet,
   SecondaryKey,
   SecurityTokenDetails,
+  StoBalanceStatus,
   StoDetails,
+  StoSaleStatus,
+  StoTimingStatus,
   TickerReservationDetails,
   TickerReservationStatus,
   TokenIdentifier,
@@ -553,7 +556,26 @@ const defaultInstructionOptions: InstructionOptions = {
 };
 let instructionOptions = defaultInstructionOptions;
 const defaultStoOptions: StoOptions = {
-  details: {} as StoDetails,
+  details: {
+    end: null,
+    start: new Date('10/14/1987'),
+    status: {
+      timing: StoTimingStatus.Started,
+      balance: StoBalanceStatus.Available,
+      sale: StoSaleStatus.Live,
+    },
+    tiers: [
+      {
+        price: new BigNumber(100000000),
+        remaining: new BigNumber(700000000),
+        amount: new BigNumber(1000000000),
+      },
+    ],
+    totalAmount: new BigNumber(1000000000),
+    totalRemaining: new BigNumber(700000000),
+    raisingCurrency: 'USD',
+    minInvestment: new BigNumber(100000000),
+  },
   ticker: 'SOME_TICKER',
   id: new BigNumber(1),
 };
@@ -1079,7 +1101,13 @@ function initCurrentAccount(opts?: CurrentAccountOptions): void {
  * Configure the Security Token Offering instance
  */
 function configureSto(opts: StoOptions): void {
-  const details = { owner: mockInstanceContainer.identity, ...opts.details };
+  const details = {
+    creator: mockInstanceContainer.identity,
+    venue: mockInstanceContainer.venue,
+    offeringPortfolio: mockInstanceContainer.defaultPortfolio,
+    raisingPorfolio: mockInstanceContainer.numberedPortfolio,
+    ...opts.details,
+  };
   const sto = ({
     details: stoDetailsStub.resolves(details),
     ticker: opts.ticker,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -639,6 +639,7 @@ export enum TxGroup {
    * - TxTags.portfolio.MovePortfolioFunds
    * - TxTags.settlement.AddInstruction
    * - TxTags.settlement.AddAndAffirmInstruction
+   * - TxTags.settlement.AffirmInstruction
    * - TxTags.settlement.RejectInstruction
    * - TxTags.settlement.CreateVenue
    */


### PR DESCRIPTION
Added total offering amount, total remaining tokens and refined status

BREAKING CHANGE: Sto status is now divided into `timing`, `sale` and `balance`