### PR TITLE
feat: create the Schedules namespace

### DIFF
--- a/src/api/entities/Entity.ts
+++ b/src/api/entities/Entity.ts
@@ -54,4 +54,11 @@ export class Entity<UniqueIdentifiers extends object> {
     this.uuid = (this.constructor as typeof Entity).generateUuid(identifiers);
     this.context = context;
   }
+
+  /**
+   * Whether this Entity is the same as another one
+   */
+  public isEqual(entity: Entity<object>): boolean {
+    return this.uuid === entity.uuid;
+  }
 }

--- a/src/api/entities/SecurityToken/Checkpoints/__tests__/index.ts
+++ b/src/api/entities/SecurityToken/Checkpoints/__tests__/index.ts
@@ -1,0 +1,106 @@
+import BigNumber from 'bignumber.js';
+import { Ticker } from 'polymesh-types/types';
+import sinon, { SinonStub } from 'sinon';
+
+import { Checkpoint, Context, createCheckpoint, Namespace, TransactionQueue } from '~/internal';
+import { dsMockUtils, entityMockUtils } from '~/testUtils/mocks';
+import { tuple } from '~/types/utils';
+import * as utilsConversionModule from '~/utils/conversion';
+
+import { Checkpoints } from '../';
+
+jest.mock(
+  '~/api/entities/Checkpoint',
+  require('~/testUtils/mocks/entities').mockCheckpointModule('~/api/entities/Checkpoint')
+);
+jest.mock(
+  '~/api/entities/CheckpointSchedule',
+  require('~/testUtils/mocks/entities').mockCheckpointScheduleModule(
+    '~/api/entities/CheckpointSchedule'
+  )
+);
+
+describe('Checkpoints class', () => {
+  let context: Context;
+  let checkpoints: Checkpoints;
+
+  let ticker: string;
+
+  let stringToTickerStub: SinonStub<[string, Context], Ticker>;
+
+  beforeAll(() => {
+    entityMockUtils.initMocks();
+    dsMockUtils.initMocks();
+
+    ticker = 'SOME_TICKER';
+
+    stringToTickerStub = sinon.stub(utilsConversionModule, 'stringToTicker');
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    dsMockUtils.reset();
+
+    context = dsMockUtils.getContextInstance();
+
+    const token = entityMockUtils.getSecurityTokenInstance({ ticker });
+    checkpoints = new Checkpoints(token, context);
+  });
+
+  afterAll(() => {
+    entityMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  test('should extend namespace', () => {
+    expect(Checkpoints.prototype instanceof Namespace).toBe(true);
+  });
+
+  describe('method: create', () => {
+    afterAll(() => {
+      sinon.restore();
+    });
+
+    test('should prepare the procedure with the correct arguments and context, and return the resulting transaction queue', async () => {
+      const expectedQueue = ('someQueue' as unknown) as TransactionQueue<Checkpoint>;
+
+      sinon.stub(createCheckpoint, 'prepare').withArgs({ ticker }, context).resolves(expectedQueue);
+
+      const queue = await checkpoints.create();
+
+      expect(queue).toBe(expectedQueue);
+    });
+  });
+
+  describe('method: get', () => {
+    afterAll(() => {
+      sinon.restore();
+    });
+
+    test('should return all created checkpoints with their timestamps', async () => {
+      const timestamps = [1000, 2000, new Date().getTime() + 10000];
+      const ids = [1, 2, 3];
+      const rawTicker = dsMockUtils.createMockTicker(ticker);
+
+      dsMockUtils.createQueryStub('checkpoint', 'timestamps', {
+        entries: timestamps.map((timestamp, index) =>
+          tuple(
+            [rawTicker, dsMockUtils.createMockU64(ids[index])],
+            dsMockUtils.createMockMoment(timestamp)
+          )
+        ),
+      });
+
+      stringToTickerStub.withArgs(ticker, context).returns(rawTicker);
+
+      const result = await checkpoints.get();
+
+      expect(result).toEqual(
+        timestamps.slice(0, -1).map((timestamp, index) => ({
+          checkpoint: entityMockUtils.getCheckpointInstance({ id: new BigNumber(ids[index]) }),
+          createdAt: new Date(timestamp),
+        }))
+      );
+    });
+  });
+});

--- a/src/api/entities/SecurityToken/Checkpoints/index.ts
+++ b/src/api/entities/SecurityToken/Checkpoints/index.ts
@@ -1,0 +1,60 @@
+import { Checkpoint, Context, createCheckpoint, Namespace, SecurityToken } from '~/internal';
+import { CheckpointWithCreationDate } from '~/types';
+import { ProcedureMethod } from '~/types/internal';
+import { momentToDate, stringToTicker, u64ToBigNumber } from '~/utils/conversion';
+import { createProcedureMethod } from '~/utils/internal';
+
+import { Schedules } from './Schedules';
+
+/**
+ * Handles all Security Token Checkpoints related functionality
+ */
+export class Checkpoints extends Namespace<SecurityToken> {
+  public schedules: Schedules;
+
+  /**
+   * @hidden
+   */
+  constructor(parent: SecurityToken, context: Context) {
+    super(parent, context);
+
+    const { ticker } = parent;
+
+    this.create = createProcedureMethod(() => [createCheckpoint, { ticker }], context);
+
+    this.schedules = new Schedules(parent, context);
+  }
+
+  /**
+   * Create a snapshot of Security Token holders and their respective balances at this moment
+   *
+   * @note required role:
+   *   - Security Token Owner
+   */
+  public create: ProcedureMethod<void, Checkpoint>;
+
+  /**
+   * Retrieve all Checkpoints created on this Security Token, together with their corresponding creation Date
+   */
+  public async get(): Promise<CheckpointWithCreationDate[]> {
+    const {
+      parent: { ticker },
+      context,
+    } = this;
+
+    const entries = await context.polymeshApi.query.checkpoint.timestamps.entries(
+      stringToTicker(ticker, context)
+    );
+
+    const now = new Date();
+    return (
+      entries
+        .map(([{ args: [, id] }, timestamp]) => ({
+          checkpoint: new Checkpoint({ id: u64ToBigNumber(id), ticker }, context),
+          createdAt: momentToDate(timestamp),
+        }))
+        // the query also returns the next scheduled checkpoint for every schedule (which haven't been created yet)
+        .filter(({ createdAt }) => createdAt <= now)
+    );
+  }
+}

--- a/src/api/entities/__tests__/Entity.ts
+++ b/src/api/entities/__tests__/Entity.ts
@@ -1,13 +1,13 @@
 import sinon from 'sinon';
 
-import { Entity } from '~/internal';
+import { Context, Entity } from '~/internal';
 import * as utilsInternalModule from '~/utils/internal';
 
 describe('Entity class', () => {
+  const serializeStub = sinon.stub(utilsInternalModule, 'serialize');
   describe('method: generateUuid', () => {
     test("should generate the Entity's UUID", async () => {
-      sinon
-        .stub(utilsInternalModule, 'serialize')
+      serializeStub
         .withArgs('Entity', {
           did: 'abc',
         })
@@ -35,6 +35,20 @@ describe('Entity class', () => {
       const fakeReturn = { someIdentifier: 'abc' };
       unserializeStub.returns(fakeReturn);
       expect(Entity.unserialize('def')).toEqual(fakeReturn);
+    });
+  });
+
+  describe('method: isEqual', () => {
+    test('should return whether the entities are the same', () => {
+      serializeStub.withArgs('Entity', { foo: 'bar' }).returns('first');
+      serializeStub.withArgs('Entity', { bar: 'baz' }).returns('second');
+
+      const first = new Entity({ foo: 'bar' }, {} as Context);
+      const second = new Entity({ bar: 'baz' }, {} as Context);
+
+      expect(first.isEqual(first)).toBe(true);
+      expect(first.isEqual(second)).toBe(false);
+      expect(second.isEqual(first)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
All schedule functionality moved from the Checkpoints namespace to this one. Also added `toEquals`
to all entities

BREAKING CHANGE: `checkpoints.createSchedule` is now `checkpoints.schedules.create`.
`checkpoints.removeSchedule` is now `checkpoints.schedules.remove`. `checkpoints.getSchedules` is
now `checkpoints.schedudles.get`