### PR TITLE
fix(transfers): validate and pad memo length

### DIFF
--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -481,7 +481,7 @@ describe('portfolioMovementToMovePortfolioItem', () => {
 
     expect(result).toBe(fakeResult);
 
-    dsMockUtils.getCreateTypeStub().withArgs('Memo', memo).returns(rawMemo);
+    dsMockUtils.getCreateTypeStub().withArgs('Memo', padString(memo, 32)).returns(rawMemo);
 
     dsMockUtils
       .getCreateTypeStub()
@@ -1872,11 +1872,18 @@ describe('stringToMemo', () => {
     const fakeResult = ('memoDescription' as unknown) as Memo;
     const context = dsMockUtils.getContextInstance();
 
-    dsMockUtils.getCreateTypeStub().withArgs('Memo', value).returns(fakeResult);
+    dsMockUtils.getCreateTypeStub().withArgs('Memo', padString(value, 32)).returns(fakeResult);
 
     const result = stringToMemo(value, context);
 
     expect(result).toEqual(fakeResult);
+  });
+
+  test('stringToMemo should throw an error if the value exceeds the maximum length', () => {
+    const value = 'someVeryLongDescriptionThatIsDefinitelyLongerThanTheMaxLength';
+    const context = dsMockUtils.getContextInstance();
+
+    expect(() => stringToMemo(value, context)).toThrow('Max memo length exceeded');
   });
 });
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -9,6 +9,7 @@ import { TransactionArgumentType } from '~/types';
 export const MAX_DECIMALS = 6;
 export const MAX_TICKER_LENGTH = 12;
 export const MAX_MODULE_LENGTH = 32;
+export const MAX_MEMO_LENGTH = 32;
 /**
  * Biggest possible number for on-chain balances
  */

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -201,6 +201,7 @@ import {
   IGNORE_CHECKSUM,
   MAX_BALANCE,
   MAX_DECIMALS,
+  MAX_MEMO_LENGTH,
   MAX_MODULE_LENGTH,
   MAX_TICKER_LENGTH,
 } from '~/utils/constants';
@@ -1186,7 +1187,17 @@ export function balanceToBigNumber(balance: Balance): BigNumber {
  * @hidden
  */
 export function stringToMemo(value: string, context: Context): Memo {
-  return context.polymeshApi.createType('Memo', value);
+  if (value.length > MAX_MEMO_LENGTH) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'Max memo length exceeded',
+      data: {
+        maxLength: MAX_MEMO_LENGTH,
+      },
+    });
+  }
+
+  return context.polymeshApi.createType('Memo', padString(value, MAX_MEMO_LENGTH));
 }
 
 /**


### PR DESCRIPTION
BREAKING CHANGE: `api.transferPolyx` and `portfolio.moveFunds` now throw an error if the memo string
is longer than 32 characters