### PR TITLE
feat(securitytoken): add `fullAgents` property to SecurityToken details

### DIFF
--- a/src/api/entities/Identity/__tests__/index.ts
+++ b/src/api/entities/Identity/__tests__/index.ts
@@ -332,6 +332,20 @@ describe('Identity class', () => {
       hasRole = await identity.hasRole(role);
 
       expect(hasRole).toBe(false);
+
+      entityMockUtils.reset();
+      entityMockUtils.configureMocks({
+        securityTokenOptions: {
+          details: {
+            primaryIssuanceAgents: [new Identity({ did: 'anotherDid' }, context)],
+            fullAgents: [identity],
+          },
+        },
+      });
+
+      hasRole = await identity.hasRole(role);
+
+      expect(hasRole).toBe(true);
     });
 
     test('hasRole should check whether the Identity has the Token CAA role', async () => {
@@ -357,6 +371,19 @@ describe('Identity class', () => {
       hasRole = await identity.hasRole(role);
 
       expect(hasRole).toBe(false);
+
+      entityMockUtils.configureMocks({
+        securityTokenOptions: {
+          corporateActionsGetAgents: [new Identity({ did: 'otherdid' }, context)],
+          details: {
+            fullAgents: [identity],
+          },
+        },
+      });
+
+      hasRole = await identity.hasRole(role);
+
+      expect(hasRole).toBe(true);
     });
 
     test('hasRole should check whether the Identity has the CDD Provider role', async () => {

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -250,16 +250,23 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
       const { ticker } = role;
 
       const token = new SecurityToken({ ticker }, context);
-      const { primaryIssuanceAgents } = await token.details();
+      const { primaryIssuanceAgents, fullAgents } = await token.details();
 
-      return !!primaryIssuanceAgents.find(({ did: agentDid }) => agentDid === did);
+      return (
+        !!fullAgents.find(({ did: agentDid }) => agentDid === did) ||
+        !!primaryIssuanceAgents.find(({ did: agentDid }) => agentDid === did)
+      );
     } else if (isTokenCaaRole(role)) {
       const { ticker } = role;
 
       const token = new SecurityToken({ ticker }, context);
+      const { fullAgents } = await token.details();
       const agents = await token.corporateActions.getAgents();
 
-      return !!agents.find(({ did: agentDid }) => agentDid === did);
+      return (
+        !!fullAgents.find(({ did: agentDid }) => agentDid === did) ||
+        !!agents.find(({ did: agentDid }) => agentDid === did)
+      );
     } else if (isCddProviderRole(role)) {
       const {
         polymeshApi: {

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -260,8 +260,11 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
       const { ticker } = role;
 
       const token = new SecurityToken({ ticker }, context);
-      const { fullAgents } = await token.details();
-      const agents = await token.corporateActions.getAgents();
+
+      const [{ fullAgents }, agents] = await Promise.all([
+        token.details(),
+        token.corporateActions.getAgents(),
+      ]);
 
       return (
         !!fullAgents.find(({ did: agentDid }) => agentDid === did) ||

--- a/src/api/entities/SecurityToken/__tests__/index.ts
+++ b/src/api/entities/SecurityToken/__tests__/index.ts
@@ -110,6 +110,14 @@ describe('SecurityToken class', () => {
             [dsMockUtils.createMockTicker(ticker), dsMockUtils.createMockIdentityId(did)],
             dsMockUtils.createMockOption(dsMockUtils.createMockAgentGroup('PolymeshV1Pia'))
           ),
+          tuple(
+            [dsMockUtils.createMockTicker(ticker), dsMockUtils.createMockIdentityId(owner)],
+            dsMockUtils.createMockOption(dsMockUtils.createMockAgentGroup('Full'))
+          ),
+          tuple(
+            [dsMockUtils.createMockTicker(ticker), dsMockUtils.createMockIdentityId(did)],
+            dsMockUtils.createMockOption(dsMockUtils.createMockAgentGroup('ExceptMeta'))
+          ),
         ],
       });
     });
@@ -129,6 +137,7 @@ describe('SecurityToken class', () => {
       expect(details.owner.did).toBe(owner);
       expect(details.assetType).toBe(assetType);
       expect(details.primaryIssuanceAgents).toEqual([entityMockUtils.getIdentityInstance({ did })]);
+      expect(details.fullAgents).toEqual([entityMockUtils.getIdentityInstance({ did: owner })]);
 
       dsMockUtils.createQueryStub('externalAgents', 'groupOfAgent', {
         entries: [
@@ -141,6 +150,7 @@ describe('SecurityToken class', () => {
 
       details = await securityToken.details();
       expect(details.primaryIssuanceAgents).toEqual([]);
+      expect(details.fullAgents).toEqual([entityMockUtils.getIdentityInstance({ did })]);
     });
 
     test('should allow subscription', async () => {
@@ -167,6 +177,7 @@ describe('SecurityToken class', () => {
           owner: sinon.match({ did: owner }),
           totalSupply: new BigNumber(totalSupply).div(Math.pow(10, 6)),
           primaryIssuanceAgents: [entityMockUtils.getIdentityInstance({ did })],
+          fullAgents: [entityMockUtils.getIdentityInstance({ did: owner })],
         })
       );
     });

--- a/src/api/entities/SecurityToken/index.ts
+++ b/src/api/entities/SecurityToken/index.ts
@@ -215,6 +215,7 @@ export class SecurityToken extends Entity<UniqueIdentifiers, string> {
       agentGroups: [StorageKey<[Ticker, IdentityId]>, Option<AgentGroup>][]
     ): SecurityTokenDetails => {
       const primaryIssuanceAgents: Identity[] = [];
+      const fullAgents: Identity[] = [];
 
       agentGroups.forEach(([storageKey, agentGroup]) => {
         const rawAgentGroup = agentGroup.unwrap();
@@ -222,6 +223,8 @@ export class SecurityToken extends Entity<UniqueIdentifiers, string> {
           primaryIssuanceAgents.push(
             new Identity({ did: identityIdToString(storageKey.args[1]) }, context)
           );
+        } else if (rawAgentGroup.isFull) {
+          fullAgents.push(new Identity({ did: identityIdToString(storageKey.args[1]) }, context));
         }
       });
 
@@ -233,6 +236,7 @@ export class SecurityToken extends Entity<UniqueIdentifiers, string> {
         owner,
         totalSupply: balanceToBigNumber(total_supply),
         primaryIssuanceAgents,
+        fullAgents,
       };
     };
     /* eslint-enable @typescript-eslint/naming-convention */

--- a/src/api/entities/SecurityToken/types.ts
+++ b/src/api/entities/SecurityToken/types.ts
@@ -10,6 +10,7 @@ export interface SecurityTokenDetails {
   owner: Identity;
   totalSupply: BigNumber;
   primaryIssuanceAgents: Identity[];
+  fullAgents: Identity[];
 }
 
 /**

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -631,6 +631,7 @@ const defaultSecurityTokenOptions: SecurityTokenOptions = {
     totalSupply: new BigNumber(1000000),
     isDivisible: false,
     primaryIssuanceAgents: [],
+    fullAgents: [],
   },
   currentFundingRound: 'Series A',
   isFrozen: false,


### PR DESCRIPTION
Additionally `isTokenPIARole` checks if the Identity is a PIA or a FullAgent