### PR TITLE
chore: remove order parameter from identity.getTrustingTokens

### DIFF
--- a/src/api/entities/Identity/__tests__/index.ts
+++ b/src/api/entities/Identity/__tests__/index.ts
@@ -489,12 +489,9 @@ describe('Identity class', () => {
     test('should return a list of security tokens', async () => {
       const identity = new Identity({ did }, context);
 
-      dsMockUtils.createApolloQueryStub(
-        tokensByTrustedClaimIssuer({ claimIssuerDid: did, order: Order.Asc }),
-        {
-          tokensByTrustedClaimIssuer: tickers,
-        }
-      );
+      dsMockUtils.createApolloQueryStub(tokensByTrustedClaimIssuer({ claimIssuerDid: did }), {
+        tokensByTrustedClaimIssuer: tickers,
+      });
 
       const result = await identity.getTrustingTokens();
 

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -446,17 +446,13 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
    *
    * @note uses the middleware
    */
-  public async getTrustingTokens(
-    args: { order: Order } = { order: Order.Asc }
-  ): Promise<SecurityToken[]> {
+  public async getTrustingTokens(): Promise<SecurityToken[]> {
     const { context, did } = this;
-
-    const { order } = args;
 
     const {
       data: { tokensByTrustedClaimIssuer: tickers },
     } = await context.queryMiddleware<Ensured<Query, 'tokensByTrustedClaimIssuer'>>(
-      tokensByTrustedClaimIssuer({ claimIssuerDid: did, order })
+      tokensByTrustedClaimIssuer({ claimIssuerDid: did })
     );
 
     return tickers.map(ticker => new SecurityToken({ ticker: removePadding(ticker) }, context));

--- a/src/middleware/__tests__/queries.ts
+++ b/src/middleware/__tests__/queries.ts
@@ -23,8 +23,8 @@ import {
   proposalVotes,
   scopesByIdentity,
   settlements,
-  tickerExternalAgentHistory,
   tickerExternalAgentActions,
+  tickerExternalAgentHistory,
   tokensByTrustedClaimIssuer,
   tokensHeldByDid,
   transactionByHash,
@@ -134,7 +134,6 @@ describe('tokensByTrustedClaimIssuer', () => {
   test('should pass the variables to the grapqhl query', () => {
     const variables = {
       claimIssuerDid: 'someDid',
-      order: Order.Asc,
     };
 
     const result = tokensByTrustedClaimIssuer(variables);
@@ -288,7 +287,7 @@ describe('tickerExternalAgentHistory', () => {
     };
 
     const result = tickerExternalAgentHistory(variables);
-    
+
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);
   });

--- a/src/middleware/queries.ts
+++ b/src/middleware/queries.ts
@@ -13,8 +13,8 @@ import {
   QueryProposalVotesArgs,
   QueryScopesByIdentityArgs,
   QuerySettlementsArgs,
-  QueryTickerExternalAgentHistoryArgs,
   QueryTickerExternalAgentActionsArgs,
+  QueryTickerExternalAgentHistoryArgs,
   QueryTokensByTrustedClaimIssuerArgs,
   QueryTokensHeldByDidArgs,
   QueryTransactionByHashArgs,
@@ -279,8 +279,8 @@ export function tokensByTrustedClaimIssuer(
   variables: QueryTokensByTrustedClaimIssuerArgs
 ): GraphqlQuery<QueryTokensByTrustedClaimIssuerArgs> {
   const query = gql`
-    query TokensByTrustedClaimIssuerQuery($claimIssuerDid: String!, $order: Order) {
-      tokensByTrustedClaimIssuer(claimIssuerDid: $claimIssuerDid, order: $order)
+    query TokensByTrustedClaimIssuerQuery($claimIssuerDid: String!) {
+      tokensByTrustedClaimIssuer(claimIssuerDid: $claimIssuerDid)
     }
   `;
 
@@ -687,7 +687,7 @@ export function getHistoryOfPaymentEventsForCa(
 /**
  * @hidden
  *
-  * Get the transaction history of each external agent of a token
+ * Get the transaction history of each external agent of a token
  */
 export function tickerExternalAgentHistory(
   variables: QueryTickerExternalAgentHistoryArgs
@@ -710,7 +710,7 @@ export function tickerExternalAgentHistory(
     variables,
   };
 }
-          
+
 /**
  * @hidden
  *


### PR DESCRIPTION
The following breaking changes are from earlier commits

BREAKING CHANGE:
- remove `order` parameter in getTrustingTokens method.