### PR TITLE
feat(client): add the `disconnect` method

### DIFF
--- a/src/Polymesh.ts
+++ b/src/Polymesh.ts
@@ -645,6 +645,17 @@ export class Polymesh {
     return this.context.getLatestBlock();
   }
 
+  /**
+   * Disconnect the client and close all open connections and subscriptions
+   *
+   * @note the SDK will become unusable after this operation. It will throw an error when attempting to
+   *   access any chain or middleware data. If you wish to continue using the SDK, you must
+   *   create a new instance by calling [[connect]]
+   */
+  public disconnect(): Promise<void> {
+    return this.context.disconnect();
+  }
+
   // TODO @monitz87: remove when the dApp team no longer needs it
   /* istanbul ignore next: only for testing purposes */
   /**

--- a/src/__tests__/Polymesh.ts
+++ b/src/__tests__/Polymesh.ts
@@ -1078,4 +1078,20 @@ describe('Polymesh Class', () => {
       expect(result).toEqual(blockNumber);
     });
   });
+
+  describe('method: disconnect', () => {
+    test('should call the underlying disconnect function', async () => {
+      const polymesh = await Polymesh.connect({
+        nodeUrl: 'wss://some.url',
+        accountUri: '//uri',
+        middleware: {
+          link: 'someLink',
+          key: 'someKey',
+        },
+      });
+
+      await polymesh.disconnect();
+      sinon.assert.calledOnce(dsMockUtils.getContextInstance().disconnect);
+    });
+  });
 });

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -167,7 +167,17 @@ function createApi(): Mutable<ApiPromise> & EventEmitter {
     off: (event: string, listener: (...args: unknown[]) => unknown) =>
       apiEmitter.off(event, listener),
     setSigner: sinon.stub() as (signer: Signer) => void,
+    disconnect: sinon.stub() as () => Promise<void>,
   } as Mutable<ApiPromise> & EventEmitter;
+}
+
+/**
+ * Create a mock instance of the Apollo client
+ */
+function createApolloClient(): Mutable<ApolloClient<NormalizedCacheObject>> {
+  return ({
+    stop: sinon.stub(),
+  } as unknown) as Mutable<ApolloClient<NormalizedCacheObject>>;
 }
 
 let apolloConstructorStub: SinonStub;
@@ -185,7 +195,7 @@ const mockInstanceContainer = {
   contextInstance: {} as MockContext,
   apiInstance: createApi(),
   keyringInstance: {} as Mutable<Keyring>,
-  apolloInstance: {} as ApolloClient<NormalizedCacheObject>,
+  apolloInstance: createApolloClient(),
 };
 
 let apiPromiseCreateStub: SinonStub;
@@ -613,6 +623,7 @@ function configureContext(opts: ContextOptions): void {
     isMiddlewareAvailable: sinon.stub().resolves(opts.middlewareAvailable),
     isArchiveNode: opts.isArchiveNode,
     ss58Format: opts.ss58Format,
+    disconnect: sinon.stub(),
   } as unknown) as MockContext;
 
   Object.assign(mockInstanceContainer.contextInstance, contextInstance);
@@ -856,7 +867,7 @@ export function cleanup(): void {
   mockInstanceContainer.apiInstance = createApi();
   mockInstanceContainer.contextInstance = {} as MockContext;
   mockInstanceContainer.keyringInstance = {} as Mutable<Keyring>;
-  mockInstanceContainer.apolloInstance = {} as ApolloClient<NormalizedCacheObject>;
+  mockInstanceContainer.apolloInstance = createApolloClient();
 }
 
 /**
@@ -1206,8 +1217,10 @@ export function getApiInstance(): ApiPromise & SinonStubbedInstance<ApiPromise> 
  * @hidden
  * Retrieve an instance of the mocked Apollo Client
  */
-export function getMiddlewareApi(): ApolloClient<NormalizedCacheObject> {
-  return mockInstanceContainer.apolloInstance;
+export function getMiddlewareApi(): ApolloClient<NormalizedCacheObject> &
+  SinonStubbedInstance<ApolloClient<NormalizedCacheObject>> {
+  return mockInstanceContainer.apolloInstance as ApolloClient<NormalizedCacheObject> &
+    SinonStubbedInstance<ApolloClient<NormalizedCacheObject>>;
 }
 
 /**


### PR DESCRIPTION
This method closes the connection with the middleware and chain. The client is then flagged as
disconnected and throws errors if attempting to do anything with it