### PR TITLE
fix(instructions): properly ignore pruned venue instructions

### DIFF
--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -73,9 +73,79 @@ describe('Instruction class', () => {
     });
   });
 
+  describe('method: exists', () => {
+    afterAll(() => {
+      sinon.restore();
+    });
+
+    let numberToU64Stub: sinon.SinonStub;
+
+    beforeAll(() => {
+      numberToU64Stub = sinon.stub(utilsConversionModule, 'numberToU64');
+    });
+
+    beforeEach(() => {
+      numberToU64Stub.withArgs(id, context).returns(rawId);
+    });
+
+    test('should return whether the instruction exists', async () => {
+      const status = InstructionStatus.Pending;
+      const createdAt = new Date('10/14/1987');
+      const tradeDate = new Date('11/17/1987');
+      const valueDate = new Date('11/17/1987');
+      const venueId = new BigNumber(1);
+      const type = InstructionType.SettleOnAffirmation;
+      const owner = 'someDid';
+
+      entityMockUtils.configureMocks({ identityOptions: { did: owner } });
+
+      const queryResult = dsMockUtils.createMockInstruction({
+        /* eslint-disable @typescript-eslint/camelcase */
+        instruction_id: dsMockUtils.createMockU64(1),
+        status: dsMockUtils.createMockInstructionStatus(status),
+        venue_id: dsMockUtils.createMockU64(venueId.toNumber()),
+        created_at: dsMockUtils.createMockOption(dsMockUtils.createMockMoment(createdAt.getTime())),
+        trade_date: dsMockUtils.createMockOption(dsMockUtils.createMockMoment(tradeDate.getTime())),
+        value_date: dsMockUtils.createMockOption(dsMockUtils.createMockMoment(valueDate.getTime())),
+        settlement_type: dsMockUtils.createMockSettlementType(type),
+        /* eslint-enable @typescript-eslint/camelcase */
+      });
+
+      const instructionDetailsStub = dsMockUtils
+        .createQueryStub('settlement', 'instructionDetails')
+        .withArgs(rawId)
+        .resolves(queryResult);
+
+      let result = await instruction.exists();
+
+      expect(result).toBe(true);
+
+      instructionDetailsStub.resolves(
+        dsMockUtils.createMockInstruction({
+          ...queryResult,
+          status: dsMockUtils.createMockInstructionStatus('Unknown'),
+        })
+      );
+
+      result = await instruction.exists();
+
+      expect(result).toBe(false);
+    });
+  });
+
   describe('method: details', () => {
     afterAll(() => {
       sinon.restore();
+    });
+
+    let numberToU64Stub: sinon.SinonStub;
+
+    beforeAll(() => {
+      numberToU64Stub = sinon.stub(utilsConversionModule, 'numberToU64');
+    });
+
+    beforeEach(() => {
+      numberToU64Stub.withArgs(id, context).returns(rawId);
     });
 
     test('should return the Instruction details', async () => {
@@ -89,22 +159,22 @@ describe('Instruction class', () => {
       const owner = 'someDid';
 
       entityMockUtils.configureMocks({ identityOptions: { did: owner } });
-      sinon.stub(utilsConversionModule, 'numberToU64').withArgs(id, context).returns(rawId);
 
-      const queryResult = {
-        status: dsMockUtils.createMockInstructionStatus(status),
+      const queryResult = dsMockUtils.createMockInstruction({
         /* eslint-disable @typescript-eslint/camelcase */
+        instruction_id: dsMockUtils.createMockU64(1),
+        status: dsMockUtils.createMockInstructionStatus(status),
         venue_id: dsMockUtils.createMockU64(venueId.toNumber()),
         created_at: dsMockUtils.createMockOption(dsMockUtils.createMockMoment(createdAt.getTime())),
         trade_date: dsMockUtils.createMockOption(dsMockUtils.createMockMoment(tradeDate.getTime())),
         value_date: dsMockUtils.createMockOption(dsMockUtils.createMockMoment(valueDate.getTime())),
         settlement_type: dsMockUtils.createMockSettlementType(type),
         /* eslint-enable @typescript-eslint/camelcase */
-      };
+      });
 
       const instructionDetailsStub = dsMockUtils
         .createQueryStub('settlement', 'instructionDetails')
-        .withArgs(rawId)
+        // .withArgs(rawId)
         .resolves(queryResult);
 
       let result = await instruction.details();
@@ -121,16 +191,18 @@ describe('Instruction class', () => {
       type = InstructionType.SettleOnBlock;
       const endBlock = new BigNumber(100);
 
-      instructionDetailsStub.resolves({
-        ...queryResult,
-        /* eslint-disable @typescript-eslint/camelcase */
-        trade_date: dsMockUtils.createMockOption(),
-        value_date: dsMockUtils.createMockOption(),
-        settlement_type: dsMockUtils.createMockSettlementType({
-          SettleOnBlock: dsMockUtils.createMockU32(endBlock.toNumber()),
-        }),
-        /* eslint-enable @typescript-eslint/camelcase */
-      });
+      instructionDetailsStub.resolves(
+        dsMockUtils.createMockInstruction({
+          ...queryResult,
+          /* eslint-disable @typescript-eslint/camelcase */
+          trade_date: dsMockUtils.createMockOption(),
+          value_date: dsMockUtils.createMockOption(),
+          settlement_type: dsMockUtils.createMockSettlementType({
+            SettleOnBlock: dsMockUtils.createMockU32(endBlock.toNumber()),
+          }),
+          /* eslint-enable @typescript-eslint/camelcase */
+        })
+      );
 
       result = await instruction.details();
 
@@ -144,12 +216,37 @@ describe('Instruction class', () => {
         venue,
       });
     });
+
+    test('should throw an error if the Instruction does not exist', () => {
+      dsMockUtils
+        .createQueryStub('settlement', 'instructionDetails')
+        .withArgs(rawId)
+        .resolves(
+          dsMockUtils.createMockInstruction({
+            /* eslint-disable @typescript-eslint/camelcase */
+            instruction_id: dsMockUtils.createMockU64(),
+            status: dsMockUtils.createMockInstructionStatus('Unknown'),
+            venue_id: dsMockUtils.createMockU64(),
+            created_at: dsMockUtils.createMockOption(),
+            trade_date: dsMockUtils.createMockOption(),
+            value_date: dsMockUtils.createMockOption(),
+            settlement_type: dsMockUtils.createMockSettlementType(),
+            /* eslint-enable @typescript-eslint/camelcase */
+          })
+        );
+
+      return expect(instruction.details()).rejects.toThrow(
+        'Instruction no longer exists. This means it was already executed/rejected (execution might have failed)'
+      );
+    });
   });
 
   describe('method: getAffirmations', () => {
     const did = 'someDid';
     const status = AffirmationStatus.Affirmed;
     let rawStorageKey: [u64, MeshPortfolioId][];
+
+    let instructionDetailsStub: sinon.SinonStub;
 
     afterAll(() => {
       sinon.restore();
@@ -173,13 +270,50 @@ describe('Instruction class', () => {
           dsMockUtils.createMockAffirmationStatus(AffirmationStatus.Affirmed)
         )
       );
-      dsMockUtils.createQueryStub('settlement', 'affirmsReceived');
       sinon
         .stub(utilsInternalModule, 'requestPaginated')
         .resolves({ entries: authsReceivedEntries, lastKey: null });
 
       sinon.stub(utilsConversionModule, 'identityIdToString').returns(did);
       sinon.stub(utilsConversionModule, 'meshAffirmationStatusToAffirmationStatus').returns(status);
+    });
+
+    beforeEach(() => {
+      instructionDetailsStub = dsMockUtils.createQueryStub('settlement', 'instructionDetails', {
+        returnValue: dsMockUtils.createMockInstruction({
+          /* eslint-disable @typescript-eslint/camelcase */
+          instruction_id: dsMockUtils.createMockU64(1),
+          venue_id: dsMockUtils.createMockU64(1),
+          status: dsMockUtils.createMockInstructionStatus('Pending'),
+          settlement_type: dsMockUtils.createMockSettlementType('SettleOnAffirmation'),
+          created_at: dsMockUtils.createMockOption(
+            dsMockUtils.createMockMoment(new Date('10/14/1987').getTime())
+          ),
+          trade_date: dsMockUtils.createMockOption(),
+          value_date: dsMockUtils.createMockOption(),
+          /* eslint-enable @typescript-eslint/camelcase */
+        }),
+      });
+      dsMockUtils.createQueryStub('settlement', 'affirmsReceived');
+    });
+
+    test('should throw an error if the instruction does not exist', () => {
+      instructionDetailsStub.resolves(
+        dsMockUtils.createMockInstruction({
+          /* eslint-disable @typescript-eslint/camelcase */
+          instruction_id: dsMockUtils.createMockU64(),
+          venue_id: dsMockUtils.createMockU64(),
+          status: dsMockUtils.createMockInstructionStatus('Unknown'),
+          settlement_type: dsMockUtils.createMockSettlementType(),
+          created_at: dsMockUtils.createMockOption(),
+          trade_date: dsMockUtils.createMockOption(),
+          value_date: dsMockUtils.createMockOption(),
+          /* eslint-enable @typescript-eslint/camelcase */
+        })
+      );
+      return expect(instruction.getAffirmations()).rejects.toThrow(
+        'Instruction no longer exists. This means it was already executed/rejected (execution might have failed)'
+      );
     });
 
     test('should return a list of Affirmation Statuses', async () => {
@@ -192,12 +326,36 @@ describe('Instruction class', () => {
   });
 
   describe('method: getLegs', () => {
+    let instructionDetailsStub: sinon.SinonStub;
+
     afterAll(() => {
       sinon.restore();
     });
 
+    let numberToU64Stub: sinon.SinonStub;
+
     beforeAll(() => {
+      numberToU64Stub = sinon.stub(utilsConversionModule, 'numberToU64');
+    });
+
+    beforeEach(() => {
+      numberToU64Stub.withArgs(id, context).returns(rawId);
       dsMockUtils.createQueryStub('settlement', 'instructionLegs');
+      instructionDetailsStub = dsMockUtils.createQueryStub('settlement', 'instructionDetails', {
+        returnValue: dsMockUtils.createMockInstruction({
+          /* eslint-disable @typescript-eslint/camelcase */
+          instruction_id: dsMockUtils.createMockU64(1),
+          venue_id: dsMockUtils.createMockU64(1),
+          status: dsMockUtils.createMockInstructionStatus('Pending'),
+          settlement_type: dsMockUtils.createMockSettlementType('SettleOnAffirmation'),
+          created_at: dsMockUtils.createMockOption(
+            dsMockUtils.createMockMoment(new Date('10/14/1987').getTime())
+          ),
+          trade_date: dsMockUtils.createMockOption(),
+          value_date: dsMockUtils.createMockOption(),
+          /* eslint-enable @typescript-eslint/camelcase */
+        }),
+      });
     });
 
     test("should return the instruction's legs", async () => {
@@ -208,7 +366,6 @@ describe('Instruction class', () => {
       const amount = new BigNumber(1000);
 
       entityMockUtils.configureMocks({ securityTokenOptions: { ticker } });
-      sinon.stub(utilsConversionModule, 'numberToU64').withArgs(id, context).returns(rawId);
 
       const entries = [
         tuple((['instructionId', 'legId'] as unknown) as StorageKey, {
@@ -234,6 +391,25 @@ describe('Instruction class', () => {
       sinon.assert.calledWithExactly(identityConstructor.secondCall, { did: toDid }, context);
       expect(leg[0].amount).toEqual(amount);
       expect(leg[0].token).toEqual(entityMockUtils.getSecurityTokenInstance());
+    });
+
+    test('should throw an error if the instruction does not exist', () => {
+      instructionDetailsStub.resolves(
+        dsMockUtils.createMockInstruction({
+          /* eslint-disable @typescript-eslint/camelcase */
+          instruction_id: dsMockUtils.createMockU64(),
+          venue_id: dsMockUtils.createMockU64(),
+          status: dsMockUtils.createMockInstructionStatus('Unknown'),
+          settlement_type: dsMockUtils.createMockSettlementType(),
+          created_at: dsMockUtils.createMockOption(),
+          trade_date: dsMockUtils.createMockOption(),
+          value_date: dsMockUtils.createMockOption(),
+          /* eslint-enable @typescript-eslint/camelcase */
+        })
+      );
+      return expect(instruction.getLegs()).rejects.toThrow(
+        'Instruction no longer exists. This means it was already executed/rejected (execution might have failed)'
+      );
     });
   });
 

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -1,5 +1,6 @@
 import BigNumber from 'bignumber.js';
 
+import { PolymeshError } from '~/base/PolymeshError';
 import {
   Context,
   Entity,
@@ -8,7 +9,7 @@ import {
   SecurityToken,
   Venue,
 } from '~/internal';
-import { PaginationOptions, ResultSet } from '~/types';
+import { ErrorCode, PaginationOptions, ResultSet } from '~/types';
 import { InstructionAffirmationOperation, ProcedureMethod } from '~/types/internal';
 import {
   balanceToBigNumber,
@@ -24,11 +25,20 @@ import {
 } from '~/utils/conversion';
 import { createProcedureMethod, requestPaginated } from '~/utils/internal';
 
-import { InstructionAffirmation, InstructionDetails, InstructionType, Leg } from './types';
+import {
+  InstructionAffirmation,
+  InstructionDetails,
+  InstructionStatus,
+  InstructionType,
+  Leg,
+} from './types';
 
 export interface UniqueIdentifiers {
   id: BigNumber;
 }
+
+const notExistsMessage =
+  'Instruction no longer exists. This means it was already executed/rejected (execution might have failed)';
 
 /**
  * Represents a settlement Instruction to be executed on a certain Venue
@@ -82,6 +92,28 @@ export class Instruction extends Entity<UniqueIdentifiers> {
   }
 
   /**
+   * Retrieve whether the Instruction still exists on chain. Executed/rejected instructions
+   *   are pruned from the storage
+   */
+  public async exists(): Promise<boolean> {
+    const {
+      context: {
+        polymeshApi: {
+          query: { settlement },
+        },
+      },
+      id,
+      context,
+    } = this;
+
+    const { status: rawStatus } = await settlement.instructionDetails(numberToU64(id, context));
+
+    const status = meshInstructionStatusToInstructionStatus(rawStatus);
+
+    return status !== InstructionStatus.Unknown;
+  }
+
+  /**
    * Retrieve information specific to this Instruction
    */
   public async details(): Promise<InstructionDetails> {
@@ -96,7 +128,7 @@ export class Instruction extends Entity<UniqueIdentifiers> {
     } = this;
 
     const {
-      status,
+      status: rawStatus,
       created_at: createdAt,
       trade_date: tradeDate,
       value_date: valueDate,
@@ -104,8 +136,17 @@ export class Instruction extends Entity<UniqueIdentifiers> {
       venue_id: venueId,
     } = await settlement.instructionDetails(numberToU64(id, context));
 
+    const status = meshInstructionStatusToInstructionStatus(rawStatus);
+
+    if (status === InstructionStatus.Unknown) {
+      throw new PolymeshError({
+        code: ErrorCode.FatalError,
+        message: notExistsMessage,
+      });
+    }
+
     const details = {
-      status: meshInstructionStatusToInstructionStatus(status),
+      status,
       createdAt: momentToDate(createdAt.unwrap()),
       tradeDate: tradeDate.isSome ? momentToDate(tradeDate.unwrap()) : null,
       valueDate: valueDate.isSome ? momentToDate(valueDate.unwrap()) : null,
@@ -144,6 +185,15 @@ export class Instruction extends Entity<UniqueIdentifiers> {
       context,
     } = this;
 
+    const exists = await this.exists();
+
+    if (!exists) {
+      throw new PolymeshError({
+        code: ErrorCode.FatalError,
+        message: notExistsMessage,
+      });
+    }
+
     const { entries, lastKey: next } = await requestPaginated(settlement.affirmsReceived, {
       arg: numberToU64(id, context),
       paginationOpts,
@@ -178,6 +228,15 @@ export class Instruction extends Entity<UniqueIdentifiers> {
       id,
       context,
     } = this;
+
+    const exists = await this.exists();
+
+    if (!exists) {
+      throw new PolymeshError({
+        code: ErrorCode.FatalError,
+        message: notExistsMessage,
+      });
+    }
 
     const { entries: legs, lastKey: next } = await requestPaginated(settlement.instructionLegs, {
       arg: numberToU64(id, context),

--- a/src/api/entities/Venue/__tests__/index.ts
+++ b/src/api/entities/Venue/__tests__/index.ts
@@ -159,7 +159,7 @@ describe('Venue class', () => {
       const owner = 'someDid';
       const instructionId = new BigNumber(1);
 
-      entityMockUtils.configureMocks({ instructionOptions: { id: instructionId } });
+      entityMockUtils.configureMocks({ instructionOptions: { id: instructionId, exists: true } });
       sinon.stub(utilsConversionModule, 'numberToU64').withArgs(id, context).returns(rawId);
 
       dsMockUtils
@@ -177,9 +177,14 @@ describe('Venue class', () => {
           )
         );
 
-      const result = await venue.getPendingInstructions();
+      let result = await venue.getPendingInstructions();
 
       expect(result[0].id).toEqual(instructionId);
+
+      entityMockUtils.configureMocks({ instructionOptions: { id: instructionId, exists: false } });
+
+      result = await venue.getPendingInstructions();
+      expect(result.length).toBe(0);
     });
   });
 

--- a/src/api/entities/Venue/index.ts
+++ b/src/api/entities/Venue/index.ts
@@ -147,6 +147,12 @@ export class Venue extends Entity<UniqueIdentifiers> {
     );
 
     return P.filter(instructions, async instruction => {
+      const instructionExists = await instruction.exists();
+
+      if (!instructionExists) {
+        return false;
+      }
+
       const { status } = await instruction.details();
 
       return status === InstructionStatus.Pending;

--- a/src/api/entities/__tests__/CurrentIdentity.ts
+++ b/src/api/entities/__tests__/CurrentIdentity.ts
@@ -294,6 +294,7 @@ describe('CurrentIdentity class', () => {
           settlement_type: dsMockUtils.createMockSettlementType('SettleOnAffirmation'),
           created_at: dsMockUtils.createMockOption(),
           trade_date: dsMockUtils.createMockOption(),
+          value_date: dsMockUtils.createMockOption(),
         }),
         dsMockUtils.createMockInstruction({
           instruction_id: dsMockUtils.createMockU64(id2.toNumber()),
@@ -302,6 +303,7 @@ describe('CurrentIdentity class', () => {
           settlement_type: dsMockUtils.createMockSettlementType('SettleOnAffirmation'),
           created_at: dsMockUtils.createMockOption(),
           trade_date: dsMockUtils.createMockOption(),
+          value_date: dsMockUtils.createMockOption(),
         }),
         dsMockUtils.createMockInstruction({
           instruction_id: dsMockUtils.createMockU64(id3.toNumber()),
@@ -310,6 +312,7 @@ describe('CurrentIdentity class', () => {
           settlement_type: dsMockUtils.createMockSettlementType('SettleOnAffirmation'),
           created_at: dsMockUtils.createMockOption(),
           trade_date: dsMockUtils.createMockOption(),
+          value_date: dsMockUtils.createMockOption(),
         }),
         dsMockUtils.createMockInstruction({
           instruction_id: dsMockUtils.createMockU64(id4.toNumber()),
@@ -318,6 +321,7 @@ describe('CurrentIdentity class', () => {
           settlement_type: dsMockUtils.createMockSettlementType('SettleOnAffirmation'),
           created_at: dsMockUtils.createMockOption(),
           trade_date: dsMockUtils.createMockOption(),
+          value_date: dsMockUtils.createMockOption(),
         }),
       ]);
 

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -2291,6 +2291,7 @@ export const createMockInstruction = (instruction?: {
   settlement_type: SettlementType;
   created_at: Option<Moment>;
   trade_date: Option<Moment>;
+  value_date: Option<Moment>;
 }): Instruction => {
   const data = instruction || {
     instruction_id: createMockU64(),

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -183,6 +183,7 @@ interface InstructionOptions {
   id?: BigNumber;
   details?: Partial<InstructionDetails>;
   getLegs?: ResultSet<Leg>;
+  exists?: boolean;
 }
 
 interface StoOptions {
@@ -256,6 +257,7 @@ let venueDetailsStub: SinonStub;
 let venueExistsStub: SinonStub;
 let instructionDetailsStub: SinonStub;
 let instructionGetLegsStub: SinonStub;
+let instructionExistsStub: SinonStub;
 let numberedPortfolioIsOwnedByStub: SinonStub;
 let numberedPortfolioGetTokenBalancesStub: SinonStub;
 let numberedPortfolioExistsStub: SinonStub;
@@ -610,6 +612,7 @@ const defaultInstructionOptions: InstructionOptions = {
     valueDate: null,
     type: InstructionType.SettleOnAffirmation,
   },
+  exists: false,
 };
 let instructionOptions = defaultInstructionOptions;
 const defaultStoOptions: StoOptions = {
@@ -1012,8 +1015,10 @@ function configureInstruction(opts: InstructionOptions): void {
     next: null,
   };
   const instruction = ({
+    id: opts.id,
     details: instructionDetailsStub.resolves(details),
     getLegs: instructionGetLegsStub.resolves(legs),
+    exists: instructionExistsStub.resolves(opts.exists),
   } as unknown) as MockInstruction;
 
   Object.assign(mockInstanceContainer.instruction, instruction);
@@ -1032,6 +1037,7 @@ function initInstruction(opts?: InstructionOptions): void {
   instructionConstructorStub = sinon.stub();
   instructionDetailsStub = sinon.stub();
   instructionGetLegsStub = sinon.stub();
+  instructionExistsStub = sinon.stub();
 
   instructionOptions = { ...defaultInstructionOptions, ...opts };
 


### PR DESCRIPTION
Added `Instruction.exists` and throw a more explicit error when fetching a pruned instruction's
details