### PR TITLE
chore: rename details to description in CreateVenueParams

### DIFF
--- a/src/api/procedures/__tests__/createVenue.ts
+++ b/src/api/procedures/__tests__/createVenue.ts
@@ -48,18 +48,18 @@ describe('createVenue procedure', () => {
   });
 
   test('should add a createVenue transaction to the queue', async () => {
-    const details = 'details';
+    const description = 'description';
     const type = VenueType.Distribution;
     const args = {
-      details,
+      description,
       type,
     };
-    const rawDetails = dsMockUtils.createMockVenueDetails(details);
+    const rawDetails = dsMockUtils.createMockVenueDetails(description);
     const rawType = dsMockUtils.createMockVenueType(type);
 
     const proc = procedureMockUtils.getInstance<CreateVenueParams, Venue>(mockContext);
 
-    stringToVenueDetailsStub.withArgs(details, mockContext).returns(rawDetails);
+    stringToVenueDetailsStub.withArgs(description, mockContext).returns(rawDetails);
     venueTypeToMeshVenueTypeStub.withArgs(type, mockContext).returns(rawType);
 
     const result = await prepareCreateVenue.call(proc, args);

--- a/src/api/procedures/createVenue.ts
+++ b/src/api/procedures/createVenue.ts
@@ -6,7 +6,7 @@ import { stringToVenueDetails, u64ToBigNumber, venueTypeToMeshVenueType } from '
 import { filterEventRecords } from '~/utils/internal';
 
 export interface CreateVenueParams {
-  details: string;
+  description: string;
   type: VenueType;
 }
 
@@ -37,9 +37,9 @@ export async function prepareCreateVenue(
     },
     context,
   } = this;
-  const { details, type } = args;
+  const { description, type } = args;
 
-  const rawDetails = stringToVenueDetails(details, context);
+  const rawDetails = stringToVenueDetails(description, context);
   const rawType = venueTypeToMeshVenueType(type, context);
 
   // NOTE @monitz87: we're sending an empty signer array for the moment


### PR DESCRIPTION
The following breaking changes are from earlier commits

BREAKING CHANGE:
- rename `details` to `description` in CreateVenueParams interface.