### PR TITLE
feat(transaction queue): support transforming queue results

### DIFF
--- a/src/Claims.ts
+++ b/src/Claims.ts
@@ -48,13 +48,15 @@ export class Claims {
       ModifyClaimsParams,
       void
     >(
-      args => [
-        modifyClaims,
-        {
-          ...args,
-          operation: ClaimOperation.Add,
-        } as ModifyClaimsParams,
-      ],
+      {
+        getProcedureAndArgs: args => [
+          modifyClaims,
+          {
+            ...args,
+            operation: ClaimOperation.Add,
+          } as ModifyClaimsParams,
+        ],
+      },
       context
     );
 
@@ -63,13 +65,15 @@ export class Claims {
       ModifyClaimsParams,
       void
     >(
-      args => [
-        modifyClaims,
-        {
-          ...args,
-          operation: ClaimOperation.Edit,
-        } as ModifyClaimsParams,
-      ],
+      {
+        getProcedureAndArgs: args => [
+          modifyClaims,
+          {
+            ...args,
+            operation: ClaimOperation.Edit,
+          } as ModifyClaimsParams,
+        ],
+      },
       context
     );
 
@@ -78,18 +82,20 @@ export class Claims {
       ModifyClaimsParams,
       void
     >(
-      args => [
-        modifyClaims,
-        {
-          ...args,
-          operation: ClaimOperation.Revoke,
-        } as ModifyClaimsParams,
-      ],
+      {
+        getProcedureAndArgs: args => [
+          modifyClaims,
+          {
+            ...args,
+            operation: ClaimOperation.Revoke,
+          } as ModifyClaimsParams,
+        ],
+      },
       context
     );
 
     this.addInvestorUniquenessClaim = createProcedureMethod(
-      args => [addInvestorUniquenessClaim, args],
+      { getProcedureAndArgs: args => [addInvestorUniquenessClaim, args] },
       context
     );
   }

--- a/src/Polymesh.ts
+++ b/src/Polymesh.ts
@@ -85,11 +85,22 @@ export class Polymesh {
     this.claims = new Claims(context);
     this.middleware = new Middleware(context);
 
-    this.transferPolyX = createProcedureMethod(args => [transferPolyX, args], context);
+    this.transferPolyX = createProcedureMethod(
+      { getProcedureAndArgs: args => [transferPolyX, args] },
+      context
+    );
 
-    this.reserveTicker = createProcedureMethod(args => [reserveTicker, args], context);
+    this.reserveTicker = createProcedureMethod(
+      {
+        getProcedureAndArgs: args => [reserveTicker, args],
+      },
+      context
+    );
 
-    this.registerIdentity = createProcedureMethod(args => [registerIdentity, args], context);
+    this.registerIdentity = createProcedureMethod(
+      { getProcedureAndArgs: args => [registerIdentity, args] },
+      context
+    );
   }
 
   /**

--- a/src/__tests__/Claims.ts
+++ b/src/__tests__/Claims.ts
@@ -320,7 +320,10 @@ describe('Claims Class', () => {
 
       sinon
         .stub(modifyClaims, 'prepare')
-        .withArgs({ ...args, operation: ClaimOperation.Add }, context)
+        .withArgs(
+          { args: { ...args, operation: ClaimOperation.Add }, transformer: undefined },
+          context
+        )
         .resolves(expectedQueue);
 
       const queue = await claims.addClaims(args);
@@ -353,7 +356,7 @@ describe('Claims Class', () => {
 
       sinon
         .stub(addInvestorUniquenessClaim, 'prepare')
-        .withArgs(args, context)
+        .withArgs({ args, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await claims.addInvestorUniquenessClaim(args);
@@ -384,7 +387,10 @@ describe('Claims Class', () => {
 
       sinon
         .stub(modifyClaims, 'prepare')
-        .withArgs({ ...args, operation: ClaimOperation.Edit }, context)
+        .withArgs(
+          { args: { ...args, operation: ClaimOperation.Edit }, transformer: undefined },
+          context
+        )
         .resolves(expectedQueue);
 
       const queue = await claims.editClaims(args);
@@ -415,7 +421,10 @@ describe('Claims Class', () => {
 
       sinon
         .stub(modifyClaims, 'prepare')
-        .withArgs({ ...args, operation: ClaimOperation.Revoke }, context)
+        .withArgs(
+          { args: { ...args, operation: ClaimOperation.Revoke }, transformer: undefined },
+          context
+        )
         .resolves(expectedQueue);
 
       const queue = await claims.revokeClaims(args);

--- a/src/__tests__/Polymesh.ts
+++ b/src/__tests__/Polymesh.ts
@@ -402,7 +402,10 @@ describe('Polymesh Class', () => {
 
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<TickerReservation>;
 
-      sinon.stub(reserveTicker, 'prepare').withArgs(args, context).resolves(expectedQueue);
+      sinon
+        .stub(reserveTicker, 'prepare')
+        .withArgs({ args, transformer: undefined }, context)
+        .resolves(expectedQueue);
 
       const queue = await polymesh.reserveTicker(args);
 
@@ -852,7 +855,10 @@ describe('Polymesh Class', () => {
 
       const expectedQueue = ('' as unknown) as TransactionQueue<void>;
 
-      sinon.stub(transferPolyX, 'prepare').withArgs(args, context).resolves(expectedQueue);
+      sinon
+        .stub(transferPolyX, 'prepare')
+        .withArgs({ args, transformer: undefined }, context)
+        .resolves(expectedQueue);
 
       const queue = await polymesh.transferPolyX(args);
 
@@ -1013,7 +1019,10 @@ describe('Polymesh Class', () => {
 
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<Identity>;
 
-      sinon.stub(registerIdentity, 'prepare').withArgs(args, context).resolves(expectedQueue);
+      sinon
+        .stub(registerIdentity, 'prepare')
+        .withArgs({ args, transformer: undefined }, context)
+        .resolves(expectedQueue);
 
       const queue = await polymesh.registerIdentity(args);
 

--- a/src/api/entities/AuthorizationRequest.ts
+++ b/src/api/entities/AuthorizationRequest.ts
@@ -98,25 +98,35 @@ export class AuthorizationRequest extends Entity<UniqueIdentifiers> {
       void,
       ConsumeAuthorizationRequestsParams | ConsumeJoinIdentityAuthorizationParams,
       void
-    >(() => {
-      if (this.data.type === AuthorizationType.JoinIdentity) {
-        return [consumeJoinIdentityAuthorization, { authRequest: this, accept: true }];
-      }
+    >(
+      {
+        getProcedureAndArgs: () => {
+          if (this.data.type === AuthorizationType.JoinIdentity) {
+            return [consumeJoinIdentityAuthorization, { authRequest: this, accept: true }];
+          }
 
-      return [consumeAuthorizationRequests, { authRequests: [this], accept: true }];
-    }, context);
+          return [consumeAuthorizationRequests, { authRequests: [this], accept: true }];
+        },
+      },
+      context
+    );
 
     this.remove = createProcedureMethod<
       void,
       ConsumeAuthorizationRequestsParams | ConsumeJoinIdentityAuthorizationParams,
       void
-    >(() => {
-      if (this.data.type === AuthorizationType.JoinIdentity) {
-        return [consumeJoinIdentityAuthorization, { authRequest: this, accept: false }];
-      }
+    >(
+      {
+        getProcedureAndArgs: () => {
+          if (this.data.type === AuthorizationType.JoinIdentity) {
+            return [consumeJoinIdentityAuthorization, { authRequest: this, accept: false }];
+          }
 
-      return [consumeAuthorizationRequests, { authRequests: [this], accept: false }];
-    }, context);
+          return [consumeAuthorizationRequests, { authRequests: [this], accept: false }];
+        },
+      },
+      context
+    );
   }
 
   /**

--- a/src/api/entities/CorporateAction/__tests__/index.ts
+++ b/src/api/entities/CorporateAction/__tests__/index.ts
@@ -155,7 +155,7 @@ describe('CorporateAction class', () => {
 
       sinon
         .stub(linkCaDocs, 'prepare')
-        .withArgs({ id, ticker, ...args }, context)
+        .withArgs({ args: { id, ticker, ...args }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await corporateAction.linkDocuments(args);

--- a/src/api/entities/CorporateAction/index.ts
+++ b/src/api/entities/CorporateAction/index.ts
@@ -119,7 +119,7 @@ export class CorporateAction extends Entity<UniqueIdentifiers> {
     this.taxWithholdings = taxWithholdings;
 
     this.linkDocuments = createProcedureMethod(
-      procedureArgs => [linkCaDocs, { id, ticker, ...procedureArgs }],
+      { getProcedureAndArgs: procedureArgs => [linkCaDocs, { id, ticker, ...procedureArgs }] },
       context
     );
   }

--- a/src/api/entities/CurrentIdentity.ts
+++ b/src/api/entities/CurrentIdentity.ts
@@ -38,27 +38,41 @@ export class CurrentIdentity extends Identity {
   constructor(identifiers: UniqueIdentifiers, context: Context) {
     super(identifiers, context);
 
-    this.removeSecondaryKeys = createProcedureMethod(args => [removeSecondaryKeys, args], context);
+    this.removeSecondaryKeys = createProcedureMethod(
+      { getProcedureAndArgs: args => [removeSecondaryKeys, args] },
+      context
+    );
     this.revokePermissions = createProcedureMethod<
       { secondaryKeys: Signer[] },
       ModifySignerPermissionsParams,
       void
-    >(args => {
-      const { secondaryKeys } = args;
-      const signers = secondaryKeys.map(signer => {
-        return {
-          signer,
-          permissions: { tokens: [], transactions: [], portfolios: [] },
-        };
-      });
-      return [modifySignerPermissions, { secondaryKeys: signers }];
-    }, context);
-    this.modifyPermissions = createProcedureMethod(
-      args => [modifySignerPermissions, args],
+    >(
+      {
+        getProcedureAndArgs: args => {
+          const { secondaryKeys } = args;
+          const signers = secondaryKeys.map(signer => {
+            return {
+              signer,
+              permissions: { tokens: [], transactions: [], portfolios: [] },
+            };
+          });
+          return [modifySignerPermissions, { secondaryKeys: signers }];
+        },
+      },
       context
     );
-    this.inviteAccount = createProcedureMethod(args => [inviteAccount, args], context);
-    this.createVenue = createProcedureMethod(args => [createVenue, args], context);
+    this.modifyPermissions = createProcedureMethod(
+      { getProcedureAndArgs: args => [modifySignerPermissions, args] },
+      context
+    );
+    this.inviteAccount = createProcedureMethod(
+      { getProcedureAndArgs: args => [inviteAccount, args] },
+      context
+    );
+    this.createVenue = createProcedureMethod(
+      { getProcedureAndArgs: args => [createVenue, args] },
+      context
+    );
   }
 
   /**

--- a/src/api/entities/DividendDistribution/__tests__/index.ts
+++ b/src/api/entities/DividendDistribution/__tests__/index.ts
@@ -155,7 +155,7 @@ describe('DividendDistribution class', () => {
 
       sinon
         .stub(claimDividends, 'prepare')
-        .withArgs({ distribution: dividendDistribution }, context)
+        .withArgs({ args: { distribution: dividendDistribution }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await dividendDistribution.claim();

--- a/src/api/entities/DividendDistribution/index.ts
+++ b/src/api/entities/DividendDistribution/index.ts
@@ -94,7 +94,10 @@ export class DividendDistribution extends CorporateAction {
     this.expiryDate = expiryDate;
     this.paymentDate = paymentDate;
 
-    this.claim = createProcedureMethod(() => [claimDividends, { distribution: this }], context);
+    this.claim = createProcedureMethod(
+      { getProcedureAndArgs: () => [claimDividends, { distribution: this }] },
+      context
+    );
   }
 
   /**

--- a/src/api/entities/Identity/Portfolios.ts
+++ b/src/api/entities/Identity/Portfolios.ts
@@ -27,13 +27,21 @@ export class Portfolios extends Namespace<Identity> {
 
     const { did } = parent;
 
-    this.create = createProcedureMethod(args => [createPortfolio, args], context);
-    this.delete = createProcedureMethod(args => {
-      const { portfolio } = args;
-      const id = portfolio instanceof BigNumber ? portfolio : portfolio.id;
+    this.create = createProcedureMethod(
+      { getProcedureAndArgs: args => [createPortfolio, args] },
+      context
+    );
+    this.delete = createProcedureMethod(
+      {
+        getProcedureAndArgs: args => {
+          const { portfolio } = args;
+          const id = portfolio instanceof BigNumber ? portfolio : portfolio.id;
 
-      return [deletePortfolio, { id, did }];
-    }, context);
+          return [deletePortfolio, { id, did }];
+        },
+      },
+      context
+    );
   }
 
   /**

--- a/src/api/entities/Identity/__tests__/Portfolios.ts
+++ b/src/api/entities/Identity/__tests__/Portfolios.ts
@@ -172,7 +172,7 @@ describe('Portfolios class', () => {
 
       sinon
         .stub(createPortfolio, 'prepare')
-        .withArgs({ name }, mockContext)
+        .withArgs({ args: { name }, transformer: undefined }, mockContext)
         .resolves(expectedQueue);
 
       const queue = await portfolios.create({ name });
@@ -188,7 +188,7 @@ describe('Portfolios class', () => {
 
       sinon
         .stub(deletePortfolio, 'prepare')
-        .withArgs({ id: portfolioId, did }, mockContext)
+        .withArgs({ args: { id: portfolioId, did }, transformer: undefined }, mockContext)
         .resolves(expectedQueue);
 
       let queue = await portfolios.delete({ portfolio: portfolioId });

--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -426,7 +426,13 @@ describe('Instruction class', () => {
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<void>;
 
       prepareModifyInstructionAffirmationStub
-        .withArgs({ id, operation: InstructionAffirmationOperation.Reject }, context)
+        .withArgs(
+          {
+            args: { id, operation: InstructionAffirmationOperation.Reject },
+            transformer: undefined,
+          },
+          context
+        )
         .resolves(expectedQueue);
 
       const queue = await instruction.reject();
@@ -447,7 +453,13 @@ describe('Instruction class', () => {
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<Instruction>;
 
       prepareModifyInstructionAffirmationStub
-        .withArgs({ id, operation: InstructionAffirmationOperation.Affirm }, context)
+        .withArgs(
+          {
+            args: { id, operation: InstructionAffirmationOperation.Affirm },
+            transformer: undefined,
+          },
+          context
+        )
         .resolves(expectedQueue);
 
       const queue = await instruction.affirm();
@@ -469,7 +481,13 @@ describe('Instruction class', () => {
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<Instruction>;
 
       prepareModifyInstructionAffirmationStub
-        .withArgs({ id, operation: InstructionAffirmationOperation.Withdraw }, context)
+        .withArgs(
+          {
+            args: { id, operation: InstructionAffirmationOperation.Withdraw },
+            transformer: undefined,
+          },
+          context
+        )
         .resolves(expectedQueue);
 
       const queue = await instruction.withdraw();

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -69,26 +69,35 @@ export class Instruction extends Entity<UniqueIdentifiers> {
 
     this.id = id;
 
-    this.reject = createProcedureMethod(() => {
-      return [
-        modifyInstructionAffirmation,
-        { id, operation: InstructionAffirmationOperation.Reject },
-      ];
-    }, context);
+    this.reject = createProcedureMethod(
+      {
+        getProcedureAndArgs: () => [
+          modifyInstructionAffirmation,
+          { id, operation: InstructionAffirmationOperation.Reject },
+        ],
+      },
+      context
+    );
 
-    this.affirm = createProcedureMethod(() => {
-      return [
-        modifyInstructionAffirmation,
-        { id, operation: InstructionAffirmationOperation.Affirm },
-      ];
-    }, context);
+    this.affirm = createProcedureMethod(
+      {
+        getProcedureAndArgs: () => [
+          modifyInstructionAffirmation,
+          { id, operation: InstructionAffirmationOperation.Affirm },
+        ],
+      },
+      context
+    );
 
-    this.withdraw = createProcedureMethod(() => {
-      return [
-        modifyInstructionAffirmation,
-        { id, operation: InstructionAffirmationOperation.Withdraw },
-      ];
-    }, context);
+    this.withdraw = createProcedureMethod(
+      {
+        getProcedureAndArgs: () => [
+          modifyInstructionAffirmation,
+          { id, operation: InstructionAffirmationOperation.Withdraw },
+        ],
+      },
+      context
+    );
   }
 
   /**

--- a/src/api/entities/NumberedPortfolio.ts
+++ b/src/api/entities/NumberedPortfolio.ts
@@ -48,9 +48,12 @@ export class NumberedPortfolio extends Portfolio {
 
     this.id = id;
 
-    this.delete = createProcedureMethod(() => [deletePortfolio, { did, id }], context);
+    this.delete = createProcedureMethod(
+      { getProcedureAndArgs: () => [deletePortfolio, { did, id }] },
+      context
+    );
     this.modifyName = createProcedureMethod(
-      args => [renamePortfolio, { ...args, did, id }],
+      { getProcedureAndArgs: args => [renamePortfolio, { ...args, did, id }] },
       context
     );
   }

--- a/src/api/entities/Portfolio/__tests__/index.ts
+++ b/src/api/entities/Portfolio/__tests__/index.ts
@@ -291,7 +291,7 @@ describe('Portfolio class', () => {
 
       sinon
         .stub(moveFunds, 'prepare')
-        .withArgs({ ...args, from: portfolio }, context)
+        .withArgs({ args: { ...args, from: portfolio }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await portfolio.moveFunds(args);
@@ -320,7 +320,7 @@ describe('Portfolio class', () => {
 
       sinon
         .stub(setCustodian, 'prepare')
-        .withArgs({ id, did, targetIdentity }, context)
+        .withArgs({ args: { id, did, targetIdentity }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await portfolio.setCustodian({ targetIdentity });

--- a/src/api/entities/Portfolio/index.ts
+++ b/src/api/entities/Portfolio/index.ts
@@ -70,10 +70,13 @@ export class Portfolio extends Entity<UniqueIdentifiers> {
     this._id = id;
 
     this.setCustodian = createProcedureMethod(
-      args => [setCustodian, { ...args, did, id }],
+      { getProcedureAndArgs: args => [setCustodian, { ...args, did, id }] },
       context
     );
-    this.moveFunds = createProcedureMethod(args => [moveFunds, { ...args, from: this }], context);
+    this.moveFunds = createProcedureMethod(
+      { getProcedureAndArgs: args => [moveFunds, { ...args, from: this }] },
+      context
+    );
   }
 
   /**

--- a/src/api/entities/SecurityToken/Checkpoints/Schedules.ts
+++ b/src/api/entities/SecurityToken/Checkpoints/Schedules.ts
@@ -28,11 +28,11 @@ export class Schedules extends Namespace<SecurityToken> {
     const { ticker } = parent;
 
     this.create = createProcedureMethod(
-      args => [createCheckpointSchedule, { ticker, ...args }],
+      { getProcedureAndArgs: args => [createCheckpointSchedule, { ticker, ...args }] },
       context
     );
     this.remove = createProcedureMethod(
-      args => [removeCheckpointSchedule, { ticker, ...args }],
+      { getProcedureAndArgs: args => [removeCheckpointSchedule, { ticker, ...args }] },
       context
     );
   }

--- a/src/api/entities/SecurityToken/Checkpoints/__tests__/Schedules.ts
+++ b/src/api/entities/SecurityToken/Checkpoints/__tests__/Schedules.ts
@@ -77,7 +77,7 @@ describe('Schedules class', () => {
 
       sinon
         .stub(createCheckpointSchedule, 'prepare')
-        .withArgs({ ticker, ...args }, context)
+        .withArgs({ args: { ticker, ...args }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await schedules.create(args);
@@ -99,7 +99,7 @@ describe('Schedules class', () => {
 
       sinon
         .stub(removeCheckpointSchedule, 'prepare')
-        .withArgs({ ticker, ...args }, context)
+        .withArgs({ args: { ticker, ...args }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await schedules.remove(args);

--- a/src/api/entities/SecurityToken/Checkpoints/__tests__/index.ts
+++ b/src/api/entities/SecurityToken/Checkpoints/__tests__/index.ts
@@ -64,7 +64,10 @@ describe('Checkpoints class', () => {
     test('should prepare the procedure with the correct arguments and context, and return the resulting transaction queue', async () => {
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<Checkpoint>;
 
-      sinon.stub(createCheckpoint, 'prepare').withArgs({ ticker }, context).resolves(expectedQueue);
+      sinon
+        .stub(createCheckpoint, 'prepare')
+        .withArgs({ args: { ticker }, transformer: undefined }, context)
+        .resolves(expectedQueue);
 
       const queue = await checkpoints.create();
 

--- a/src/api/entities/SecurityToken/Checkpoints/index.ts
+++ b/src/api/entities/SecurityToken/Checkpoints/index.ts
@@ -20,7 +20,10 @@ export class Checkpoints extends Namespace<SecurityToken> {
 
     const { ticker } = parent;
 
-    this.create = createProcedureMethod(() => [createCheckpoint, { ticker }], context);
+    this.create = createProcedureMethod(
+      { getProcedureAndArgs: () => [createCheckpoint, { ticker }] },
+      context
+    );
 
     this.schedules = new Schedules(parent, context);
   }

--- a/src/api/entities/SecurityToken/Compliance/Requirements.ts
+++ b/src/api/entities/SecurityToken/Compliance/Requirements.ts
@@ -36,17 +36,20 @@ export class Requirements extends Namespace<SecurityToken> {
 
     const { ticker } = parent;
 
-    this.set = createProcedureMethod(args => [setAssetRequirements, { ticker, ...args }], context);
+    this.set = createProcedureMethod(
+      { getProcedureAndArgs: args => [setAssetRequirements, { ticker, ...args }] },
+      context
+    );
     this.reset = createProcedureMethod(
-      () => [setAssetRequirements, { ticker, requirements: [] }],
+      { getProcedureAndArgs: () => [setAssetRequirements, { ticker, requirements: [] }] },
       context
     );
     this.pause = createProcedureMethod(
-      () => [togglePauseRequirements, { ticker, pause: true }],
+      { getProcedureAndArgs: () => [togglePauseRequirements, { ticker, pause: true }] },
       context
     );
     this.unpause = createProcedureMethod(
-      () => [togglePauseRequirements, { ticker, pause: false }],
+      { getProcedureAndArgs: () => [togglePauseRequirements, { ticker, pause: false }] },
       context
     );
   }

--- a/src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts
+++ b/src/api/entities/SecurityToken/Compliance/TrustedClaimIssuers.ts
@@ -32,10 +32,12 @@ export class TrustedClaimIssuers extends Namespace<SecurityToken> {
       ModifyTokenTrustedClaimIssuersParams,
       SecurityToken
     >(
-      args => [
-        modifyTokenTrustedClaimIssuers,
-        { ticker, ...args, operation: TrustedClaimIssuerOperation.Set },
-      ],
+      {
+        getProcedureAndArgs: args => [
+          modifyTokenTrustedClaimIssuers,
+          { ticker, ...args, operation: TrustedClaimIssuerOperation.Set },
+        ],
+      },
       context
     );
     this.add = createProcedureMethod<
@@ -43,10 +45,12 @@ export class TrustedClaimIssuers extends Namespace<SecurityToken> {
       ModifyTokenTrustedClaimIssuersParams,
       SecurityToken
     >(
-      args => [
-        modifyTokenTrustedClaimIssuers,
-        { ticker, ...args, operation: TrustedClaimIssuerOperation.Add },
-      ],
+      {
+        getProcedureAndArgs: args => [
+          modifyTokenTrustedClaimIssuers,
+          { ticker, ...args, operation: TrustedClaimIssuerOperation.Add },
+        ],
+      },
       context
     );
     this.remove = createProcedureMethod<
@@ -54,10 +58,12 @@ export class TrustedClaimIssuers extends Namespace<SecurityToken> {
       ModifyTokenTrustedClaimIssuersParams,
       SecurityToken
     >(
-      args => [
-        modifyTokenTrustedClaimIssuers,
-        { ticker, ...args, operation: TrustedClaimIssuerOperation.Remove },
-      ],
+      {
+        getProcedureAndArgs: args => [
+          modifyTokenTrustedClaimIssuers,
+          { ticker, ...args, operation: TrustedClaimIssuerOperation.Remove },
+        ],
+      },
       context
     );
   }

--- a/src/api/entities/SecurityToken/Compliance/__tests__/Requirements.ts
+++ b/src/api/entities/SecurityToken/Compliance/__tests__/Requirements.ts
@@ -87,7 +87,7 @@ describe('Requirements class', () => {
 
       sinon
         .stub(setAssetRequirements, 'prepare')
-        .withArgs({ ticker: token.ticker, ...args }, context)
+        .withArgs({ args: { ticker: token.ticker, ...args }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await requirements.set(args);
@@ -110,7 +110,10 @@ describe('Requirements class', () => {
 
       sinon
         .stub(setAssetRequirements, 'prepare')
-        .withArgs({ ticker: token.ticker, requirements: [] }, context)
+        .withArgs(
+          { args: { ticker: token.ticker, requirements: [] }, transformer: undefined },
+          context
+        )
         .resolves(expectedQueue);
 
       const queue = await requirements.reset();
@@ -313,7 +316,7 @@ describe('Requirements class', () => {
 
       sinon
         .stub(togglePauseRequirements, 'prepare')
-        .withArgs({ ticker: token.ticker, pause: true }, context)
+        .withArgs({ args: { ticker: token.ticker, pause: true }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await requirements.pause();
@@ -336,7 +339,7 @@ describe('Requirements class', () => {
 
       sinon
         .stub(togglePauseRequirements, 'prepare')
-        .withArgs({ ticker: token.ticker, pause: false }, context)
+        .withArgs({ args: { ticker: token.ticker, pause: false }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await requirements.unpause();

--- a/src/api/entities/SecurityToken/Compliance/__tests__/TrustedClaimIssuers.ts
+++ b/src/api/entities/SecurityToken/Compliance/__tests__/TrustedClaimIssuers.ts
@@ -61,7 +61,10 @@ describe('TrustedClaimIssuers class', () => {
       sinon
         .stub(modifyTokenTrustedClaimIssuers, 'prepare')
         .withArgs(
-          { ticker: token.ticker, ...args, operation: TrustedClaimIssuerOperation.Set },
+          {
+            args: { ticker: token.ticker, ...args, operation: TrustedClaimIssuerOperation.Set },
+            transformer: undefined,
+          },
           context
         )
         .resolves(expectedQueue);
@@ -96,7 +99,10 @@ describe('TrustedClaimIssuers class', () => {
       sinon
         .stub(modifyTokenTrustedClaimIssuers, 'prepare')
         .withArgs(
-          { ticker: token.ticker, ...args, operation: TrustedClaimIssuerOperation.Add },
+          {
+            args: { ticker: token.ticker, ...args, operation: TrustedClaimIssuerOperation.Add },
+            transformer: undefined,
+          },
           context
         )
         .resolves(expectedQueue);
@@ -128,7 +134,10 @@ describe('TrustedClaimIssuers class', () => {
       sinon
         .stub(modifyTokenTrustedClaimIssuers, 'prepare')
         .withArgs(
-          { ticker: token.ticker, ...args, operation: TrustedClaimIssuerOperation.Remove },
+          {
+            args: { ticker: token.ticker, ...args, operation: TrustedClaimIssuerOperation.Remove },
+            transformer: undefined,
+          },
           context
         )
         .resolves(expectedQueue);

--- a/src/api/entities/SecurityToken/CorporateActions/Distributions.ts
+++ b/src/api/entities/SecurityToken/CorporateActions/Distributions.ts
@@ -62,7 +62,7 @@ export class Distributions extends Namespace<SecurityToken> {
     const { ticker } = parent;
 
     this.configureDividendDistribution = createProcedureMethod(
-      args => [configureDividendDistribution, { ticker, ...args }],
+      { getProcedureAndArgs: args => [configureDividendDistribution, { ticker, ...args }] },
       context
     );
   }

--- a/src/api/entities/SecurityToken/CorporateActions/__tests__/Distributions.ts
+++ b/src/api/entities/SecurityToken/CorporateActions/__tests__/Distributions.ts
@@ -70,7 +70,7 @@ describe('Distributions class', () => {
 
       sinon
         .stub(configureDividendDistribution, 'prepare')
-        .withArgs({ ticker: token.ticker, ...args }, context)
+        .withArgs({ args: { ticker: token.ticker, ...args }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await distributions.configureDividendDistribution(args);

--- a/src/api/entities/SecurityToken/CorporateActions/__tests__/index.ts
+++ b/src/api/entities/SecurityToken/CorporateActions/__tests__/index.ts
@@ -69,7 +69,7 @@ describe('CorporateActions class', () => {
 
       sinon
         .stub(modifyCorporateActionsAgent, 'prepare')
-        .withArgs({ ticker, target }, context)
+        .withArgs({ args: { ticker, target }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await corporateActions.setAgent({ target });
@@ -84,7 +84,7 @@ describe('CorporateActions class', () => {
 
       sinon
         .stub(removeCorporateActionsAgent, 'prepare')
-        .withArgs({ ticker: 'SOME_TICKER' }, context)
+        .withArgs({ args: { ticker: 'SOME_TICKER' }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await corporateActions.removeAgent();

--- a/src/api/entities/SecurityToken/CorporateActions/index.ts
+++ b/src/api/entities/SecurityToken/CorporateActions/index.ts
@@ -30,12 +30,12 @@ export class CorporateActions extends Namespace<SecurityToken> {
     this.distributions = new Distributions(parent, context);
 
     this.setAgent = createProcedureMethod(
-      args => [modifyCorporateActionsAgent, { ticker, ...args }],
+      { getProcedureAndArgs: args => [modifyCorporateActionsAgent, { ticker, ...args }] },
       context
     );
 
     this.removeAgent = createProcedureMethod(
-      () => [removeCorporateActionsAgent, { ticker }],
+      { getProcedureAndArgs: () => [removeCorporateActionsAgent, { ticker }] },
       context
     );
   }

--- a/src/api/entities/SecurityToken/Documents.ts
+++ b/src/api/entities/SecurityToken/Documents.ts
@@ -22,7 +22,10 @@ export class Documents extends Namespace<SecurityToken> {
 
     const { ticker } = parent;
 
-    this.set = createProcedureMethod(args => [setTokenDocuments, { ticker, ...args }], context);
+    this.set = createProcedureMethod(
+      { getProcedureAndArgs: args => [setTokenDocuments, { ticker, ...args }] },
+      context
+    );
   }
 
   /**

--- a/src/api/entities/SecurityToken/Issuance.ts
+++ b/src/api/entities/SecurityToken/Issuance.ts
@@ -16,7 +16,10 @@ export class Issuance extends Namespace<SecurityToken> {
 
     const { ticker } = parent;
 
-    this.issue = createProcedureMethod(args => [issueTokens, { ticker, ...args }], context);
+    this.issue = createProcedureMethod(
+      { getProcedureAndArgs: args => [issueTokens, { ticker, ...args }] },
+      context
+    );
   }
 
   /**

--- a/src/api/entities/SecurityToken/Offerings.ts
+++ b/src/api/entities/SecurityToken/Offerings.ts
@@ -18,7 +18,10 @@ export class Offerings extends Namespace<SecurityToken> {
 
     const { ticker } = parent;
 
-    this.launch = createProcedureMethod(args => [launchSto, { ticker, ...args }], context);
+    this.launch = createProcedureMethod(
+      { getProcedureAndArgs: args => [launchSto, { ticker, ...args }] },
+      context
+    );
   }
 
   /**

--- a/src/api/entities/SecurityToken/TransferRestrictions/TransferRestrictionBase.ts
+++ b/src/api/entities/SecurityToken/TransferRestrictions/TransferRestrictionBase.ts
@@ -65,10 +65,12 @@ export abstract class TransferRestrictionBase<
       AddTransferRestrictionParams,
       number
     >(
-      args => [
-        addTransferRestriction,
-        ({ ...args, type: this.type, ticker } as unknown) as AddTransferRestrictionParams,
-      ],
+      {
+        getProcedureAndArgs: args => [
+          addTransferRestriction,
+          ({ ...args, type: this.type, ticker } as unknown) as AddTransferRestrictionParams,
+        ],
+      },
       context
     );
 
@@ -78,10 +80,12 @@ export abstract class TransferRestrictionBase<
       number,
       SetTransferRestrictionsStorage
     >(
-      args => [
-        setTransferRestrictions,
-        ({ ...args, type: this.type, ticker } as unknown) as SetTransferRestrictionsParams,
-      ],
+      {
+        getProcedureAndArgs: args => [
+          setTransferRestrictions,
+          ({ ...args, type: this.type, ticker } as unknown) as SetTransferRestrictionsParams,
+        ],
+      },
       context
     );
 
@@ -91,10 +95,16 @@ export abstract class TransferRestrictionBase<
       number,
       SetTransferRestrictionsStorage
     >(
-      () => [
-        setTransferRestrictions,
-        ({ restrictions: [], type: this.type, ticker } as unknown) as SetTransferRestrictionsParams,
-      ],
+      {
+        getProcedureAndArgs: () => [
+          setTransferRestrictions,
+          ({
+            restrictions: [],
+            type: this.type,
+            ticker,
+          } as unknown) as SetTransferRestrictionsParams,
+        ],
+      },
       context
     );
   }

--- a/src/api/entities/SecurityToken/TransferRestrictions/__tests__/TransferRestrictionBase.ts
+++ b/src/api/entities/SecurityToken/TransferRestrictions/__tests__/TransferRestrictionBase.ts
@@ -70,7 +70,13 @@ describe('TransferRestrictionBase class', () => {
 
       sinon
         .stub(addTransferRestriction, 'prepare')
-        .withArgs({ ticker: token.ticker, ...args, type: TransferRestrictionType.Count }, context)
+        .withArgs(
+          {
+            args: { ticker: token.ticker, ...args, type: TransferRestrictionType.Count },
+            transformer: undefined,
+          },
+          context
+        )
         .resolves(expectedQueue);
 
       const queue = await count.addRestriction({
@@ -93,7 +99,10 @@ describe('TransferRestrictionBase class', () => {
       sinon
         .stub(addTransferRestriction, 'prepare')
         .withArgs(
-          { ticker: token.ticker, ...args, type: TransferRestrictionType.Percentage },
+          {
+            args: { ticker: token.ticker, ...args, type: TransferRestrictionType.Percentage },
+            transformer: undefined,
+          },
           context
         )
         .resolves(expectedQueue);
@@ -130,7 +139,13 @@ describe('TransferRestrictionBase class', () => {
 
       sinon
         .stub(setTransferRestrictions, 'prepare')
-        .withArgs({ ticker: token.ticker, ...args, type: TransferRestrictionType.Count }, context)
+        .withArgs(
+          {
+            args: { ticker: token.ticker, ...args, type: TransferRestrictionType.Count },
+            transformer: undefined,
+          },
+          context
+        )
         .resolves(expectedQueue);
 
       const queue = await count.setRestrictions({
@@ -152,7 +167,10 @@ describe('TransferRestrictionBase class', () => {
       sinon
         .stub(setTransferRestrictions, 'prepare')
         .withArgs(
-          { ticker: token.ticker, ...args, type: TransferRestrictionType.Percentage },
+          {
+            args: { ticker: token.ticker, ...args, type: TransferRestrictionType.Percentage },
+            transformer: undefined,
+          },
           context
         )
         .resolves(expectedQueue);
@@ -186,7 +204,10 @@ describe('TransferRestrictionBase class', () => {
       sinon
         .stub(setTransferRestrictions, 'prepare')
         .withArgs(
-          { ticker: token.ticker, restrictions: [], type: TransferRestrictionType.Count },
+          {
+            args: { ticker: token.ticker, restrictions: [], type: TransferRestrictionType.Count },
+            transformer: undefined,
+          },
           context
         )
         .resolves(expectedQueue);
@@ -204,7 +225,14 @@ describe('TransferRestrictionBase class', () => {
       sinon
         .stub(setTransferRestrictions, 'prepare')
         .withArgs(
-          { ticker: token.ticker, restrictions: [], type: TransferRestrictionType.Percentage },
+          {
+            args: {
+              ticker: token.ticker,
+              restrictions: [],
+              type: TransferRestrictionType.Percentage,
+            },
+            transformer: undefined,
+          },
           context
         )
         .resolves(expectedQueue);

--- a/src/api/entities/SecurityToken/__tests__/Documents.ts
+++ b/src/api/entities/SecurityToken/__tests__/Documents.ts
@@ -51,7 +51,7 @@ describe('Documents class', () => {
 
       sinon
         .stub(setTokenDocuments, 'prepare')
-        .withArgs({ ticker: token.ticker, ...args }, context)
+        .withArgs({ args: { ticker: token.ticker, ...args }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await documents.set(args);

--- a/src/api/entities/SecurityToken/__tests__/Issuance.ts
+++ b/src/api/entities/SecurityToken/__tests__/Issuance.ts
@@ -43,7 +43,10 @@ describe('Issuance class', () => {
 
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<SecurityToken>;
 
-      sinon.stub(issueTokens, 'prepare').withArgs(args, context).resolves(expectedQueue);
+      sinon
+        .stub(issueTokens, 'prepare')
+        .withArgs({ args, transformer: undefined }, context)
+        .resolves(expectedQueue);
 
       const queue = await issuance.issue(args);
 

--- a/src/api/entities/SecurityToken/__tests__/Offerings.ts
+++ b/src/api/entities/SecurityToken/__tests__/Offerings.ts
@@ -71,7 +71,7 @@ describe('Offerings class', () => {
 
       sinon
         .stub(launchSto, 'prepare')
-        .withArgs({ ticker, ...args }, context)
+        .withArgs({ args: { ticker, ...args }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await offerings.launch(args);

--- a/src/api/entities/SecurityToken/__tests__/index.ts
+++ b/src/api/entities/SecurityToken/__tests__/index.ts
@@ -8,7 +8,6 @@ import {
 } from 'polymesh-types/types';
 import sinon, { SinonStub } from 'sinon';
 
-import { Params } from '~/api/procedures/toggleFreezeTransfers';
 import {
   Context,
   controllerTransfer,
@@ -36,10 +35,7 @@ jest.mock(
 );
 
 describe('SecurityToken class', () => {
-  let prepareToggleFreezeTransfersStub: SinonStub<
-    [Params, Context],
-    Promise<TransactionQueue<SecurityToken, unknown[][]>>
-  >;
+  let prepareToggleFreezeTransfersStub: SinonStub;
 
   beforeAll(() => {
     dsMockUtils.initMocks();
@@ -199,7 +195,7 @@ describe('SecurityToken class', () => {
 
       sinon
         .stub(transferTokenOwnership, 'prepare')
-        .withArgs({ ticker, ...args }, context)
+        .withArgs({ args: { ticker, ...args }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await securityToken.transferOwnership(args);
@@ -223,7 +219,7 @@ describe('SecurityToken class', () => {
 
       sinon
         .stub(modifyToken, 'prepare')
-        .withArgs({ ticker, ...args }, context)
+        .withArgs({ args: { ticker, ...args }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await securityToken.modify(args);
@@ -421,7 +417,7 @@ describe('SecurityToken class', () => {
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<SecurityToken>;
 
       prepareToggleFreezeTransfersStub
-        .withArgs({ ticker, freeze: true }, context)
+        .withArgs({ args: { ticker, freeze: true }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await securityToken.freeze();
@@ -439,7 +435,7 @@ describe('SecurityToken class', () => {
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<SecurityToken>;
 
       prepareToggleFreezeTransfersStub
-        .withArgs({ ticker, freeze: false }, context)
+        .withArgs({ args: { ticker, freeze: false }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await securityToken.unfreeze();
@@ -504,7 +500,7 @@ describe('SecurityToken class', () => {
 
       sinon
         .stub(modifyPrimaryIssuanceAgent, 'prepare')
-        .withArgs({ ticker, target }, context)
+        .withArgs({ args: { ticker, target }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await securityToken.modifyPrimaryIssuanceAgent({ target });
@@ -523,7 +519,7 @@ describe('SecurityToken class', () => {
 
       sinon
         .stub(removePrimaryIssuanceAgent, 'prepare')
-        .withArgs({ ticker }, context)
+        .withArgs({ args: { ticker }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await securityToken.removePrimaryIssuanceAgent();
@@ -543,7 +539,7 @@ describe('SecurityToken class', () => {
 
       sinon
         .stub(redeemToken, 'prepare')
-        .withArgs({ amount, ticker }, context)
+        .withArgs({ args: { amount, ticker }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await securityToken.redeem({ amount });
@@ -612,7 +608,7 @@ describe('SecurityToken class', () => {
 
       sinon
         .stub(controllerTransfer, 'prepare')
-        .withArgs({ ticker, originPortfolio, amount }, context)
+        .withArgs({ args: { ticker, originPortfolio, amount }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await securityToken.controllerTransfer({ originPortfolio, amount });

--- a/src/api/entities/SecurityToken/index.ts
+++ b/src/api/entities/SecurityToken/index.ts
@@ -115,29 +115,35 @@ export class SecurityToken extends Entity<UniqueIdentifiers> {
     this.corporateActions = new CorporateActions(this, context);
 
     this.transferOwnership = createProcedureMethod(
-      args => [transferTokenOwnership, { ticker, ...args }],
+      { getProcedureAndArgs: args => [transferTokenOwnership, { ticker, ...args }] },
       context
     );
-    this.modify = createProcedureMethod(args => [modifyToken, { ticker, ...args }], context);
+    this.modify = createProcedureMethod(
+      { getProcedureAndArgs: args => [modifyToken, { ticker, ...args }] },
+      context
+    );
     this.freeze = createProcedureMethod(
-      () => [toggleFreezeTransfers, { ticker, freeze: true }],
+      { getProcedureAndArgs: () => [toggleFreezeTransfers, { ticker, freeze: true }] },
       context
     );
     this.unfreeze = createProcedureMethod(
-      () => [toggleFreezeTransfers, { ticker, freeze: false }],
+      { getProcedureAndArgs: () => [toggleFreezeTransfers, { ticker, freeze: false }] },
       context
     );
     this.modifyPrimaryIssuanceAgent = createProcedureMethod(
-      args => [modifyPrimaryIssuanceAgent, { ticker, ...args }],
+      { getProcedureAndArgs: args => [modifyPrimaryIssuanceAgent, { ticker, ...args }] },
       context
     );
     this.removePrimaryIssuanceAgent = createProcedureMethod(
-      () => [removePrimaryIssuanceAgent, { ticker }],
+      { getProcedureAndArgs: () => [removePrimaryIssuanceAgent, { ticker }] },
       context
     );
-    this.redeem = createProcedureMethod(args => [redeemToken, { ticker, ...args }], context);
+    this.redeem = createProcedureMethod(
+      { getProcedureAndArgs: args => [redeemToken, { ticker, ...args }] },
+      context
+    );
     this.controllerTransfer = createProcedureMethod(
-      args => [controllerTransfer, { ticker, ...args }],
+      { getProcedureAndArgs: args => [controllerTransfer, { ticker, ...args }] },
       context
     );
   }

--- a/src/api/entities/Sto/__tests__/index.ts
+++ b/src/api/entities/Sto/__tests__/index.ts
@@ -11,7 +11,6 @@ import {
   modifyStoTimes,
   Sto,
   toggleFreezeSto,
-  ToggleFreezeStoParams,
   TransactionQueue,
   Venue,
 } from '~/internal';
@@ -42,10 +41,7 @@ jest.mock(
 
 describe('Sto class', () => {
   let context: Context;
-  let prepareToggleFreezeStoStub: SinonStub<
-    [ToggleFreezeStoParams, Context],
-    Promise<TransactionQueue<Sto, unknown[][]>>
-  >;
+  let prepareToggleFreezeStoStub: SinonStub;
 
   beforeAll(() => {
     dsMockUtils.initMocks();
@@ -228,7 +224,10 @@ describe('Sto class', () => {
 
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<void>;
 
-      sinon.stub(closeSto, 'prepare').withArgs(args, context).resolves(expectedQueue);
+      sinon
+        .stub(closeSto, 'prepare')
+        .withArgs({ args, transformer: undefined }, context)
+        .resolves(expectedQueue);
 
       const queue = await sto.close();
 
@@ -255,7 +254,10 @@ describe('Sto class', () => {
 
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<void>;
 
-      sinon.stub(modifyStoTimes, 'prepare').withArgs(args, context).resolves(expectedQueue);
+      sinon
+        .stub(modifyStoTimes, 'prepare')
+        .withArgs({ args, transformer: undefined }, context)
+        .resolves(expectedQueue);
 
       const queue = await sto.modifyTimes({
         start,
@@ -349,7 +351,7 @@ describe('Sto class', () => {
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<Sto>;
 
       prepareToggleFreezeStoStub
-        .withArgs({ ticker, id, freeze: true }, context)
+        .withArgs({ args: { ticker, id, freeze: true }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await sto.freeze();
@@ -367,7 +369,7 @@ describe('Sto class', () => {
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<Sto>;
 
       prepareToggleFreezeStoStub
-        .withArgs({ ticker, id, freeze: false }, context)
+        .withArgs({ args: { ticker, id, freeze: false }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await sto.unfreeze();
@@ -397,7 +399,10 @@ describe('Sto class', () => {
 
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<void>;
 
-      sinon.stub(investInSto, 'prepare').withArgs(args, context).resolves(expectedQueue);
+      sinon
+        .stub(investInSto, 'prepare')
+        .withArgs({ args, transformer: undefined }, context)
+        .resolves(expectedQueue);
 
       const queue = await sto.invest({
         purchasePortfolio,

--- a/src/api/entities/Sto/index.ts
+++ b/src/api/entities/Sto/index.ts
@@ -64,19 +64,25 @@ export class Sto extends Entity<UniqueIdentifiers> {
     this.ticker = ticker;
 
     this.freeze = createProcedureMethod(
-      () => [toggleFreezeSto, { ticker, id, freeze: true }],
+      { getProcedureAndArgs: () => [toggleFreezeSto, { ticker, id, freeze: true }] },
       context
     );
     this.unfreeze = createProcedureMethod(
-      () => [toggleFreezeSto, { ticker, id, freeze: false }],
+      { getProcedureAndArgs: () => [toggleFreezeSto, { ticker, id, freeze: false }] },
       context
     );
-    this.close = createProcedureMethod(() => [closeSto, { ticker, id }], context);
+    this.close = createProcedureMethod(
+      { getProcedureAndArgs: () => [closeSto, { ticker, id }] },
+      context
+    );
     this.modifyTimes = createProcedureMethod(
-      args => [modifyStoTimes, { ticker, id, ...args }],
+      { getProcedureAndArgs: args => [modifyStoTimes, { ticker, id, ...args }] },
       context
     );
-    this.invest = createProcedureMethod(args => [investInSto, { ticker, id, ...args }], context);
+    this.invest = createProcedureMethod(
+      { getProcedureAndArgs: args => [investInSto, { ticker, id, ...args }] },
+      context
+    );
   }
 
   /**

--- a/src/api/entities/TickerReservation/__tests__/index.ts
+++ b/src/api/entities/TickerReservation/__tests__/index.ts
@@ -211,7 +211,10 @@ describe('TickerReservation class', () => {
 
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<TickerReservation>;
 
-      sinon.stub(reserveTicker, 'prepare').withArgs(args, context).resolves(expectedQueue);
+      sinon
+        .stub(reserveTicker, 'prepare')
+        .withArgs({ args, transformer: undefined }, context)
+        .resolves(expectedQueue);
 
       const queue = await tickerReservation.extend();
 
@@ -236,7 +239,10 @@ describe('TickerReservation class', () => {
 
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<SecurityToken>;
 
-      sinon.stub(createSecurityToken, 'prepare').withArgs(args, context).resolves(expectedQueue);
+      sinon
+        .stub(createSecurityToken, 'prepare')
+        .withArgs({ args, transformer: undefined }, context)
+        .resolves(expectedQueue);
 
       const queue = await tickerReservation.createToken(args);
 

--- a/src/api/entities/TickerReservation/index.ts
+++ b/src/api/entities/TickerReservation/index.ts
@@ -56,12 +56,12 @@ export class TickerReservation extends Entity<UniqueIdentifiers> {
     this.ticker = ticker;
 
     this.extend = createProcedureMethod(
-      () => [reserveTicker, { ticker, extendPeriod: true }],
+      { getProcedureAndArgs: () => [reserveTicker, { ticker, extendPeriod: true }] },
       context
     );
 
     this.createToken = createProcedureMethod(
-      args => [createSecurityToken, { ...args, ticker }],
+      { getProcedureAndArgs: args => [createSecurityToken, { ...args, ticker }] },
       context
     );
   }

--- a/src/api/entities/Venue/__tests__/index.ts
+++ b/src/api/entities/Venue/__tests__/index.ts
@@ -189,10 +189,10 @@ describe('Venue class', () => {
   });
 
   describe('method: addInstruction', () => {
-    let prepareAddInstructionStub: sinon.SinonStub;
+    let addInstructionPrepareStub: sinon.SinonStub;
 
     beforeAll(() => {
-      prepareAddInstructionStub = sinon.stub(addInstruction, 'prepare');
+      addInstructionPrepareStub = sinon.stub(addInstruction, 'prepare');
     });
 
     afterAll(() => {
@@ -220,8 +220,11 @@ describe('Venue class', () => {
 
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<Instruction>;
 
-      prepareAddInstructionStub
-        .withArgs({ venueId: id, legs, tradeDate, endBlock }, context)
+      addInstructionPrepareStub
+        .withArgs(
+          { args: { venueId: id, legs, tradeDate, endBlock }, transformer: undefined },
+          context
+        )
         .resolves(expectedQueue);
 
       const queue = await venue.addInstruction({ legs, tradeDate, endBlock });

--- a/src/api/entities/Venue/index.ts
+++ b/src/api/entities/Venue/index.ts
@@ -57,7 +57,7 @@ export class Venue extends Entity<UniqueIdentifiers> {
     this.id = id;
 
     this.addInstruction = createProcedureMethod(
-      args => [addInstruction, { ...args, venueId: id }],
+      { getProcedureAndArgs: args => [addInstruction, { ...args, venueId: id }] },
       context
     );
   }

--- a/src/api/entities/__tests__/AuthorizationRequest.ts
+++ b/src/api/entities/__tests__/AuthorizationRequest.ts
@@ -90,7 +90,7 @@ describe('AuthorizationRequest class', () => {
 
       sinon
         .stub(consumeAuthorizationRequests, 'prepare')
-        .withArgs({ ...args }, context)
+        .withArgs({ args, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await authorizationRequest.accept();
@@ -127,7 +127,7 @@ describe('AuthorizationRequest class', () => {
 
       sinon
         .stub(consumeJoinIdentityAuthorization, 'prepare')
-        .withArgs({ ...args }, context)
+        .withArgs({ args, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await authorizationRequest.accept();
@@ -162,7 +162,7 @@ describe('AuthorizationRequest class', () => {
 
       sinon
         .stub(consumeAuthorizationRequests, 'prepare')
-        .withArgs({ ...args }, context)
+        .withArgs({ args, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await authorizationRequest.remove();
@@ -199,7 +199,7 @@ describe('AuthorizationRequest class', () => {
 
       sinon
         .stub(consumeJoinIdentityAuthorization, 'prepare')
-        .withArgs({ ...args }, context)
+        .withArgs({ args, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await authorizationRequest.remove();

--- a/src/api/entities/__tests__/CurrentIdentity.ts
+++ b/src/api/entities/__tests__/CurrentIdentity.ts
@@ -19,13 +19,13 @@ import * as utilsConversionModule from '~/utils/conversion';
 
 describe('CurrentIdentity class', () => {
   let context: Context;
-  let modifySignerPermissionsStub: sinon.SinonStub;
+  let modifySignerPermissionsPrepareStub: sinon.SinonStub;
 
   beforeAll(() => {
     entityMockUtils.initMocks();
     dsMockUtils.initMocks();
 
-    modifySignerPermissionsStub = sinon.stub(modifySignerPermissions, 'prepare');
+    modifySignerPermissionsPrepareStub = sinon.stub(modifySignerPermissions, 'prepare');
   });
 
   beforeEach(() => {
@@ -99,7 +99,7 @@ describe('CurrentIdentity class', () => {
 
       sinon
         .stub(removeSecondaryKeys, 'prepare')
-        .withArgs({ signers }, context)
+        .withArgs({ args: { signers }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await identity.removeSecondaryKeys({ signers });
@@ -123,7 +123,9 @@ describe('CurrentIdentity class', () => {
 
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<void>;
 
-      modifySignerPermissionsStub.withArgs({ secondaryKeys }, context).resolves(expectedQueue);
+      modifySignerPermissionsPrepareStub
+        .withArgs({ args: { secondaryKeys }, transformer: undefined }, context)
+        .resolves(expectedQueue);
 
       const queue = await identity.revokePermissions({ secondaryKeys: signers });
 
@@ -145,7 +147,9 @@ describe('CurrentIdentity class', () => {
 
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<void>;
 
-      modifySignerPermissionsStub.withArgs({ secondaryKeys }, context).resolves(expectedQueue);
+      modifySignerPermissionsPrepareStub
+        .withArgs({ args: { secondaryKeys }, transformer: undefined }, context)
+        .resolves(expectedQueue);
 
       const queue = await identity.modifyPermissions({ secondaryKeys });
 
@@ -164,7 +168,10 @@ describe('CurrentIdentity class', () => {
 
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<void>;
 
-      sinon.stub(inviteAccount, 'prepare').withArgs(args, context).resolves(expectedQueue);
+      sinon
+        .stub(inviteAccount, 'prepare')
+        .withArgs({ args, transformer: undefined }, context)
+        .resolves(expectedQueue);
 
       const queue = await identity.inviteAccount(args);
 
@@ -184,7 +191,10 @@ describe('CurrentIdentity class', () => {
 
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<Venue>;
 
-      sinon.stub(createVenue, 'prepare').withArgs(args, context).resolves(expectedQueue);
+      sinon
+        .stub(createVenue, 'prepare')
+        .withArgs({ args, transformer: undefined }, context)
+        .resolves(expectedQueue);
 
       const queue = await identity.createVenue(args);
 

--- a/src/api/entities/__tests__/NumberedPortfolio.ts
+++ b/src/api/entities/__tests__/NumberedPortfolio.ts
@@ -76,7 +76,10 @@ describe('NumberedPortfolio class', () => {
       const numberedPortfolio = new NumberedPortfolio({ id, did }, context);
       const expectedQueue = ('someQueue' as unknown) as TransactionQueue<void>;
 
-      sinon.stub(deletePortfolio, 'prepare').withArgs({ id, did }, context).resolves(expectedQueue);
+      sinon
+        .stub(deletePortfolio, 'prepare')
+        .withArgs({ args: { id, did }, transformer: undefined }, context)
+        .resolves(expectedQueue);
 
       const queue = await numberedPortfolio.delete();
 
@@ -94,7 +97,7 @@ describe('NumberedPortfolio class', () => {
 
       sinon
         .stub(renamePortfolio, 'prepare')
-        .withArgs({ id, did, name }, context)
+        .withArgs({ args: { id, did, name }, transformer: undefined }, context)
         .resolves(expectedQueue);
 
       const queue = await numberedPortfolio.modifyName({ name });

--- a/src/base/__tests__/Procedure.ts
+++ b/src/base/__tests__/Procedure.ts
@@ -153,16 +153,18 @@ describe('Procedure class', () => {
 
       const constructorSpy = sinon.spy(baseModule, 'TransactionQueue');
 
-      let { transactions } = await proc1.prepare(procArgs, context);
+      let { transactions } = await proc1.prepare({ args: procArgs }, context);
 
       expect(transactions.length).toBe(2);
       sinon.assert.calledWith(
         constructorSpy,
-        sinon.match([
-          sinon.match({ tx: tx1, args: [ticker] }),
-          sinon.match({ tx: tx2, args: [secondaryKeys] }),
-        ]),
-        returnValue,
+        sinon.match({
+          transactions: sinon.match([
+            sinon.match({ tx: tx1, args: [ticker] }),
+            sinon.match({ tx: tx2, args: [secondaryKeys] }),
+          ]),
+          procedureResult: returnValue,
+        }),
         context
       );
 
@@ -175,16 +177,18 @@ describe('Procedure class', () => {
 
       const proc2 = new Procedure(func2);
 
-      ({ transactions } = await proc2.prepare(procArgs, context));
+      ({ transactions } = await proc2.prepare({ args: procArgs }, context));
 
       expect(transactions.length).toBe(2);
       sinon.assert.calledWith(
         constructorSpy,
-        sinon.match([
-          sinon.match({ tx: tx1, args: [ticker] }),
-          sinon.match({ tx: tx2, args: [secondaryKeys] }),
-        ]),
-        returnValue,
+        sinon.match({
+          transactions: sinon.match([
+            sinon.match({ tx: tx1, args: [ticker] }),
+            sinon.match({ tx: tx2, args: [secondaryKeys] }),
+          ]),
+          procedureResult: returnValue,
+        }),
         context
       );
     });
@@ -206,7 +210,7 @@ describe('Procedure class', () => {
 
       const proc = new Procedure(func);
 
-      return expect(proc.prepare(procArgs, context)).rejects.toThrow(errorMsg);
+      return expect(proc.prepare({ args: procArgs }, context)).rejects.toThrow(errorMsg);
     });
 
     test("should throw an error if the caller doesn't have the appropriate roles", async () => {
@@ -227,7 +231,7 @@ describe('Procedure class', () => {
       });
       context = dsMockUtils.getContextInstance({ hasRoles: false, hasPermissions: false });
 
-      await expect(proc.prepare(procArgs, context)).rejects.toThrow(
+      await expect(proc.prepare({ args: procArgs }, context)).rejects.toThrow(
         "Current Identity doesn't have the required roles to execute this procedure"
       );
 
@@ -239,7 +243,7 @@ describe('Procedure class', () => {
         },
       });
 
-      await expect(proc.prepare(procArgs, context)).rejects.toThrow(
+      await expect(proc.prepare({ args: procArgs }, context)).rejects.toThrow(
         "Current Account doesn't have the required permissions to execute this procedure"
       );
 
@@ -247,13 +251,13 @@ describe('Procedure class', () => {
         signerPermissions: false,
       });
 
-      await expect(proc.prepare(procArgs, context)).rejects.toThrow(
+      await expect(proc.prepare({ args: procArgs }, context)).rejects.toThrow(
         "Current Account doesn't have the required permissions to execute this procedure"
       );
 
       proc = new Procedure(func, async () => ({ identityRoles: false }));
 
-      await expect(proc.prepare(procArgs, context)).rejects.toThrow(
+      await expect(proc.prepare({ args: procArgs }, context)).rejects.toThrow(
         "Current Identity doesn't have the required roles to execute this procedure"
       );
     });

--- a/src/base/__tests__/TransactionQueue.ts
+++ b/src/base/__tests__/TransactionQueue.ts
@@ -50,14 +50,14 @@ describe('Transaction Queue class', () => {
         },
       ];
       const transactions = polymeshTransactionMockUtils.setupNextTransactions(transactionSpecs);
-      const returnValue = 3;
-      const queue = new TransactionQueue(transactions, returnValue, context);
+      const procedureResult = 3;
+      const queue = new TransactionQueue({ transactions, procedureResult }, context);
       expect(queue.transactions).toEqual(transactions);
     });
   });
 
   describe('method: run', () => {
-    test("should run each transaction in the queue and return the queue's return value, unwrapping it if it is a PostTransactionValue", async () => {
+    test("should run each transaction in the queue and return the queue's return value, unwrapping it if it is a PostTransactionValue and transforming it if there is a transform function", async () => {
       const transactionSpecs = [
         {
           args: [1],
@@ -73,12 +73,15 @@ describe('Transaction Queue class', () => {
 
       let transactions = polymeshTransactionMockUtils.setupNextTransactions(transactionSpecs);
 
-      const returnValue = 3;
-      let queue = new TransactionQueue(transactions, returnValue, context);
+      const procedureResult = 3;
+      let queue = new TransactionQueue(
+        { transactions, procedureResult, transformer: (val: number): string => `${val}` },
+        context
+      );
 
       let returned = await queue.run();
 
-      expect(returned).toBe(returnValue);
+      expect(returned).toBe('3');
       transactions.forEach(transaction => {
         sinon.assert.calledOnce(transaction.run);
       });
@@ -86,15 +89,18 @@ describe('Transaction Queue class', () => {
       transactions = polymeshTransactionMockUtils.setupNextTransactions(transactionSpecs);
 
       const returnPostTransactionValue = new PostTransactionValue(() =>
-        Promise.resolve(returnValue)
+        Promise.resolve(procedureResult)
       );
       await returnPostTransactionValue.run({} as ISubmittableResult);
 
-      queue = new TransactionQueue(transactions, returnPostTransactionValue, context);
+      queue = new TransactionQueue(
+        { transactions, procedureResult: returnPostTransactionValue },
+        context
+      );
 
       returned = await queue.run();
 
-      expect(returned).toBe(returnValue);
+      expect(returned).toBe(procedureResult);
     });
 
     test('should update the queue status', async () => {
@@ -106,8 +112,8 @@ describe('Transaction Queue class', () => {
         },
       ];
       let transactions = polymeshTransactionMockUtils.setupNextTransactions(transactionSpecs);
-      const returnValue = 3;
-      let queue = new TransactionQueue(transactions, returnValue, context);
+      const procedureResult = 3;
+      let queue = new TransactionQueue({ transactions, procedureResult }, context);
 
       // Idle -> Running -> Succeeded
       expect(queue.status).toBe(TransactionQueueStatus.Idle);
@@ -130,7 +136,7 @@ describe('Transaction Queue class', () => {
       transactions = polymeshTransactionMockUtils.setupNextTransactions(transactionSpecs);
 
       // Idle -> Running -> Failed
-      queue = new TransactionQueue(transactions, returnValue, context);
+      queue = new TransactionQueue({ transactions, procedureResult }, context);
 
       queue.run().catch(noop);
 
@@ -161,8 +167,8 @@ describe('Transaction Queue class', () => {
 
       const transactions = polymeshTransactionMockUtils.setupNextTransactions(transactionSpecs);
 
-      const returnValue = 3;
-      const queue = new TransactionQueue(transactions, returnValue, context);
+      const procedureResult = 3;
+      const queue = new TransactionQueue({ transactions, procedureResult }, context);
 
       const runPromise = queue.run();
 
@@ -193,8 +199,8 @@ describe('Transaction Queue class', () => {
         locked: new BigNumber(0),
       });
 
-      const returnValue = 3;
-      const queue = new TransactionQueue(transactions, returnValue, context);
+      const procedureResult = 3;
+      const queue = new TransactionQueue({ transactions, procedureResult }, context);
 
       const runPromise = queue.run();
 
@@ -219,8 +225,8 @@ describe('Transaction Queue class', () => {
 
       const transactions = polymeshTransactionMockUtils.setupNextTransactions(transactionSpecs);
 
-      const returnValue = 3;
-      const queue = new TransactionQueue(transactions, returnValue, context);
+      const procedureResult = 3;
+      const queue = new TransactionQueue({ transactions, procedureResult }, context);
 
       let err;
 
@@ -249,8 +255,8 @@ describe('Transaction Queue class', () => {
 
       const transactions = polymeshTransactionMockUtils.setupNextTransactions(transactionSpecs);
 
-      const returnValue = 3;
-      const queue = new TransactionQueue(transactions, returnValue, context);
+      const procedureResult = 3;
+      const queue = new TransactionQueue({ transactions, procedureResult }, context);
 
       await queue.run();
 
@@ -268,8 +274,8 @@ describe('Transaction Queue class', () => {
         },
       ];
       const transactions = polymeshTransactionMockUtils.setupNextTransactions(transactionSpecs);
-      const returnValue = 3;
-      const queue = new TransactionQueue(transactions, returnValue, context);
+      const procedureResult = 3;
+      const queue = new TransactionQueue({ transactions, procedureResult }, context);
 
       const listenerStub = sinon.stub();
       queue.onStatusChange(q => listenerStub(q.status));
@@ -289,8 +295,8 @@ describe('Transaction Queue class', () => {
         },
       ];
       const transactions = polymeshTransactionMockUtils.setupNextTransactions(transactionSpecs);
-      const returnValue = 3;
-      const queue = new TransactionQueue(transactions, returnValue, context);
+      const procedureResult = 3;
+      const queue = new TransactionQueue({ transactions, procedureResult }, context);
 
       const listenerStub = sinon.stub();
       const unsub = queue.onStatusChange(q => listenerStub(q.status));
@@ -321,8 +327,8 @@ describe('Transaction Queue class', () => {
         },
       ];
       const transactions = polymeshTransactionMockUtils.setupNextTransactions(transactionSpecs);
-      const returnValue = 3;
-      const queue = new TransactionQueue(transactions, returnValue, context);
+      const procedureResult = 3;
+      const queue = new TransactionQueue({ transactions, procedureResult }, context);
 
       const listenerStub = sinon.stub();
       queue.onTransactionStatusChange(transaction => {
@@ -355,8 +361,8 @@ describe('Transaction Queue class', () => {
         },
       ];
       const transactions = polymeshTransactionMockUtils.setupNextTransactions(transactionSpecs);
-      const returnValue = 3;
-      const queue = new TransactionQueue(transactions, returnValue, context);
+      const procedureResult = 3;
+      const queue = new TransactionQueue({ transactions, procedureResult }, context);
 
       const listenerStub = sinon.stub();
       const unsub = queue.onTransactionStatusChange(transaction => {
@@ -404,8 +410,8 @@ describe('Transaction Queue class', () => {
         },
       ];
       const transactions = polymeshTransactionMockUtils.setupNextTransactions(transactionSpecs);
-      const returnValue = 3;
-      const queue = new TransactionQueue(transactions, returnValue, context);
+      const procedureResult = 3;
+      const queue = new TransactionQueue({ transactions, procedureResult }, context);
 
       const listenerStub = sinon.stub();
       queue.onProcessedByMiddleware(err => listenerStub(err));
@@ -439,8 +445,8 @@ describe('Transaction Queue class', () => {
         },
       ];
       const transactions = polymeshTransactionMockUtils.setupNextTransactions(transactionSpecs);
-      const returnValue = 3;
-      const queue = new TransactionQueue(transactions, returnValue, context);
+      const procedureResult = 3;
+      const queue = new TransactionQueue({ transactions, procedureResult }, context);
 
       const listenerStub = sinon.stub();
       queue.onProcessedByMiddleware(err => listenerStub(err));
@@ -471,8 +477,8 @@ describe('Transaction Queue class', () => {
         },
       ];
       const transactions = polymeshTransactionMockUtils.setupNextTransactions(transactionSpecs);
-      const returnValue = 3;
-      const queue = new TransactionQueue(transactions, returnValue, context);
+      const procedureResult = 3;
+      const queue = new TransactionQueue({ transactions, procedureResult }, context);
 
       const listenerStub = sinon.stub();
       expect(() => queue.onProcessedByMiddleware(err => listenerStub(err))).toThrow(
@@ -489,8 +495,8 @@ describe('Transaction Queue class', () => {
         },
       ];
       const transactions = polymeshTransactionMockUtils.setupNextTransactions(transactionSpecs);
-      const returnValue = 3;
-      const queue = new TransactionQueue(transactions, returnValue, context);
+      const procedureResult = 3;
+      const queue = new TransactionQueue({ transactions, procedureResult }, context);
 
       const listenerStub = sinon.stub();
       const unsub = queue.onProcessedByMiddleware(err => listenerStub(err));
@@ -547,8 +553,8 @@ describe('Transaction Queue class', () => {
 
       const transactions = polymeshTransactionMockUtils.setupNextTransactions(transactionSpecs);
 
-      const returnValue = 3;
-      const queue = new TransactionQueue(transactions, returnValue, context);
+      const procedureResult = 3;
+      const queue = new TransactionQueue({ transactions, procedureResult }, context);
 
       const fees = await queue.getMinFees();
 

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -223,8 +223,12 @@ export interface ProcedureAuthorization {
   identityRoles?: Role[] | boolean;
 }
 
-export interface ProcedureMethod<MethodArgs, ReturnValue> {
-  (args: MethodArgs): Promise<TransactionQueue<ReturnValue>>;
+export interface ProcedureMethod<
+  MethodArgs,
+  ProcedureReturnValue,
+  ReturnValue = ProcedureReturnValue
+> {
+  (args: MethodArgs): Promise<TransactionQueue<ProcedureReturnValue, ReturnValue>>;
   checkAuthorization: (args: MethodArgs) => Promise<ProcedureAuthorizationStatus>;
 }
 

--- a/src/types/utils/index.ts
+++ b/src/types/utils/index.ts
@@ -4,7 +4,7 @@ export type Mutable<Immutable> = {
   -readonly [K in keyof Immutable]: Immutable[K];
 };
 
-export type UnionOfProcedures<Args extends unknown, ReturnValue, Storage> = Args extends unknown
+export type UnionOfProcedures<Args extends unknown, ReturnValue, Storage> = Args extends object
   ? Procedure<Args, ReturnValue, Storage>
   : never;
 

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -9,7 +9,7 @@ import { ClaimScopeTypeEnum } from '~/middleware/types';
 import { dsMockUtils, entityMockUtils } from '~/testUtils/mocks';
 import { ClaimType, CommonKeyring, CountryCode } from '~/types';
 import { tuple } from '~/types/utils';
-import { MAX_BATCH_ELEMENTS } from '~/utils/constants';
+import { DEFAULT_MAX_BATCH_ELEMENTS, MAX_BATCH_ELEMENTS } from '~/utils/constants';
 
 import {
   assertFormatValid,
@@ -373,8 +373,8 @@ describe('batchArguments', () => {
   });
 
   test('should use a custom batching function to group elements', () => {
-    const tag = TxTags.asset.BatchAddDocument;
-    const expectedBatchLength = MAX_BATCH_ELEMENTS[tag];
+    const tag = TxTags.corporateAction.InitiateCorporateAction;
+    const expectedBatchLength = DEFAULT_MAX_BATCH_ELEMENTS;
 
     const elements = range(0, 2 * expectedBatchLength);
 
@@ -463,17 +463,21 @@ describe('createProcedureMethod', () => {
   test('should return a ProcedureMethod object', async () => {
     const prepare = sinon.stub();
     const checkAuthorization = sinon.stub();
+    const transformer = sinon.stub();
     const fakeProcedure = ({
       prepare,
       checkAuthorization,
     } as unknown) as Procedure<number, void>;
 
-    const method = createProcedureMethod((args: number) => [fakeProcedure, args], context);
+    const method = createProcedureMethod(
+      { getProcedureAndArgs: (args: number) => [fakeProcedure, args], transformer },
+      context
+    );
 
     const procArgs = 1;
     await method(procArgs);
 
-    sinon.assert.calledWithExactly(prepare, procArgs, context);
+    sinon.assert.calledWithExactly(prepare, { args: procArgs, transformer }, context);
 
     await method.checkAuthorization(procArgs);
 
@@ -500,7 +504,10 @@ describe('assertIsInteger', () => {
 });
 
 describe('assertIsPositive', () => {
-  test('assertIsPositive should throw an error if the argument is negative', async () => {
+  test('should not throw an error if the argument is positive', () => {
+    expect(() => assertIsPositive(new BigNumber(43))).not.toThrow();
+  });
+  test('should throw an error if the argument is negative', async () => {
     expect(() => assertIsPositive(new BigNumber(-3))).toThrow('The number must be positive');
   });
 });

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -390,28 +390,82 @@ export function calculateNextKey(totalCount: number, size?: number, start?: numb
 export function createProcedureMethod<
   MethodArgs,
   ProcedureArgs extends unknown,
+  ProcedureReturnValue,
+  Storage = {}
+>(
+  args: {
+    getProcedureAndArgs: (
+      methodArgs: MethodArgs
+    ) => [
+      (
+        | UnionOfProcedures<ProcedureArgs, ProcedureReturnValue, Storage>
+        | Procedure<ProcedureArgs, ProcedureReturnValue, Storage>
+      ),
+      ProcedureArgs
+    ];
+  },
+  context: Context
+): ProcedureMethod<MethodArgs, ProcedureReturnValue, ProcedureReturnValue>;
+export function createProcedureMethod<
+  MethodArgs,
+  ProcedureArgs extends unknown,
+  ProcedureReturnValue,
   ReturnValue,
   Storage = {}
 >(
-  getProcedureAndArgs: (
-    args: MethodArgs
-  ) => [
-    (
-      | UnionOfProcedures<ProcedureArgs, ReturnValue, Storage>
-      | Procedure<ProcedureArgs, ReturnValue, Storage>
-    ),
-    ProcedureArgs
-  ],
+  args: {
+    getProcedureAndArgs: (
+      methodArgs: MethodArgs
+    ) => [
+      (
+        | UnionOfProcedures<ProcedureArgs, ProcedureReturnValue, Storage>
+        | Procedure<ProcedureArgs, ProcedureReturnValue, Storage>
+      ),
+      ProcedureArgs
+    ];
+    transformer: (value: ProcedureReturnValue) => ReturnValue | Promise<ReturnValue>;
+  },
   context: Context
-): ProcedureMethod<MethodArgs, ReturnValue> {
-  const method = (args: MethodArgs): Promise<TransactionQueue<ReturnValue>> => {
-    const [proc, procArgs] = getProcedureAndArgs(args);
+): ProcedureMethod<MethodArgs, ProcedureReturnValue, ReturnValue>;
+// eslint-disable-next-line require-jsdoc
+export function createProcedureMethod<
+  MethodArgs,
+  ProcedureArgs extends unknown,
+  ProcedureReturnValue,
+  ReturnValue = ProcedureReturnValue,
+  Storage = {}
+>(
+  args: {
+    getProcedureAndArgs: (
+      methodArgs: MethodArgs
+    ) => [
+      (
+        | UnionOfProcedures<ProcedureArgs, ProcedureReturnValue, Storage>
+        | Procedure<ProcedureArgs, ProcedureReturnValue, Storage>
+      ),
+      ProcedureArgs
+    ];
+    transformer?: (value: ProcedureReturnValue) => ReturnValue | Promise<ReturnValue>;
+  },
+  context: Context
+): ProcedureMethod<MethodArgs, ProcedureReturnValue, ReturnValue> {
+  const { getProcedureAndArgs, transformer } = args;
 
-    return proc.prepare(procArgs, context);
+  const method = (
+    methodArgs: MethodArgs
+  ): Promise<TransactionQueue<ProcedureReturnValue, ReturnValue>> => {
+    const [proc, procArgs] = getProcedureAndArgs(methodArgs);
+
+    return (proc as Procedure<ProcedureArgs, ProcedureReturnValue, Storage>).prepare(
+      { args: procArgs, transformer },
+      context
+    );
   };
 
-  method.checkAuthorization = async (args: MethodArgs): Promise<ProcedureAuthorizationStatus> => {
-    const [proc, procArgs] = getProcedureAndArgs(args);
+  method.checkAuthorization = async (
+    methodArgs: MethodArgs
+  ): Promise<ProcedureAuthorizationStatus> => {
+    const [proc, procArgs] = getProcedureAndArgs(methodArgs);
 
     return proc.checkAuthorization(procArgs, context);
   };


### PR DESCRIPTION
`createProcedureMethod` now supports a `transformer` function that performs a transformation on the
procedure result before returning it