### PR TITLE
chore: 🤖 allow specifying different signer and agent perms

### DIFF
--- a/src/base/Procedure.ts
+++ b/src/base/Procedure.ts
@@ -193,10 +193,7 @@ export class Procedure<
         identity = await fetchIdentity();
 
         const agentPermissionResults = await P.map(tokens, token =>
-          // the compiler doesn't recognize that identity is defined even though
-          //   we checked at the top of the block
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          identity!.hasTokenPermissions({ token, transactions })
+          identity.hasTokenPermissions({ token, transactions })
         );
 
         hasAgentPermissions = agentPermissionResults.every(perm => perm);

--- a/src/base/__tests__/Procedure.ts
+++ b/src/base/__tests__/Procedure.ts
@@ -118,7 +118,48 @@ describe('Procedure class', () => {
         accountFrozen: false,
       });
 
-      context = dsMockUtils.getContextInstance({ hasTokenPermissions: true });
+      authFunc.resolves({
+        roles: [{ type: RoleType.TickerOwner, ticker: 'ticker' }],
+        permissions: {
+          tokens: [entityMockUtils.getSecurityTokenInstance({ ticker: 'SOME_TICKER' })],
+          portfolios: null,
+          transactions: [TxTags.asset.Redeem],
+        },
+        agentPermissions: false,
+        signerPermissions: false,
+      });
+
+      result = await procedure.checkAuthorization(args, context);
+      expect(result).toEqual({
+        agentPermissions: false,
+        signerPermissions: false,
+        roles: true,
+        accountFrozen: false,
+      });
+
+      authFunc.resolves({
+        roles: [{ type: RoleType.TickerOwner, ticker: 'ticker' }],
+        permissions: false,
+        signerPermissions: {
+          tokens: [entityMockUtils.getSecurityTokenInstance({ ticker: 'SOME_TICKER' })],
+          portfolios: null,
+          transactions: [TxTags.asset.Redeem],
+        },
+        agentPermissions: {
+          tokens: [entityMockUtils.getSecurityTokenInstance({ ticker: 'SOME_TICKER' })],
+          portfolios: null,
+          transactions: [TxTags.asset.Redeem],
+        },
+      });
+
+      result = await procedure.checkAuthorization(args, context);
+      expect(result).toEqual({
+        agentPermissions: true,
+        signerPermissions: true,
+        roles: true,
+        accountFrozen: false,
+      });
+
       authFunc.resolves({
         roles: [{ type: RoleType.TickerOwner, ticker: 'ticker' }],
         permissions: {

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -204,7 +204,21 @@ export interface CorporateActionIdentifier {
 }
 
 export interface ProcedureAuthorization {
+  /**
+   * general permissions that apply to both Secondary Key Accounts and External
+   *   Agent Identities. Overridden by `signerPermissions` and `agentPermissions` respectively
+   */
   permissions?: SimplePermissions | boolean;
+  /**
+   * permissions specific to Secondary Key Accounts. This value takes precedence over `permissions` for
+   *   Secondary Keys
+   */
+  signerPermissions?: SimplePermissions | boolean;
+  /**
+   * permissions specific to External Agent Identities. This value takes precedence over `permissions` for
+   *   External Agents
+   */
+  agentPermissions?: Omit<SimplePermissions, 'portfolios'> | boolean;
   roles?: Role[] | boolean;
 }
 


### PR DESCRIPTION
- procedures can now have different permission requirements for
secondary keys and external agents