### PR TITLE
fix: 🐛 allow polkadot.js to handle disconnects by itself

### DIFF
--- a/src/base/Context.ts
+++ b/src/base/Context.ts
@@ -127,20 +127,6 @@ export class Context {
   private constructor(params: ConstructorParams) {
     const { polymeshApi, middlewareApi, keyring, ss58Format } = params;
 
-    const callback = (): void => {
-      polymeshApi.off('disconnected', callback);
-      polymeshApi.off('error', callback);
-
-      if (this.isDisconnected) {
-        return;
-      }
-
-      this.disconnect();
-    };
-
-    polymeshApi.on('disconnected', callback);
-    polymeshApi.on('error', callback);
-
     this._middlewareApi = middlewareApi;
     this._polymeshApi = polymeshApi;
     this.polymeshApi = Context.createPolymeshApiProxy(this);

--- a/src/base/__tests__/Context.ts
+++ b/src/base/__tests__/Context.ts
@@ -127,33 +127,6 @@ describe('Context class', () => {
     expect(context.middlewareApi).toEqual(middlewareApi);
   });
 
-  test('should listen for polkadot disconnection and errors in order to finish cleanup', async () => {
-    const polymeshApi = dsMockUtils.getApiInstance();
-
-    let context = await Context.create({
-      polymeshApi,
-      middlewareApi: null,
-      accountSeed: '0x6'.padEnd(66, '0'),
-    });
-
-    polymeshApi.emit('disconnected');
-
-    expect(() => context.getSigner).toThrow();
-
-    context = await Context.create({
-      polymeshApi,
-      middlewareApi: null,
-      accountSeed: '0x6'.padEnd(66, '0'),
-    });
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (context as any).isDisconnected = true;
-
-    polymeshApi.emit('disconnected');
-
-    expect(() => context.getSigner).toThrow();
-  });
-
   describe('method: create', () => {
     beforeEach(() => {
       dsMockUtils.createQueryStub('balances', 'totalIssuance', {
@@ -1552,7 +1525,7 @@ describe('Context class', () => {
     test('should disconnect everything and leave the instance unusable', async () => {
       const polymeshApi = dsMockUtils.getApiInstance();
       const middlewareApi = dsMockUtils.getMiddlewareApi();
-      const context = await Context.create({
+      let context = await Context.create({
         polymeshApi,
         middlewareApi,
         accountSeed: '0x6'.padEnd(66, '0'),
@@ -1562,6 +1535,22 @@ describe('Context class', () => {
       polymeshApi.emit('disconnected');
 
       sinon.assert.calledOnce(polymeshApi.disconnect);
+      sinon.assert.calledOnce(middlewareApi.stop);
+
+      expect(() => context.getAccounts()).toThrow(
+        'Client disconnected. Please create a new instance via "Polymesh.connect()"'
+      );
+
+      context = await Context.create({
+        polymeshApi,
+        middlewareApi: null,
+        accountSeed: '0x6'.padEnd(66, '0'),
+      });
+
+      await context.disconnect();
+      polymeshApi.emit('disconnected');
+
+      sinon.assert.calledTwice(polymeshApi.disconnect);
       sinon.assert.calledOnce(middlewareApi.stop);
 
       expect(() => context.getAccounts()).toThrow(


### PR DESCRIPTION
Previously, we were forcing a total disconnect when the polkadot.js API
emitted 'disconnect' or 'error' events. That was not necessary, since
polkadot.js already handles automatic reconnects