### PR TITLE
feat(corporate actions): add `setDefaults` to the namespace

### DIFF
--- a/src/api/entities/CorporateAction/types.ts
+++ b/src/api/entities/CorporateAction/types.ts
@@ -17,6 +17,14 @@ export interface TaxWithholding {
   percentage: BigNumber;
 }
 
+export type InputTargets = Omit<CorporateActionTargets, 'identities'> & {
+  identities: (string | Identity)[];
+};
+
+export type InputTaxWithholding = Omit<TaxWithholding, 'identity'> & {
+  identity: string | Identity;
+};
+
 export enum CorporateActionKind {
   PredictableBenefit = 'PredictableBenefit',
   UnpredictableBenefit = 'UnpredictableBenefit',

--- a/src/api/entities/SecurityToken/CorporateActions/__tests__/index.ts
+++ b/src/api/entities/SecurityToken/CorporateActions/__tests__/index.ts
@@ -63,7 +63,43 @@ describe('CorporateActions class', () => {
     expect(CorporateActions.prototype instanceof Namespace).toBe(true);
   });
 
-  describe('method: modifyCorporateActionAgent', () => {
+  describe('method: setDefaults', () => {
+    test('should prepare the procedure with the correct arguments and context, and return the resulting transaction queue', async () => {
+      const targets = {
+        identities: ['someDid'],
+        treatment: TargetTreatment.Exclude,
+      };
+      const defaultTaxWithholding = new BigNumber(15);
+      const taxWithholdings = [
+        {
+          identity: 'someDid',
+          percentage: new BigNumber(20),
+        },
+      ];
+      const expectedQueue = ('someQueue' as unknown) as TransactionQueue<void>;
+
+      procedureMockUtils
+        .getPrepareStub()
+        .withArgs(
+          {
+            args: { ticker: 'SOME_TICKER', targets, taxWithholdings, defaultTaxWithholding },
+            transformer: undefined,
+          },
+          context
+        )
+        .resolves(expectedQueue);
+
+      const queue = await corporateActions.setDefaults({
+        targets,
+        taxWithholdings,
+        defaultTaxWithholding,
+      });
+
+      expect(queue).toBe(expectedQueue);
+    });
+  });
+
+  describe('method: setAgent', () => {
     test('should prepare the procedure and return the resulting transaction queue', async () => {
       const target = 'someDid';
 

--- a/src/api/entities/SecurityToken/CorporateActions/index.ts
+++ b/src/api/entities/SecurityToken/CorporateActions/index.ts
@@ -6,6 +6,8 @@ import { IdentityId, TargetIdentities, Tax } from 'polymesh-types/types';
 import {
   Context,
   Identity,
+  modifyCaDefaults,
+  ModifyCaDefaultsParams,
   modifyCorporateActionsAgent,
   ModifyCorporateActionsAgentParams,
   Namespace,
@@ -40,6 +42,11 @@ export class CorporateActions extends Namespace<SecurityToken> {
 
     this.distributions = new Distributions(parent, context);
 
+    this.setDefaults = createProcedureMethod(
+      { getProcedureAndArgs: args => [modifyCaDefaults, { ticker, ...args }] },
+      context
+    );
+
     this.setAgent = createProcedureMethod(
       { getProcedureAndArgs: args => [modifyCorporateActionsAgent, { ticker, ...args }] },
       context
@@ -50,6 +57,16 @@ export class CorporateActions extends Namespace<SecurityToken> {
       context
     );
   }
+
+  /**
+   * Assign default values for targets, global tax withholding percentage and per-identity tax withholding perecentages.
+   *
+   *
+   * @note These values are applied to every Corporate Action that is created until they are modified. Modifying these values
+   *   does not impact existing Corporate Actions.
+   *   When creating a Corporate Action, values passed explicitly will override these defaults
+   */
+  public setDefaults: ProcedureMethod<ModifyCaDefaultsParams, void>;
 
   /**
    * Assign a new Corporate Actions Agent for the Security Token
@@ -107,8 +124,9 @@ export class CorporateActions extends Namespace<SecurityToken> {
    * Retrieve default values for targets, global tax withholding percentage and per-identity tax withholding perecentages.
    *
    *
-   * @note These values are applied to every Corporate Action that is created while they are set.
-   *   They can be overriden by passing them explicitly when creating a Corporate Action
+   * @note These values are applied to every Corporate Action that is created until they are modified. Modifying these values
+   *   does not impact existing Corporate Actions.
+   *   When creating a Corporate Action, values passed explicitly will override these defaults
    */
   public async getDefaults(): Promise<CorporateActionDefaults> {
     const {

--- a/src/api/procedures/__tests__/modifyCaDefaults.ts
+++ b/src/api/procedures/__tests__/modifyCaDefaults.ts
@@ -1,0 +1,308 @@
+import BigNumber from 'bignumber.js';
+import { Ticker, TxTags } from 'polymesh-types/types';
+import sinon from 'sinon';
+
+import {
+  getAuthorization,
+  Params,
+  prepareModifyCaDefaults,
+} from '~/api/procedures/modifyCaDefaults';
+import { Context } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
+import { RoleType, TargetTreatment } from '~/types';
+import * as utilsConversionModule from '~/utils/conversion';
+
+jest.mock(
+  '~/api/entities/SecurityToken',
+  require('~/testUtils/mocks/entities').mockSecurityTokenModule('~/api/entities/SecurityToken')
+);
+
+describe('modifyCaDefaults procedure', () => {
+  let mockContext: Mocked<Context>;
+  let stringToTickerStub: sinon.SinonStub;
+  let targetsToTargetIdentitiesStub: sinon.SinonStub;
+  let percentageToPermillStub: sinon.SinonStub;
+  let stringToIdentityIdStub: sinon.SinonStub;
+  let ticker: string;
+  let rawTicker: Ticker;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+    entityMockUtils.initMocks();
+    stringToTickerStub = sinon.stub(utilsConversionModule, 'stringToTicker');
+    targetsToTargetIdentitiesStub = sinon.stub(utilsConversionModule, 'targetsToTargetIdentities');
+    percentageToPermillStub = sinon.stub(utilsConversionModule, 'percentageToPermill');
+    stringToIdentityIdStub = sinon.stub(utilsConversionModule, 'stringToIdentityId');
+    ticker = 'someTicker';
+    rawTicker = dsMockUtils.createMockTicker(ticker);
+  });
+
+  let addTransactionStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    addTransactionStub = procedureMockUtils.getAddTransactionStub();
+    mockContext = dsMockUtils.getContextInstance();
+    stringToTickerStub.withArgs(ticker, mockContext).returns(rawTicker);
+  });
+
+  afterEach(() => {
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+    dsMockUtils.reset();
+  });
+
+  afterAll(() => {
+    entityMockUtils.cleanup();
+    procedureMockUtils.cleanup();
+    dsMockUtils.cleanup();
+  });
+
+  test('should throw an error if the user has not passed any arguments', () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    return expect(prepareModifyCaDefaults.call(proc, ({} as unknown) as Params)).rejects.toThrow(
+      'Nothing to modify'
+    );
+  });
+
+  test('should throw an error if the new targets are the same as the current ones', () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    const targets = {
+      identities: [],
+      treatment: TargetTreatment.Exclude,
+    };
+    entityMockUtils.configureMocks({
+      securityTokenOptions: { corporateActionsGetDefaults: { targets } },
+    });
+
+    return expect(
+      prepareModifyCaDefaults.call(proc, {
+        ticker,
+        targets,
+      })
+    ).rejects.toThrow('New targets are the same as the current ones');
+  });
+
+  test('should throw an error if the new default tax withholding is the same as the current one', () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    const defaultTaxWithholding = new BigNumber(10);
+    entityMockUtils.configureMocks({
+      securityTokenOptions: { corporateActionsGetDefaults: { defaultTaxWithholding } },
+    });
+
+    return expect(
+      prepareModifyCaDefaults.call(proc, {
+        ticker,
+        defaultTaxWithholding,
+      })
+    ).rejects.toThrow('New default tax withholding is the same as the current one');
+  });
+
+  test('should throw an error if the new tax withholdings are the same as the current ones', () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    const taxWithholdings = [
+      {
+        identity: entityMockUtils.getIdentityInstance({ did: 'someDid' }),
+        percentage: new BigNumber(15),
+      },
+    ];
+    entityMockUtils.configureMocks({
+      securityTokenOptions: { corporateActionsGetDefaults: { taxWithholdings } },
+    });
+
+    return expect(
+      prepareModifyCaDefaults.call(proc, {
+        ticker,
+        taxWithholdings,
+      })
+    ).rejects.toThrow('New per-Identity tax withholding percentages are the same as current ones');
+  });
+
+  test('should add a set default targets transaction to the queue', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    const transaction = dsMockUtils.createTxStub('corporateAction', 'setDefaultTargets');
+
+    entityMockUtils.configureMocks({
+      securityTokenOptions: {
+        corporateActionsGetDefaults: {
+          targets: {
+            identities: [entityMockUtils.getIdentityInstance({ did: 'someDid' })],
+            treatment: TargetTreatment.Include,
+          },
+        },
+      },
+    });
+
+    let rawTargets = dsMockUtils.createMockTargetIdentities({
+      identities: [],
+      treatment: 'Exclude',
+    });
+    targetsToTargetIdentitiesStub
+      .withArgs(
+        {
+          identities: [],
+          treatment: TargetTreatment.Exclude,
+        },
+        mockContext
+      )
+      .returns(rawTargets);
+
+    await prepareModifyCaDefaults.call(proc, {
+      ticker,
+      targets: {
+        identities: [],
+        treatment: TargetTreatment.Exclude,
+      },
+    });
+
+    sinon.assert.calledWith(
+      addTransactionStub,
+      transaction,
+      sinon.match({}),
+      rawTicker,
+      rawTargets
+    );
+
+    rawTargets = dsMockUtils.createMockTargetIdentities({
+      identities: ['someDid', 'otherDid'],
+      treatment: 'Exclude',
+    });
+    targetsToTargetIdentitiesStub
+      .withArgs(
+        {
+          identities: ['someDid', 'otherDid'],
+          treatment: TargetTreatment.Exclude,
+        },
+        mockContext
+      )
+      .returns(rawTargets);
+
+    await prepareModifyCaDefaults.call(proc, {
+      ticker,
+      targets: {
+        identities: ['someDid', 'otherDid'],
+        treatment: TargetTreatment.Exclude,
+      },
+    });
+
+    sinon.assert.calledWith(
+      addTransactionStub,
+      transaction,
+      sinon.match({}),
+      rawTicker,
+      rawTargets
+    );
+  });
+
+  test('should add a set default withholding tax transaction to the queue', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    const transaction = dsMockUtils.createTxStub('corporateAction', 'setDefaultWithholdingTax');
+
+    entityMockUtils.configureMocks({
+      securityTokenOptions: {
+        corporateActionsGetDefaults: {
+          defaultTaxWithholding: new BigNumber(10),
+        },
+      },
+    });
+
+    const rawPercentage = dsMockUtils.createMockPermill(150000);
+    percentageToPermillStub.withArgs(new BigNumber(15), mockContext).returns(rawPercentage);
+
+    await prepareModifyCaDefaults.call(proc, {
+      ticker,
+      defaultTaxWithholding: new BigNumber(15),
+    });
+
+    sinon.assert.calledWith(
+      addTransactionStub,
+      transaction,
+      sinon.match({}),
+      rawTicker,
+      rawPercentage
+    );
+  });
+
+  test('should add a batch of set did withholding tax transactions to the queue', async () => {
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    const transaction = dsMockUtils.createTxStub('corporateAction', 'setDidWithholdingTax');
+
+    entityMockUtils.configureMocks({
+      securityTokenOptions: {
+        corporateActionsGetDefaults: {
+          taxWithholdings: [],
+        },
+      },
+    });
+
+    const rawDid = dsMockUtils.createMockIdentityId('someDid');
+    const rawPercentage = dsMockUtils.createMockPermill(250000);
+
+    stringToIdentityIdStub.withArgs('someDid', mockContext).returns(rawDid);
+    percentageToPermillStub.withArgs(new BigNumber(25), mockContext).returns(rawPercentage);
+
+    await prepareModifyCaDefaults.call(proc, {
+      ticker,
+      taxWithholdings: [
+        {
+          identity: 'someDid',
+          percentage: new BigNumber(25),
+        },
+      ],
+    });
+
+    sinon.assert.calledWith(
+      procedureMockUtils.getAddBatchTransactionStub(),
+      transaction,
+      sinon.match({}),
+      [[rawTicker, rawDid, rawPercentage]]
+    );
+  });
+
+  describe('getAuthorization', () => {
+    test('should return the appropriate roles and permissions', () => {
+      const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+      const boundFunc = getAuthorization.bind(proc);
+      const args = {
+        ticker,
+      } as Params;
+
+      expect(boundFunc(args)).toEqual({
+        identityRoles: [{ type: RoleType.TokenCaa, ticker }],
+        signerPermissions: {
+          transactions: [],
+          portfolios: [],
+          tokens: [entityMockUtils.getSecurityTokenInstance({ ticker })],
+        },
+      });
+
+      expect(
+        boundFunc({
+          ...args,
+          targets: { identities: [], treatment: TargetTreatment.Include },
+          defaultTaxWithholding: new BigNumber(10),
+          taxWithholdings: [],
+        })
+      ).toEqual({
+        identityRoles: [{ type: RoleType.TokenCaa, ticker }],
+        signerPermissions: {
+          transactions: [
+            TxTags.corporateAction.SetDefaultTargets,
+            TxTags.corporateAction.SetDefaultWithholdingTax,
+            TxTags.corporateAction.SetDidWithholdingTax,
+          ],
+          portfolios: [],
+          tokens: [entityMockUtils.getSecurityTokenInstance({ ticker })],
+        },
+      });
+    });
+  });
+});

--- a/src/api/procedures/modifyCaDefaults.ts
+++ b/src/api/procedures/modifyCaDefaults.ts
@@ -1,8 +1,9 @@
 import BigNumber from 'bignumber.js';
 import { differenceWith } from 'lodash';
 
-import { Identity, PolymeshError, Procedure, SecurityToken } from '~/internal';
-import { CorporateActionTargets, ErrorCode, RoleType, TaxWithholding, TxTags } from '~/types';
+import { assertCaTargetsValid, assertCaTaxWithholdingsValid } from '~/api/procedures/utils';
+import { PolymeshError, Procedure, SecurityToken } from '~/internal';
+import { ErrorCode, InputTargets, InputTaxWithholding, RoleType, TxTags } from '~/types';
 import { ProcedureAuthorization } from '~/types/internal';
 import { tuple } from '~/types/utils';
 import {
@@ -12,14 +13,6 @@ import {
   stringToTicker,
   targetsToTargetIdentities,
 } from '~/utils/conversion';
-
-export type InputTargets = Omit<CorporateActionTargets, 'identities'> & {
-  identities: (string | Identity)[];
-};
-
-export type InputTaxWithholding = Omit<TaxWithholding, 'identity'> & {
-  identity: string | Identity;
-};
 
 export type ModifyCaDefaultsParams =
   | {
@@ -73,6 +66,13 @@ export async function prepareModifyCaDefaults(
       code: ErrorCode.ValidationError,
       message: 'Nothing to modify',
     });
+  }
+
+  if (newTargets) {
+    assertCaTargetsValid(newTargets, context);
+  }
+  if (newTaxWithholdings) {
+    assertCaTaxWithholdingsValid(newTaxWithholdings, context);
   }
 
   const rawTicker = stringToTicker(ticker, context);

--- a/src/api/procedures/modifyCaDefaults.ts
+++ b/src/api/procedures/modifyCaDefaults.ts
@@ -1,0 +1,194 @@
+import BigNumber from 'bignumber.js';
+import { differenceWith } from 'lodash';
+
+import { Identity, PolymeshError, Procedure, SecurityToken } from '~/internal';
+import { CorporateActionTargets, ErrorCode, RoleType, TaxWithholding, TxTags } from '~/types';
+import { ProcedureAuthorization } from '~/types/internal';
+import { tuple } from '~/types/utils';
+import {
+  percentageToPermill,
+  signerToString,
+  stringToIdentityId,
+  stringToTicker,
+  targetsToTargetIdentities,
+} from '~/utils/conversion';
+
+export type InputTargets = Omit<CorporateActionTargets, 'identities'> & {
+  identities: (string | Identity)[];
+};
+
+export type InputTaxWithholding = Omit<TaxWithholding, 'identity'> & {
+  identity: string | Identity;
+};
+
+export type ModifyCaDefaultsParams =
+  | {
+      targets?: InputTargets;
+      defaultTaxWithholding: BigNumber;
+      taxWithholdings?: InputTaxWithholding[];
+    }
+  | {
+      targets: InputTargets;
+      defaultTaxWithholding?: BigNumber;
+      taxWithholdings?: InputTaxWithholding[];
+    }
+  | {
+      targets?: InputTargets;
+      defaultTaxWithholding?: BigNumber;
+      taxWithholdings: InputTaxWithholding[];
+    };
+
+/**
+ * @hidden
+ */
+export type Params = { ticker: string } & ModifyCaDefaultsParams;
+
+/**
+ * @hidden
+ */
+export async function prepareModifyCaDefaults(
+  this: Procedure<Params, void>,
+  args: Params
+): Promise<void> {
+  const {
+    context: {
+      polymeshApi: { tx },
+    },
+    context,
+  } = this;
+  const {
+    ticker,
+    targets: newTargets,
+    defaultTaxWithholding: newDefaultTaxWithholding,
+    taxWithholdings: newTaxWithholdings,
+  } = args;
+
+  const noArguments =
+    newTargets === undefined &&
+    newDefaultTaxWithholding === undefined &&
+    newTaxWithholdings === undefined;
+
+  if (noArguments) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'Nothing to modify',
+    });
+  }
+
+  const rawTicker = stringToTicker(ticker, context);
+
+  const securityToken = new SecurityToken({ ticker }, context);
+
+  const {
+    targets,
+    defaultTaxWithholding,
+    taxWithholdings,
+  } = await securityToken.corporateActions.getDefaults();
+
+  if (newTargets) {
+    const { identities: newIdentities, treatment: newTreatment } = newTargets;
+    const { identities, treatment } = targets;
+
+    const areSameTargets =
+      !differenceWith(
+        identities,
+        newIdentities,
+        ({ did }, newIdentity) => did === signerToString(newIdentity)
+      ).length &&
+      identities.length === newIdentities.length &&
+      treatment === newTreatment;
+    if (areSameTargets) {
+      throw new PolymeshError({
+        code: ErrorCode.ValidationError,
+        message: 'New targets are the same as the current ones',
+      });
+    }
+
+    this.addTransaction(
+      tx.corporateAction.setDefaultTargets,
+      {},
+      rawTicker,
+      targetsToTargetIdentities(newTargets, context)
+    );
+  }
+
+  if (newDefaultTaxWithholding) {
+    if (newDefaultTaxWithholding.eq(defaultTaxWithholding)) {
+      throw new PolymeshError({
+        code: ErrorCode.ValidationError,
+        message: 'New default tax withholding is the same as the current one',
+      });
+    }
+
+    this.addTransaction(
+      tx.corporateAction.setDefaultWithholdingTax,
+      {},
+      rawTicker,
+      percentageToPermill(newDefaultTaxWithholding, context)
+    );
+  }
+
+  if (newTaxWithholdings) {
+    const areSameWithholdings =
+      !differenceWith(
+        taxWithholdings,
+        newTaxWithholdings,
+        ({ identity: { did }, percentage }, { identity: newIdentity, percentage: newPercentage }) =>
+          did === signerToString(newIdentity) && percentage.eq(newPercentage)
+      ).length && taxWithholdings.length === newTaxWithholdings.length;
+
+    if (areSameWithholdings) {
+      throw new PolymeshError({
+        code: ErrorCode.ValidationError,
+        message: 'New per-Identity tax withholding percentages are the same as current ones',
+      });
+    }
+
+    const batchParams = newTaxWithholdings.map(({ identity, percentage }) =>
+      tuple(
+        rawTicker,
+        stringToIdentityId(signerToString(identity), context),
+        percentageToPermill(percentage, context)
+      )
+    );
+
+    this.addBatchTransaction(tx.corporateAction.setDidWithholdingTax, {}, batchParams);
+  }
+}
+
+/**
+ * @hidden
+ */
+export function getAuthorization(
+  this: Procedure<Params, void>,
+  { ticker, targets, defaultTaxWithholding, taxWithholdings }: Params
+): ProcedureAuthorization {
+  const transactions = [];
+
+  if (targets) {
+    transactions.push(TxTags.corporateAction.SetDefaultTargets);
+  }
+
+  if (defaultTaxWithholding) {
+    transactions.push(TxTags.corporateAction.SetDefaultWithholdingTax);
+  }
+
+  if (taxWithholdings) {
+    transactions.push(TxTags.corporateAction.SetDidWithholdingTax);
+  }
+
+  return {
+    identityRoles: [{ type: RoleType.TokenCaa, ticker }],
+    signerPermissions: {
+      transactions,
+      portfolios: [],
+      tokens: [new SecurityToken({ ticker }, this.context)],
+    },
+  };
+}
+
+/**
+ * @hidden
+ */
+export const modifyCaDefaults = (): Procedure<Params, void> =>
+  new Procedure(prepareModifyCaDefaults, getAuthorization);

--- a/src/api/procedures/utils.ts
+++ b/src/api/procedures/utils.ts
@@ -1,9 +1,16 @@
 // import BigNumber from 'bignumber.js';
 
 import { Context, Instruction, NumberedPortfolio, PolymeshError } from '~/internal';
-import { ErrorCode, InstructionStatus, InstructionType, SecondaryKey } from '~/types';
+import {
+  ErrorCode,
+  InputTargets,
+  InputTaxWithholding,
+  InstructionStatus,
+  InstructionType,
+  SecondaryKey,
+} from '~/types';
 import { PortfolioId, SignerValue } from '~/types/internal';
-import { signerToSignerValue } from '~/utils/conversion';
+import { signerToSignerValue, u64ToBigNumber } from '~/utils/conversion';
 
 // import { Proposal } from '~/internal';
 // import { ProposalStage, ProposalState } from '~/api/entities/Proposal/types';
@@ -143,6 +150,47 @@ export function assertDistributionOpen(paymentDate: Date, expiryDate: Date | nul
       message: 'The Distribution has already expired',
       data: {
         expiryDate,
+      },
+    });
+  }
+}
+
+/**
+ * @hidden
+ */
+export function assertCaTargetsValid(targets: InputTargets, context: Context): void {
+  const { maxTargetIds } = context.polymeshApi.consts.corporateAction;
+
+  const maxTargets = u64ToBigNumber(maxTargetIds);
+
+  if (maxTargets.lt(targets.identities.length)) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'Too many target Identities',
+      data: {
+        maxTargets,
+      },
+    });
+  }
+}
+
+/**
+ * @hidden
+ */
+export function assertCaTaxWithholdingsValid(
+  taxWithholdings: InputTaxWithholding[],
+  context: Context
+): void {
+  const { maxDidWhts } = context.polymeshApi.consts.corporateAction;
+
+  const maxWithholdingEntries = u64ToBigNumber(maxDidWhts);
+
+  if (maxWithholdingEntries.lt(taxWithholdings.length)) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'Too many tax withholding emties',
+      data: {
+        maxWithholdingEntries,
       },
     });
   }

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -153,3 +153,4 @@ export {
 export { claimDividends } from '~/api/procedures/claimDividends';
 export { removeCorporateActionsAgent } from '~/api/procedures/removeCorporateActionsAgent';
 export { payDividends, PayDividendsParams } from '~/api/procedures/payDividends';
+export { modifyCaDefaults, ModifyCaDefaultsParams } from '~/api/procedures/modifyCaDefaults';

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -33,6 +33,7 @@ import {
   AuthorizationType,
   CalendarPeriod,
   CalendarUnit,
+  CorporateActionDefaults,
   CorporateActionKind,
   CorporateActionTargets,
   CountTransferRestriction,
@@ -136,6 +137,7 @@ interface SecurityTokenOptions {
   transferRestrictionsCountGet?: ActiveTransferRestrictions<CountTransferRestriction>;
   transferRestrictionsPercentageGet?: ActiveTransferRestrictions<PercentageTransferRestriction>;
   corporateActionsGetAgent?: Identity;
+  corporateActionsGetDefaults?: Partial<CorporateActionDefaults>;
 }
 
 interface AuthorizationRequestOptions {
@@ -274,6 +276,7 @@ let securityTokenGetIdentifiersStub: SinonStub;
 let securityTokenTransferRestrictionsCountGetStub: SinonStub;
 let securityTokenTransferRestrictionsPercentageGetStub: SinonStub;
 let securityTokenCorporateActionsGetAgentStub: SinonStub;
+let securityTokenCorporateActionsGetDefaultsStub: SinonStub;
 let identityHasRolesStub: SinonStub;
 let identityHasRoleStub: SinonStub;
 let identityHasValidCddStub: SinonStub;
@@ -628,6 +631,11 @@ const defaultSecurityTokenOptions: SecurityTokenOptions = {
     availableSlots: 3,
   },
   corporateActionsGetAgent: { did: 'someDid' } as Identity,
+  corporateActionsGetDefaults: {
+    targets: { identities: [], treatment: TargetTreatment.Exclude },
+    defaultTaxWithholding: new BigNumber(10),
+    taxWithholdings: [],
+  },
 };
 let securityTokenOptions = defaultSecurityTokenOptions;
 const defaultAuthorizationRequestOptions: AuthorizationRequestOptions = {
@@ -1003,6 +1011,9 @@ function configureSecurityToken(opts: SecurityTokenOptions): void {
     },
     corporateActions: {
       getAgent: securityTokenCorporateActionsGetAgentStub.resolves(opts.corporateActionsGetAgent),
+      getDefaults: securityTokenCorporateActionsGetDefaultsStub.resolves(
+        opts.corporateActionsGetDefaults
+      ),
     },
   } as unknown) as MockSecurityToken;
 
@@ -1028,6 +1039,7 @@ function initSecurityToken(opts?: SecurityTokenOptions): void {
   securityTokenTransferRestrictionsCountGetStub = sinon.stub();
   securityTokenTransferRestrictionsPercentageGetStub = sinon.stub();
   securityTokenCorporateActionsGetAgentStub = sinon.stub();
+  securityTokenCorporateActionsGetDefaultsStub = sinon.stub();
 
   securityTokenOptions = merge({}, defaultSecurityTokenOptions, opts);
 
@@ -2130,6 +2142,20 @@ export function getSecurityTokenCorporateActionsGetAgentStub(agent?: Identity): 
   }
 
   return securityTokenCorporateActionsGetAgentStub;
+}
+
+/**
+ * @hidden
+ * Retrieve the stub of the `SecurityToken.corporateActions.getDefaults` method
+ */
+export function getSecurityTokenCorporateActionsGetDefaultsStub(
+  defaults?: Partial<CorporateActionDefaults>
+): SinonStub {
+  if (defaults) {
+    return securityTokenCorporateActionsGetDefaultsStub.resolves(defaults);
+  }
+
+  return securityTokenCorporateActionsGetDefaultsStub;
 }
 
 /**


### PR DESCRIPTION
Allows to set default targets, global tax withholding % and per-identity tax withholding %