### PR TITLE
feat: support new custom asset type system

### DIFF
--- a/src/api/entities/SecurityToken/__tests__/index.ts
+++ b/src/api/entities/SecurityToken/__tests__/index.ts
@@ -124,7 +124,7 @@ describe('SecurityToken class', () => {
     });
 
     test('should return details for a security token', async () => {
-      dsMockUtils.createQueryStub('asset', 'tokens', {
+      const tokensStub = dsMockUtils.createQueryStub('asset', 'tokens', {
         returnValue: rawToken,
       });
 
@@ -152,6 +152,26 @@ describe('SecurityToken class', () => {
       details = await securityToken.details();
       expect(details.primaryIssuanceAgents).toEqual([]);
       expect(details.fullAgents).toEqual([entityMockUtils.getIdentityInstance({ did })]);
+
+      tokensStub.resolves(
+        dsMockUtils.createMockSecurityToken({
+          /* eslint-disable @typescript-eslint/naming-convention */
+          owner_did: dsMockUtils.createMockIdentityId(owner),
+          asset_type: dsMockUtils.createMockAssetType({ Custom: dsMockUtils.createMockU32(10) }),
+          divisible: dsMockUtils.createMockBool(isDivisible),
+          total_supply: dsMockUtils.createMockBalance(totalSupply),
+          /* eslint-enable @typescript-eslint/naming-convention */
+        })
+      );
+
+      const customType = 'something';
+
+      dsMockUtils.createQueryStub('asset', 'customTypes', {
+        returnValue: dsMockUtils.createMockBytes(customType),
+      });
+
+      details = await securityToken.details();
+      expect(details.assetType).toEqual(customType);
     });
 
     test('should allow subscription', async () => {

--- a/src/api/entities/SecurityToken/index.ts
+++ b/src/api/entities/SecurityToken/index.ts
@@ -1,6 +1,7 @@
-import { Option, StorageKey } from '@polkadot/types';
+import { bool, Option, StorageKey } from '@polkadot/types';
 import {
   AgentGroup,
+  AssetName,
   Counter,
   IdentityId,
   SecurityToken as MeshSecurityToken,
@@ -46,6 +47,7 @@ import {
   middlewareEventToEventIdentifier,
   numberToU32,
   stringToTicker,
+  textToString,
   tickerToDid,
   u64ToBigNumber,
 } from '~/utils/conversion';
@@ -183,7 +185,7 @@ export class SecurityToken extends Entity<UniqueIdentifiers, string> {
   public modify: ProcedureMethod<ModifyTokenParams, SecurityToken>;
 
   /**
-   * Retrieve the Security Token's name, total supply, whether it is divisible or not and the Identity of the owner
+   * Retrieve the Security Token's data
    *
    * @note can be subscribed to
    */
@@ -207,7 +209,9 @@ export class SecurityToken extends Entity<UniqueIdentifiers, string> {
     /* eslint-disable @typescript-eslint/naming-convention */
     const assembleResult = async (
       { total_supply, divisible, owner_did, asset_type }: MeshSecurityToken,
-      agentGroups: [StorageKey<[Ticker, IdentityId]>, Option<AgentGroup>][]
+      agentGroups: [StorageKey<[Ticker, IdentityId]>, Option<AgentGroup>][],
+      assetName: AssetName,
+      iuDisabled: bool
     ): Promise<SecurityTokenDetails> => {
       const primaryIssuanceAgents: Identity[] = [];
       const fullAgents: Identity[] = [];
@@ -237,11 +241,12 @@ export class SecurityToken extends Entity<UniqueIdentifiers, string> {
       return {
         assetType,
         isDivisible: boolToBoolean(divisible),
-        name: 'placeholder',
+        name: textToString(assetName),
         owner,
         totalSupply: balanceToBigNumber(total_supply),
         primaryIssuanceAgents,
         fullAgents,
+        requiresInvestorUniqueness: !boolToBoolean(iuDisabled),
       };
     };
     /* eslint-enable @typescript-eslint/naming-convention */
@@ -249,19 +254,28 @@ export class SecurityToken extends Entity<UniqueIdentifiers, string> {
     const rawTicker = stringToTicker(ticker, context);
 
     const groupOfAgentPromise = externalAgents.groupOfAgent.entries(rawTicker);
+    const namePromise = asset.assetNames(rawTicker);
+    const disabledIuPromise = asset.disableInvestorUniqueness(rawTicker);
 
     if (callback) {
-      const groupOfAgents = await groupOfAgentPromise;
+      const groups = await groupOfAgentPromise;
+      const name = await namePromise;
+      const disabledIu = await disabledIuPromise;
 
       return asset.tokens(rawTicker, async securityToken => {
-        const result = await assembleResult(securityToken, groupOfAgents);
+        const result = await assembleResult(securityToken, groups, name, disabledIu);
         callback(result);
       });
     }
 
-    const [token, groupOfAgent] = await Promise.all([asset.tokens(rawTicker), groupOfAgentPromise]);
+    const [token, groups, name, disabledIu] = await Promise.all([
+      asset.tokens(rawTicker),
+      groupOfAgentPromise,
+      namePromise,
+      disabledIuPromise,
+    ]);
 
-    return assembleResult(token, groupOfAgent);
+    return assembleResult(token, groups, name, disabledIu);
   }
 
   /**

--- a/src/api/entities/SecurityToken/index.ts
+++ b/src/api/entities/SecurityToken/index.ts
@@ -258,12 +258,17 @@ export class SecurityToken extends Entity<UniqueIdentifiers, string> {
     const disabledIuPromise = asset.disableInvestorUniqueness(rawTicker);
 
     if (callback) {
-      const groups = await groupOfAgentPromise;
-      const name = await namePromise;
-      const disabledIu = await disabledIuPromise;
+      const groupEntries = await groupOfAgentPromise;
+      const assetName = await namePromise;
+      const disabledInvestorUniqueness = await disabledIuPromise;
 
       return asset.tokens(rawTicker, async securityToken => {
-        const result = await assembleResult(securityToken, groups, name, disabledIu);
+        const result = await assembleResult(
+          securityToken,
+          groupEntries,
+          assetName,
+          disabledInvestorUniqueness
+        );
         callback(result);
       });
     }

--- a/src/api/entities/SecurityToken/types.ts
+++ b/src/api/entities/SecurityToken/types.ts
@@ -9,8 +9,12 @@ export interface SecurityTokenDetails {
   name: string;
   owner: Identity;
   totalSupply: BigNumber;
+  /**
+   * @deprecated
+   */
   primaryIssuanceAgents: Identity[];
   fullAgents: Identity[];
+  requiresInvestorUniqueness: boolean;
 }
 
 /**

--- a/src/api/procedures/__tests__/consumeAuthorizationRequests.ts
+++ b/src/api/procedures/__tests__/consumeAuthorizationRequests.ts
@@ -257,7 +257,7 @@ describe('consumeAuthorizationRequests procedure', () => {
           target: entityMockUtils.getIdentityInstance({ did }),
           issuer: entityMockUtils.getIdentityInstance({ did: 'issuerDid1' }),
           data: {
-            type: AuthorizationType.NoData,
+            type: AuthorizationType.BecomeAgent,
           } as Authorization,
         },
         {
@@ -266,7 +266,7 @@ describe('consumeAuthorizationRequests procedure', () => {
           target: entityMockUtils.getIdentityInstance({ did: 'notTheCurrentIdentity' }),
           issuer: entityMockUtils.getIdentityInstance({ did: 'issuerDid2' }),
           data: {
-            type: AuthorizationType.NoData,
+            type: AuthorizationType.PortfolioCustody,
           } as Authorization,
         },
       ];
@@ -284,7 +284,10 @@ describe('consumeAuthorizationRequests procedure', () => {
         permissions: {
           tokens: [],
           portfolios: [],
-          transactions: [TxTags.identity.AcceptAuthorization],
+          transactions: [
+            TxTags.externalAgents.AcceptBecomeAgent,
+            TxTags.portfolio.AcceptPortfolioCustody,
+          ],
         },
       });
 

--- a/src/api/procedures/__tests__/createSecurityToken.ts
+++ b/src/api/procedures/__tests__/createSecurityToken.ts
@@ -67,6 +67,7 @@ describe('createSecurityToken procedure', () => {
   let tokenType: string;
   let tokenIdentifiers: TokenIdentifier[];
   let fundingRound: string;
+  let requireInvestorUniqueness: boolean;
   let documents: TokenDocument[];
   let rawTicker: Ticker;
   let rawName: AssetName;
@@ -117,6 +118,7 @@ describe('createSecurityToken procedure', () => {
       },
     ];
     fundingRound = 'Series A';
+    requireInvestorUniqueness = true;
     documents = [
       {
         name: 'someDocument',
@@ -152,7 +154,7 @@ describe('createSecurityToken procedure', () => {
       })
     );
     rawFundingRound = dsMockUtils.createMockFundingRoundName(fundingRound);
-    rawDisableIu = dsMockUtils.createMockBool(false);
+    rawDisableIu = dsMockUtils.createMockBool(!requireInvestorUniqueness);
     args = {
       ticker,
       name,
@@ -187,7 +189,7 @@ describe('createSecurityToken procedure', () => {
     numberToBalanceStub.withArgs(totalSupply, mockContext, isDivisible).returns(rawTotalSupply);
     stringToAssetNameStub.withArgs(name, mockContext).returns(rawName);
     booleanToBoolStub.withArgs(isDivisible, mockContext).returns(rawIsDivisible);
-    booleanToBoolStub.withArgs(false, mockContext).returns(rawDisableIu);
+    booleanToBoolStub.withArgs(!requireInvestorUniqueness, mockContext).returns(rawDisableIu);
     internalTokenTypeToAssetTypeStub
       .withArgs(tokenType as KnownTokenType, mockContext)
       .returns(rawType);
@@ -271,6 +273,7 @@ describe('createSecurityToken procedure', () => {
       totalSupply: new BigNumber(0),
       tokenIdentifiers: undefined,
       fundingRound: undefined,
+      requireInvestorUniqueness: false,
     });
 
     sinon.assert.calledWith(
@@ -283,7 +286,7 @@ describe('createSecurityToken procedure', () => {
       rawType,
       [],
       null,
-      rawDisableIu
+      rawIsDivisible // disable IU = true
     );
 
     const issueTransaction = dsMockUtils.createTxStub('asset', 'issue');

--- a/src/api/procedures/__tests__/setPermissionGroup.ts
+++ b/src/api/procedures/__tests__/setPermissionGroup.ts
@@ -197,13 +197,19 @@ describe('setPermissionGroup procedure', () => {
       }),
     });
 
-    let rawAgentGroup = dsMockUtils.createMockAgentGroup('Full');
-
-    procedureMockUtils.getAddProcedureStub().resolves({
-      transform: sinon.stub().returns(rawAgentGroup),
+    const rawAgentGroup = dsMockUtils.createMockAgentGroup({
+      Custom: dsMockUtils.createMockU32(id.toNumber()),
     });
 
-    permissionGroupIdentifierToAgentGroupStub.returns(dsMockUtils.createMockAgentGroup());
+    permissionGroupIdentifierToAgentGroupStub
+      .withArgs({ custom: id }, mockContext)
+      .returns(rawAgentGroup);
+
+    procedureMockUtils.getAddProcedureStub().resolves({
+      transform: sinon
+        .stub()
+        .callsFake(cb => cb(entityMockUtils.getCustomPermissionGroupInstance({ id }))),
+    });
 
     await prepareSetPermissionGroup.call(proc, {
       agent: entityMockUtils.getAgentInstance({
@@ -228,16 +234,6 @@ describe('setPermissionGroup procedure', () => {
       rawIdentityId,
       rawAgentGroup
     );
-
-    rawAgentGroup = dsMockUtils.createMockAgentGroup({
-      Custom: dsMockUtils.createMockU32(id.toNumber()),
-    });
-
-    procedureMockUtils.getAddProcedureStub().resolves({
-      transform: sinon.stub().returns(rawAgentGroup),
-    });
-
-    permissionGroupIdentifierToAgentGroupStub.returns(dsMockUtils.createMockAgentGroup());
 
     await prepareSetPermissionGroup.call(proc, {
       agent: entityMockUtils.getAgentInstance({

--- a/src/api/procedures/createSecurityToken.ts
+++ b/src/api/procedures/createSecurityToken.ts
@@ -1,28 +1,43 @@
+import { Bytes } from '@polkadot/types';
+import { ISubmittableResult } from '@polkadot/types/types';
 import BigNumber from 'bignumber.js';
-import { TxTags } from 'polymesh-types/types';
+import { values } from 'lodash';
+import { AssetType, CustomAssetTypeId, TxTags } from 'polymesh-types/types';
 
-import { PolymeshError, Procedure, SecurityToken, TickerReservation } from '~/internal';
+import { Context, PolymeshError, Procedure, SecurityToken, TickerReservation } from '~/internal';
 import {
   ErrorCode,
+  KnownTokenType,
   RoleType,
   TickerReservationStatus,
   TokenDocument,
   TokenIdentifier,
-  TokenType,
 } from '~/types';
-import { ProcedureAuthorization } from '~/types/internal';
+import { MaybePostTransactionValue, ProcedureAuthorization } from '~/types/internal';
 import {
   booleanToBool,
   boolToBoolean,
+  internalTokenTypeToAssetType,
   numberToBalance,
   stringToAssetName,
+  stringToBytes,
   stringToFundingRoundName,
   stringToTicker,
   tokenDocumentToDocument,
   tokenIdentifierToAssetIdentifier,
-  tokenTypeToAssetType,
 } from '~/utils/conversion';
-import { batchArguments } from '~/utils/internal';
+import { batchArguments, filterEventRecords } from '~/utils/internal';
+
+/**
+ * @hidden
+ */
+export const createRegisterCustomAssetTypeResolver = (context: Context) => (
+  receipt: ISubmittableResult
+): AssetType => {
+  const [{ data }] = filterEventRecords(receipt, 'asset', 'CustomAssetTypeRegistered');
+
+  return internalTokenTypeToAssetType({ Custom: data[1] }, context);
+};
 
 export interface CreateSecurityTokenParams {
   name: string;
@@ -35,9 +50,11 @@ export interface CreateSecurityTokenParams {
    */
   isDivisible: boolean;
   /**
-   * type of security that the token represents (i.e. Equity, Debt, Commodity, etc)
+   * type of security that the token represents (i.e. Equity, Debt, Commodity, etc). Common values are included in the
+   *   [[KnownTokenType]] enum, but custom values can be used as well. Custom values must be registered on-chain the first time
+   *   they're used, requiring an additional transaction. They aren't tied to a specific Security Token
    */
-  tokenType: TokenType;
+  tokenType: string;
   /**
    * array of domestic or international alphanumeric security identifiers for the token (ISIN, CUSIP, etc)
    */
@@ -59,15 +76,33 @@ export type Params = CreateSecurityTokenParams & {
 /**
  * @hidden
  */
+export interface Storage {
+  /**
+   * fetched custom asset type ID and raw value in bytes. If `id.isEmpty`, then the type should be registered. A
+   *   null value means the type is not custom
+   */
+  customTypeData: {
+    id: CustomAssetTypeId;
+    rawValue: Bytes;
+  } | null;
+}
+
+/**
+ * @hidden
+ */
 export async function prepareCreateSecurityToken(
-  this: Procedure<Params, SecurityToken>,
+  this: Procedure<Params, SecurityToken, Storage>,
   args: Params
 ): Promise<SecurityToken> {
   const {
     context: {
-      polymeshApi: { tx, query },
+      polymeshApi: {
+        tx,
+        query: { asset },
+      },
     },
     context,
+    storage: { customTypeData },
   } = this;
   const {
     ticker,
@@ -86,7 +121,7 @@ export async function prepareCreateSecurityToken(
 
   const [{ status }, classicTicker] = await Promise.all([
     reservation.details(),
-    query.asset.classicTickers(rawTicker),
+    asset.classicTickers(rawTicker),
   ]);
 
   if (status === TickerReservationStatus.TokenCreated) {
@@ -103,9 +138,27 @@ export async function prepareCreateSecurityToken(
     });
   }
 
+  let rawType: MaybePostTransactionValue<AssetType>;
+
+  if (customTypeData) {
+    const { rawValue, id } = customTypeData;
+
+    if (id.isEmpty) {
+      // if the custom asset type doesn't exist, we create it
+      [rawType] = this.addTransaction(
+        tx.asset.registerCustomAssetType,
+        { resolvers: [createRegisterCustomAssetTypeResolver(context)] },
+        rawValue
+      );
+    } else {
+      rawType = internalTokenTypeToAssetType({ Custom: id }, context);
+    }
+  } else {
+    rawType = internalTokenTypeToAssetType(tokenType as KnownTokenType, context);
+  }
+
   const rawName = stringToAssetName(name, context);
   const rawIsDivisible = booleanToBool(isDivisible, context);
-  const rawType = tokenTypeToAssetType(tokenType, context);
   const rawIdentifiers = tokenIdentifiers.map(identifier =>
     tokenIdentifierToAssetIdentifier(identifier, context)
   );
@@ -140,7 +193,7 @@ export async function prepareCreateSecurityToken(
     this.addTransaction(tx.asset.issue, {}, rawTicker, rawTotalSupply);
   }
 
-  if (documents) {
+  if (documents?.length) {
     const rawDocuments = documents.map(doc => tokenDocumentToDocument(doc, context));
     batchArguments(rawDocuments, TxTags.asset.AddDocuments).forEach(rawDocumentBatch => {
       this.addTransaction(
@@ -158,11 +211,22 @@ export async function prepareCreateSecurityToken(
 /**
  * @hidden
  */
-export function getAuthorization({ ticker, documents }: Params): ProcedureAuthorization {
+export function getAuthorization(
+  this: Procedure<Params, SecurityToken, Storage>,
+  { ticker, documents }: Params
+): ProcedureAuthorization {
+  const {
+    storage: { customTypeData },
+  } = this;
+
   const transactions = [TxTags.asset.CreateAsset];
 
-  if (documents) {
+  if (documents?.length) {
     transactions.push(TxTags.asset.AddDocuments);
+  }
+
+  if (customTypeData?.id.isEmpty) {
+    transactions.push(TxTags.asset.RegisterCustomAssetType);
   }
 
   return {
@@ -178,5 +242,33 @@ export function getAuthorization({ ticker, documents }: Params): ProcedureAuthor
 /**
  * @hidden
  */
-export const createSecurityToken = (): Procedure<Params, SecurityToken> =>
-  new Procedure(prepareCreateSecurityToken, getAuthorization);
+export async function prepareStorage(
+  this: Procedure<Params, SecurityToken, Storage>,
+  { tokenType }: Params
+): Promise<Storage> {
+  const { context } = this;
+
+  const isCustomType = !values<string>(KnownTokenType).includes(tokenType);
+
+  if (isCustomType) {
+    const rawValue = stringToBytes(tokenType, context);
+    const id = await context.polymeshApi.query.asset.customTypesInverse(rawValue);
+
+    return {
+      customTypeData: {
+        id,
+        rawValue,
+      },
+    };
+  }
+
+  return {
+    customTypeData: null,
+  };
+}
+
+/**
+ * @hidden
+ */
+export const createSecurityToken = (): Procedure<Params, SecurityToken, Storage> =>
+  new Procedure(prepareCreateSecurityToken, getAuthorization, prepareStorage);

--- a/src/api/procedures/createSecurityToken.ts
+++ b/src/api/procedures/createSecurityToken.ts
@@ -64,6 +64,11 @@ export interface CreateSecurityTokenParams {
    */
   fundingRound?: string;
   documents?: TokenDocument[];
+  /**
+   * whether this asset requires investors to have a Investor Uniqueness Claim in order
+   *   to hold it. Optional, defaults to true. More information about Investor Uniqueness and PUIS [here](https://developers.polymesh.live/introduction/identity#polymesh-unique-identity-system-puis)
+   */
+  requireInvestorUniqueness?: boolean;
 }
 
 /**
@@ -113,6 +118,7 @@ export async function prepareCreateSecurityToken(
     tokenIdentifiers = [],
     fundingRound,
     documents,
+    requireInvestorUniqueness = true,
   } = args;
 
   const reservation = new TickerReservation({ ticker }, context);
@@ -163,6 +169,7 @@ export async function prepareCreateSecurityToken(
     tokenIdentifierToAssetIdentifier(identifier, context)
   );
   const rawFundingRound = fundingRound ? stringToFundingRoundName(fundingRound, context) : null;
+  const rawDisableIu = booleanToBool(!requireInvestorUniqueness, context);
 
   let fee: undefined | BigNumber;
 
@@ -184,7 +191,7 @@ export async function prepareCreateSecurityToken(
     rawType,
     rawIdentifiers,
     rawFundingRound,
-    booleanToBool(false, context)
+    rawDisableIu
   );
 
   if (totalSupply && totalSupply.gt(0)) {

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -209,15 +209,15 @@ interface DefaultPortfolioOptions {
 }
 
 interface CustomPermissionGroupOptions {
-  ticker: string;
-  id: BigNumber;
+  ticker?: string;
+  id?: BigNumber;
   getPermissions?: GroupPermissions;
   isEqual?: boolean;
 }
 
 interface KnownPermissionGroupOptions {
-  ticker: string;
-  type: PermissionGroupType;
+  ticker?: string;
+  type?: PermissionGroupType;
   getPermissions?: GroupPermissions;
   isEqual?: boolean;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -172,11 +172,6 @@ export enum KnownTokenType {
   StableCoin = 'StableCoin',
 }
 
-/**
- * Type of security that the token represents
- */
-export type TokenType = KnownTokenType | { custom: string };
-
 export enum TokenIdentifierType {
   Isin = 'Isin',
   Cusip = 'Cusip',

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -13,7 +13,15 @@ import { DocumentNode } from 'graphql';
 
 import { PostTransactionValue } from '~/internal';
 import { CallIdEnum, ModuleIdEnum } from '~/middleware/types';
-import { CalendarPeriod, PermissionGroupType, Role, SignerValue, SimplePermissions } from '~/types';
+import { CustomAssetTypeId } from '~/polkadot';
+import {
+  CalendarPeriod,
+  KnownTokenType,
+  PermissionGroupType,
+  Role,
+  SignerValue,
+  SimplePermissions,
+} from '~/types';
 
 /**
  * Polkadot's `tx` submodule
@@ -235,3 +243,5 @@ export enum InstructionStatus {
  * Determines the subset of permissions an Agent has over a Security Token
  */
 export type PermissionGroupIdentifier = PermissionGroupType | { custom: BigNumber };
+
+export type InternalTokenType = KnownTokenType | { Custom: CustomAssetTypeId };

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -124,7 +124,7 @@ import {
   assetComplianceResultToCompliance,
   assetIdentifierToTokenIdentifier,
   assetNameToString,
-  assetTypeToString,
+  assetTypeToKnownOrId,
   authorizationDataToAuthorization,
   authorizationToAuthorizationData,
   authorizationTypeToMeshAuthorizationType,
@@ -157,6 +157,7 @@ import {
   fundraiserToStoDetails,
   granularCanTransferResultToTransferBreakdown,
   identityIdToString,
+  internalTokenTypeToAssetType,
   isCusipValid,
   isIsinValid,
   isLeiValid,
@@ -232,7 +233,6 @@ import {
   toIdentityWithClaimsArray,
   tokenDocumentToDocument,
   tokenIdentifierToAssetIdentifier,
-  tokenTypeToAssetType,
   transactionHexToTxTag,
   transactionPermissionsToExtrinsicPermissions,
   transactionPermissionsToTxGroups,
@@ -2099,7 +2099,7 @@ describe('u8ToTransferStatus', () => {
   });
 });
 
-describe('tokenTypeToAssetType and assetTypeToString', () => {
+describe('internalTokenTypeToAssetType and assetTypeToKnownOrId', () => {
   beforeAll(() => {
     dsMockUtils.initMocks();
   });
@@ -2112,91 +2112,91 @@ describe('tokenTypeToAssetType and assetTypeToString', () => {
     dsMockUtils.cleanup();
   });
 
-  test('tokenTypeToAssetType should convert a TokenType to a polkadot AssetType object', () => {
+  test('internalTokenTypeToAssetType should convert a TokenType to a polkadot AssetType object', () => {
     const value = KnownTokenType.Commodity;
     const fakeResult = ('CommodityEnum' as unknown) as AssetType;
     const context = dsMockUtils.getContextInstance();
 
     dsMockUtils.getCreateTypeStub().withArgs('AssetType', value).returns(fakeResult);
 
-    const result = tokenTypeToAssetType(value, context);
+    const result = internalTokenTypeToAssetType(value, context);
 
     expect(result).toBe(fakeResult);
   });
 
-  test('assetTypeToString should convert a polkadot AssetType object to a string', () => {
+  test('assetTypeToKnownOrId should convert a polkadot AssetType object to a string', () => {
     let fakeResult = KnownTokenType.Commodity;
     let assetType = dsMockUtils.createMockAssetType(fakeResult);
 
-    let result = assetTypeToString(assetType);
+    let result = assetTypeToKnownOrId(assetType);
     expect(result).toEqual(fakeResult);
 
     fakeResult = KnownTokenType.EquityCommon;
     assetType = dsMockUtils.createMockAssetType(fakeResult);
 
-    result = assetTypeToString(assetType);
+    result = assetTypeToKnownOrId(assetType);
     expect(result).toEqual(fakeResult);
 
     fakeResult = KnownTokenType.EquityPreferred;
     assetType = dsMockUtils.createMockAssetType(fakeResult);
 
-    result = assetTypeToString(assetType);
+    result = assetTypeToKnownOrId(assetType);
     expect(result).toEqual(fakeResult);
 
     fakeResult = KnownTokenType.Commodity;
     assetType = dsMockUtils.createMockAssetType(fakeResult);
 
-    result = assetTypeToString(assetType);
+    result = assetTypeToKnownOrId(assetType);
     expect(result).toEqual(fakeResult);
 
     fakeResult = KnownTokenType.FixedIncome;
     assetType = dsMockUtils.createMockAssetType(fakeResult);
 
-    result = assetTypeToString(assetType);
+    result = assetTypeToKnownOrId(assetType);
     expect(result).toEqual(fakeResult);
 
     fakeResult = KnownTokenType.Reit;
     assetType = dsMockUtils.createMockAssetType(fakeResult);
 
-    result = assetTypeToString(assetType);
+    result = assetTypeToKnownOrId(assetType);
     expect(result).toEqual(fakeResult);
 
     fakeResult = KnownTokenType.Fund;
     assetType = dsMockUtils.createMockAssetType(fakeResult);
 
-    result = assetTypeToString(assetType);
+    result = assetTypeToKnownOrId(assetType);
     expect(result).toEqual(fakeResult);
 
     fakeResult = KnownTokenType.RevenueShareAgreement;
     assetType = dsMockUtils.createMockAssetType(fakeResult);
 
-    result = assetTypeToString(assetType);
+    result = assetTypeToKnownOrId(assetType);
     expect(result).toEqual(fakeResult);
 
     fakeResult = KnownTokenType.StructuredProduct;
     assetType = dsMockUtils.createMockAssetType(fakeResult);
 
-    result = assetTypeToString(assetType);
+    result = assetTypeToKnownOrId(assetType);
     expect(result).toEqual(fakeResult);
 
     fakeResult = KnownTokenType.Derivative;
     assetType = dsMockUtils.createMockAssetType(fakeResult);
 
-    result = assetTypeToString(assetType);
+    result = assetTypeToKnownOrId(assetType);
     expect(result).toEqual(fakeResult);
 
     fakeResult = KnownTokenType.StableCoin;
     assetType = dsMockUtils.createMockAssetType(fakeResult);
 
-    result = assetTypeToString(assetType);
+    result = assetTypeToKnownOrId(assetType);
     expect(result).toEqual(fakeResult);
 
     assetType = dsMockUtils.createMockAssetType({
       Custom: dsMockUtils.createMockU32(1),
     });
 
-    result = assetTypeToString(assetType);
-    expect(result).toEqual('1');
+    result = assetTypeToKnownOrId(assetType);
+    expect(result).toEqual(new BigNumber(1));
   });
 });
 

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -178,7 +178,6 @@ import {
   TokenDocument,
   TokenIdentifier,
   TokenIdentifierType,
-  TokenType,
   TransactionPermissions,
   TransferBreakdown,
   TransferError,
@@ -193,6 +192,7 @@ import {
   CorporateActionIdentifier,
   ExtrinsicIdentifier,
   InstructionStatus,
+  InternalTokenType,
   PalletPermissions,
   PermissionGroupIdentifier,
   PermissionsEnum,
@@ -1363,14 +1363,14 @@ export function u8ToTransferStatus(status: u8): TransferStatus {
 /**
  * @hidden
  */
-export function tokenTypeToAssetType(type: TokenType, context: Context): AssetType {
+export function internalTokenTypeToAssetType(type: InternalTokenType, context: Context): AssetType {
   return context.polymeshApi.createType('AssetType', type);
 }
 
 /**
  * @hidden
  */
-export function assetTypeToString(assetType: AssetType): string {
+export function assetTypeToKnownOrId(assetType: AssetType): KnownTokenType | BigNumber {
   if (assetType.isEquityCommon) {
     return KnownTokenType.EquityCommon;
   }
@@ -1402,8 +1402,7 @@ export function assetTypeToString(assetType: AssetType): string {
     return KnownTokenType.StableCoin;
   }
 
-  // TODO @monitz87: figure out how to return this properly (probably make it async and have it fetch the value)
-  return u32ToBigNumber(assetType.asCustom).toFormat();
+  return u32ToBigNumber(assetType.asCustom);
 }
 
 /**


### PR DESCRIPTION
- when creating a Security Token, if the token type in the inputs is a custom type that hasn’t
  been registered, an additional transaction is submitted to register it
- when creating a Security Token, only ask for permission to add documents if the documents
  array has elements
- request the correct transaction permissions when accepting an authorization request