### PR TITLE
feat(corporate actions): add `getDefaults`

### DIFF
--- a/src/api/entities/SecurityToken/CorporateActions/types.ts
+++ b/src/api/entities/SecurityToken/CorporateActions/types.ts
@@ -1,0 +1,9 @@
+import BigNumber from 'bignumber.js';
+
+import { CorporateActionTargets, TaxWithholding } from '~/types';
+
+export interface CorporateActionDefaults {
+  targets: CorporateActionTargets;
+  defaultTaxWithholding: BigNumber;
+  taxWithholdings: TaxWithholding[];
+}

--- a/src/api/entities/SecurityToken/types.ts
+++ b/src/api/entities/SecurityToken/types.ts
@@ -26,3 +26,5 @@ export interface TokenHolderOptions {
 export interface TokenHolderProperties {
   canBeIssuedTo: boolean;
 }
+
+export * from './CorporateActions/types';

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -209,6 +209,7 @@ import {
   stringToText,
   stringToTicker,
   stringToVenueDetails,
+  targetIdentitiesToCorporateActionTargets,
   targetsToTargetIdentities,
   textToString,
   tickerToDid,
@@ -5465,6 +5466,47 @@ describe('checkpointToRecordDateSpec', () => {
 
     const result = checkpointToRecordDateSpec(value, context);
 
+    expect(result).toEqual(fakeResult);
+  });
+});
+
+describe('targetIdentitiesToCorporateActionTargets', () => {
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    entityMockUtils.initMocks();
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+    entityMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+    entityMockUtils.cleanup();
+  });
+
+  test('should convert a polkadot TargetIdentities object to a CorporateActionTargets object', () => {
+    const fakeResult = {
+      identities: [entityMockUtils.getIdentityInstance({ did: 'someDid' })],
+      treatment: TargetTreatment.Include,
+    };
+    const context = dsMockUtils.getContextInstance();
+    let targetIdentities = dsMockUtils.createMockTargetIdentities({
+      identities: ['someDid'],
+      treatment: 'Include',
+    });
+
+    let result = targetIdentitiesToCorporateActionTargets(targetIdentities, context);
+    expect(result).toEqual(fakeResult);
+
+    fakeResult.treatment = TargetTreatment.Exclude;
+    targetIdentities = dsMockUtils.createMockTargetIdentities({
+      identities: ['someDid'],
+      treatment: 'Exclude',
+    });
+
+    result = targetIdentitiesToCorporateActionTargets(targetIdentities, context);
     expect(result).toEqual(fakeResult);
   });
 });

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -2816,6 +2816,23 @@ export function scopeClaimProofToMeshScopeClaimProof(
 /**
  * @hidden
  */
+export function targetIdentitiesToCorporateActionTargets(
+  targetIdentities: TargetIdentities,
+  context: Context
+): CorporateActionTargets {
+  const { identities, treatment } = targetIdentities;
+
+  return {
+    identities: identities.map(
+      identity => new Identity({ did: identityIdToString(identity) }, context)
+    ),
+    treatment: treatment.isInclude ? TargetTreatment.Include : TargetTreatment.Exclude,
+  };
+}
+
+/**
+ * @hidden
+ */
 export function targetsToTargetIdentities(
   targets: Omit<CorporateActionTargets, 'identities'> & {
     identities: (string | Identity)[];


### PR DESCRIPTION
Returns the default CA targets, base tax withholding percentage and per-identity tax withholding
percentages for the ST