### PR TITLE
feat: 🎸 allow void procedure methods to be called with opts

### DIFF
--- a/scripts/prepareCodeForDocs.js
+++ b/scripts/prepareCodeForDocs.js
@@ -6,7 +6,7 @@
  *  (and we're using an older version), the way we're handling it is:
  *
  *   1. copy and rename the `src` directory
- *   2. replace all `ProcedureMethod` declarations in the code to resemble a method signature
+ *   2. replace all `ProcedureMethod` and `NoArgsProcedureMethod` declarations in the code to resemble a method signature
  *   3. add a `@note` tag explaining the special functionality of procedure methods
  *   4. add necessary imports to modified files
  *   5. run typedoc targeting the modified source code
@@ -18,31 +18,41 @@ const ts = require('typescript');
 const replace = require('replace-in-file');
 const path = require('path');
 
-const methodRegex = /\*\/\n\s+?public (\w+?)!?: (ProcedureMethod<[\w\W]+?>);/gs;
+const methodRegex = /\*\/\n\s+?public (\w+?)!?: ((?:NoArgs)?ProcedureMethod<[\w\W]+?>);/gs;
 const importRegex = /(import .+? from '.+?';\n)\n/s;
 
 /**
- * Get type arguments from a `ProcedureMethod` type declaration
+ * Get type arguments from a `ProcedureMethod` or `NoArgsProcedureMethod`  type declaration
  *
- * - calling the function with `ProcedureMethod<Foo, Bar, Baz>` will yield `{ methodArgs: 'Foo', procedureReturnValue: 'Bar', returnValue: 'Baz' }`
- * - calling the function with `ProcedureMethod<Foo, Bar>` will yield `{ methodArgs: 'Foo', procedureReturnValue: 'Bar', returnValue: undefined }`
+ * - calling the function with `ProcedureMethod<Foo, Bar, Baz>` will yield `{ methodArgs: 'Foo', procedureReturnValue: 'Bar', returnValue: 'Baz', kind: 'ProcedureMethod' }`
+ * - calling the function with `ProcedureMethod<Foo, Bar>` will yield `{ methodArgs: 'Foo', procedureReturnValue: 'Bar', returnValue: undefined, kind: 'ProcedureMethod' }`
+ * - calling the function with `NoArgsProcedureMethod<Foo, Bar>` will yield `{ procedureReturnValue: 'Foo', returnValue: 'Bar', kind: 'NoArgsProcedureMethod' }`
+ * - calling the function with `NoArgsProcedureMethod<Foo>` will yield `{ procedureReturnValue: 'Foo', returnValue: undefined, kind: 'NoArgsProcedureMethod' }`
  */
 const getTypeArgumentsFromProcedureMethod = typeString => {
   const source = ts.createSourceFile('temp', typeString);
 
   // NOTE @monitz87: this is very ugly but it's the quickest way I found of getting the type arguments
-  const [methodArgs, , procedureReturnValue, , returnValue] = source
-    .getChildren(source)[0]
-    .getChildren(source)[0]
-    .getChildren(source)[0]
+  const signature = source.getChildren(source)[0].getChildren(source)[0].getChildren(source)[0];
+  const kind = signature.getChildren(source)[0].getText(source);
+  const [first, , second, , third] = signature
     .getChildren(source)[2]
     .getChildren(source)
     .map(child => child.getText(source));
 
+  if (kind === 'ProcedureMethod') {
+    return {
+      methodArgs: first,
+      procedureReturnValue: second,
+      returnValue: third,
+      kind,
+    };
+  }
+
   return {
-    methodArgs,
-    procedureReturnValue,
-    returnValue,
+    procedureReturnValue: first,
+    returnValue: second,
+    kind,
   };
 };
 
@@ -50,18 +60,24 @@ const getTypeArgumentsFromProcedureMethod = typeString => {
  * Assemble a method signature according to the Procedure Method that is being replaced
  */
 const createReplacementSignature = (_, funcName, type) => {
-  const { methodArgs, returnValue, procedureReturnValue } = getTypeArgumentsFromProcedureMethod(
-    type
-  );
+  const {
+    methodArgs,
+    returnValue,
+    procedureReturnValue,
+    kind,
+  } = getTypeArgumentsFromProcedureMethod(type);
   const returnValueString = returnValue ? `, ${returnValue}` : '';
   const returnType = `Promise<TransactionQueue<${procedureReturnValue}${returnValueString}>>`;
 
+  const args = `args: ${methodArgs}, `;
+  const funcArgs = `(${kind === 'ProcedureMethod' ? args : ''}opts?: ProcedureOpts)`;
+
   // NOTE @monitz87: we make the function return a type asserted value to avoid compilation errors
   return `*
-   * @note this method is of type [[ProcedureMethod]], which means you can call \`${funcName}.checkAuthorization\`
+   * @note this method is of type [[${kind}]], which means you can call \`${funcName}.checkAuthorization\`
    *   on it to see whether the Current Account has the required permissions to run it
    */
-  public ${funcName}(args: ${methodArgs}, opts?: ProcedureOpts): ${returnType} {
+  public ${funcName}${funcArgs}: ${returnType} {
     return {} as ${returnType};
   }`;
 };

--- a/src/api/entities/Account.ts
+++ b/src/api/entities/Account.ts
@@ -10,10 +10,10 @@ import {
   Ensured,
   ExtrinsicData,
   ModuleName,
+  NoArgsProcedureMethod,
   NumberedPortfolio,
   Permissions,
   PermissionType,
-  ProcedureMethod,
   ResultSet,
   SimplePermissions,
   SubCallback,
@@ -84,7 +84,7 @@ export class Account extends Entity<UniqueIdentifiers, string> {
     this.authorizations = new Authorizations(this, context);
 
     this.leaveIdentity = createProcedureMethod(
-      { getProcedureAndArgs: () => [leaveIdentity, { account: this }] },
+      { getProcedureAndArgs: () => [leaveIdentity, { account: this }], voidArgs: true },
       context
     );
   }
@@ -92,7 +92,7 @@ export class Account extends Entity<UniqueIdentifiers, string> {
   /**
    * Leave the Account's Identity. This operation can only be done if the Account is a secondary key for the Identity
    */
-  public leaveIdentity: ProcedureMethod<void, void>;
+  public leaveIdentity: NoArgsProcedureMethod<void>;
 
   /**
    * Get the free/locked POLYX balance of the account

--- a/src/api/entities/AuthorizationRequest.ts
+++ b/src/api/entities/AuthorizationRequest.ts
@@ -11,7 +11,13 @@ import {
   Entity,
   Identity,
 } from '~/internal';
-import { Authorization, AuthorizationType, ProcedureMethod, Signer, SignerValue } from '~/types';
+import {
+  Authorization,
+  AuthorizationType,
+  NoArgsProcedureMethod,
+  Signer,
+  SignerValue,
+} from '~/types';
 import { HumanReadableType } from '~/types/utils';
 import { numberToU64, signerToSignerValue, signerValueToSignatory } from '~/utils/conversion';
 import { createProcedureMethod, toHumanReadable } from '~/utils/internal';
@@ -106,7 +112,6 @@ export class AuthorizationRequest extends Entity<UniqueIdentifiers, HumanReadabl
     this.data = data;
 
     this.accept = createProcedureMethod<
-      void,
       | ConsumeAuthorizationRequestsParams
       | ConsumeJoinIdentityAuthorizationParams
       | ConsumeAddMultiSigSignerAuthorizationParams,
@@ -128,12 +133,12 @@ export class AuthorizationRequest extends Entity<UniqueIdentifiers, HumanReadabl
             }
           }
         },
+        voidArgs: true,
       },
       context
     );
 
     this.remove = createProcedureMethod<
-      void,
       | ConsumeAuthorizationRequestsParams
       | ConsumeJoinIdentityAuthorizationParams
       | ConsumeAddMultiSigSignerAuthorizationParams,
@@ -155,6 +160,7 @@ export class AuthorizationRequest extends Entity<UniqueIdentifiers, HumanReadabl
             }
           }
         },
+        voidArgs: true,
       },
       context
     );
@@ -163,7 +169,7 @@ export class AuthorizationRequest extends Entity<UniqueIdentifiers, HumanReadabl
   /**
    * Accept the authorization request. You must be the target of the request to be able to accept it
    */
-  public accept: ProcedureMethod<void, void>;
+  public accept: NoArgsProcedureMethod<void>;
 
   /**
    * Remove the authorization request
@@ -171,7 +177,7 @@ export class AuthorizationRequest extends Entity<UniqueIdentifiers, HumanReadabl
    * - If you are the request issuer, this will cancel the authorization
    * - If you are the request target, this will reject the authorization
    */
-  public remove: ProcedureMethod<void, void>;
+  public remove: NoArgsProcedureMethod<void>;
 
   /**
    * Returns whether the Authorization Request has expired

--- a/src/api/entities/DividendDistribution/index.ts
+++ b/src/api/entities/DividendDistribution/index.ts
@@ -34,6 +34,7 @@ import {
   Ensured,
   ErrorCode,
   IdentityBalance,
+  NoArgsProcedureMethod,
   ProcedureMethod,
   ResultSet,
   TargetTreatment,
@@ -150,7 +151,7 @@ export class DividendDistribution extends CorporateAction {
     );
 
     this.claim = createProcedureMethod(
-      { getProcedureAndArgs: () => [claimDividends, { distribution: this }] },
+      { getProcedureAndArgs: () => [claimDividends, { distribution: this }], voidArgs: true },
       context
     );
 
@@ -167,6 +168,7 @@ export class DividendDistribution extends CorporateAction {
     this.reclaimFunds = createProcedureMethod(
       {
         getProcedureAndArgs: () => [reclaimDividendDistributionFunds, { distribution: this }],
+        voidArgs: true,
       },
       context
     );
@@ -177,7 +179,7 @@ export class DividendDistribution extends CorporateAction {
    *
    * @note if `currency` is indivisible, the Identity's share will be rounded down to the nearest integer (after taxes are withheld)
    */
-  public claim: ProcedureMethod<void, void>;
+  public claim: NoArgsProcedureMethod<void>;
 
   /**
    * Modify the Distribution's checkpoint
@@ -200,7 +202,7 @@ export class DividendDistribution extends CorporateAction {
    * @note required roles:
    *   - Origin Portfolio Custodian
    */
-  public reclaimFunds: ProcedureMethod<void, void>;
+  public reclaimFunds: NoArgsProcedureMethod<void>;
 
   /**
    * Retrieve the Checkpoint associated with this Dividend Distribution. If the Checkpoint is scheduled and has not been created yet,

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -36,6 +36,7 @@ import {
   isPortfolioCustodianRole,
   isTickerOwnerRole,
   isVenueOwnerRole,
+  NoArgsProcedureMethod,
   Order,
   PermissionType,
   ProcedureMethod,
@@ -161,11 +162,17 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
       context
     );
     this.freezeSecondaryKeys = createProcedureMethod(
-      { getProcedureAndArgs: () => [toggleFreezeSecondaryKeys, { freeze: true, identity: this }] },
+      {
+        getProcedureAndArgs: () => [toggleFreezeSecondaryKeys, { freeze: true, identity: this }],
+        voidArgs: true,
+      },
       context
     );
     this.unfreezeSecondaryKeys = createProcedureMethod(
-      { getProcedureAndArgs: () => [toggleFreezeSecondaryKeys, { freeze: false, identity: this }] },
+      {
+        getProcedureAndArgs: () => [toggleFreezeSecondaryKeys, { freeze: false, identity: this }],
+        voidArgs: true,
+      },
       context
     );
   }
@@ -202,12 +209,12 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
   /**
    * Freeze all the secondary keys in this Identity. This means revoking their permission to perform any operation on the blockchain and freezing their funds until the keys are unfrozen via [[unfreezeSecondaryKeys]]
    */
-  public freezeSecondaryKeys: ProcedureMethod<void, void>;
+  public freezeSecondaryKeys: NoArgsProcedureMethod<void>;
 
   /**
    * Unfreeze all the secondary keys in this Identity. This will restore their permissions as they were before being frozen
    */
-  public unfreezeSecondaryKeys: ProcedureMethod<void, void>;
+  public unfreezeSecondaryKeys: NoArgsProcedureMethod<void>;
 
   /**
    * Check whether this Identity possesses the specified Role

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -16,8 +16,8 @@ import {
   Ensured,
   ErrorCode,
   EventIdentifier,
+  NoArgsProcedureMethod,
   PaginationOptions,
-  ProcedureMethod,
   ResultSet,
 } from '~/types';
 import {
@@ -90,6 +90,7 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
           modifyInstructionAffirmation,
           { id, operation: InstructionAffirmationOperation.Reject },
         ],
+        voidArgs: true,
       },
       context
     );
@@ -100,6 +101,7 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
           modifyInstructionAffirmation,
           { id, operation: InstructionAffirmationOperation.Affirm },
         ],
+        voidArgs: true,
       },
       context
     );
@@ -110,6 +112,7 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
           modifyInstructionAffirmation,
           { id, operation: InstructionAffirmationOperation.Withdraw },
         ],
+        voidArgs: true,
       },
       context
     );
@@ -117,6 +120,7 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
     this.reschedule = createProcedureMethod(
       {
         getProcedureAndArgs: () => [rescheduleInstruction, { id }],
+        voidArgs: true,
       },
       context
     );
@@ -385,23 +389,23 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
    * @note reject on `SettleOnBlock` behaves just like unauthorize
    */
 
-  public reject: ProcedureMethod<void, Instruction>;
+  public reject: NoArgsProcedureMethod<Instruction>;
 
   /**
    * Affirm this instruction (authorize)
    */
 
-  public affirm: ProcedureMethod<void, Instruction>;
+  public affirm: NoArgsProcedureMethod<Instruction>;
 
   /**
    * Withdraw affirmation from this instruction (unauthorize)
    */
-  public withdraw: ProcedureMethod<void, Instruction>;
+  public withdraw: NoArgsProcedureMethod<Instruction>;
 
   /**
    * Schedule a failed Instructi oto rwaa
    */
-  public reschedule: ProcedureMethod<void, Instruction>;
+  public reschedule: NoArgsProcedureMethod<Instruction>;
 
   /**
    * @hidden

--- a/src/api/entities/NumberedPortfolio.ts
+++ b/src/api/entities/NumberedPortfolio.ts
@@ -9,7 +9,7 @@ import {
 } from '~/internal';
 import { eventByIndexedArgs } from '~/middleware/queries';
 import { EventIdEnum, ModuleIdEnum, Query } from '~/middleware/types';
-import { Ensured, EventIdentifier, ProcedureMethod } from '~/types';
+import { Ensured, EventIdentifier, NoArgsProcedureMethod, ProcedureMethod } from '~/types';
 import {
   middlewareEventToEventIdentifier,
   numberToU64,
@@ -53,7 +53,7 @@ export class NumberedPortfolio extends Portfolio {
     this.id = id;
 
     this.delete = createProcedureMethod(
-      { getProcedureAndArgs: () => [deletePortfolio, { did, id }] },
+      { getProcedureAndArgs: () => [deletePortfolio, { did, id }], voidArgs: true },
       context
     );
     this.modifyName = createProcedureMethod(
@@ -68,7 +68,7 @@ export class NumberedPortfolio extends Portfolio {
    * @note required role:
    *   - Portfolio Custodian
    */
-  public delete: ProcedureMethod<void, void>;
+  public delete: NoArgsProcedureMethod<void>;
 
   /**
    * Rename portfolio

--- a/src/api/entities/Portfolio/index.ts
+++ b/src/api/entities/Portfolio/index.ts
@@ -16,7 +16,7 @@ import {
 } from '~/internal';
 import { settlements } from '~/middleware/queries';
 import { Query } from '~/middleware/types';
-import { Ensured, ErrorCode, ProcedureMethod, ResultSet } from '~/types';
+import { Ensured, ErrorCode, NoArgsProcedureMethod, ProcedureMethod, ResultSet } from '~/types';
 import {
   addressToKey,
   balanceToBigNumber,
@@ -92,7 +92,7 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
       context
     );
     this.quitCustody = createProcedureMethod(
-      { getProcedureAndArgs: () => [quitCustody, { portfolio: this }] },
+      { getProcedureAndArgs: () => [quitCustody, { portfolio: this }], voidArgs: true },
       context
     );
   }
@@ -230,7 +230,7 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
    * @note required role:
    *   - Portfolio Custodian
    */
-  public quitCustody: ProcedureMethod<void, void>;
+  public quitCustody: NoArgsProcedureMethod<void>;
 
   /**
    * Retrieve the custodian Identity of this Portfolio

--- a/src/api/entities/SecurityToken/Checkpoints/index.ts
+++ b/src/api/entities/SecurityToken/Checkpoints/index.ts
@@ -12,8 +12,8 @@ import {
 import {
   CheckpointWithData,
   ErrorCode,
+  NoArgsProcedureMethod,
   PaginationOptions,
-  ProcedureMethod,
   ResultSet,
 } from '~/types';
 import { tuple } from '~/types/utils';
@@ -42,7 +42,7 @@ export class Checkpoints extends Namespace<SecurityToken> {
     const { ticker } = parent;
 
     this.create = createProcedureMethod(
-      { getProcedureAndArgs: () => [createCheckpoint, { ticker }] },
+      { getProcedureAndArgs: () => [createCheckpoint, { ticker }], voidArgs: true },
       context
     );
 
@@ -52,7 +52,7 @@ export class Checkpoints extends Namespace<SecurityToken> {
   /**
    * Create a snapshot of Security Token holders and their respective balances at this moment
    */
-  public create: ProcedureMethod<void, Checkpoint>;
+  public create: NoArgsProcedureMethod<Checkpoint>;
 
   /**
    * Retrieve a single Checkpoint for this Security Token by its ID

--- a/src/api/entities/SecurityToken/Compliance/Requirements.ts
+++ b/src/api/entities/SecurityToken/Compliance/Requirements.ts
@@ -11,7 +11,14 @@ import {
   SetAssetRequirementsParams,
   togglePauseRequirements,
 } from '~/internal';
-import { Compliance, ProcedureMethod, Requirement, SubCallback, UnsubCallback } from '~/types';
+import {
+  Compliance,
+  NoArgsProcedureMethod,
+  ProcedureMethod,
+  Requirement,
+  SubCallback,
+  UnsubCallback,
+} from '~/types';
 import {
   assetComplianceResultToCompliance,
   boolToBoolean,
@@ -40,15 +47,24 @@ export class Requirements extends Namespace<SecurityToken> {
       context
     );
     this.reset = createProcedureMethod(
-      { getProcedureAndArgs: () => [setAssetRequirements, { ticker, requirements: [] }] },
+      {
+        getProcedureAndArgs: () => [setAssetRequirements, { ticker, requirements: [] }],
+        voidArgs: true,
+      },
       context
     );
     this.pause = createProcedureMethod(
-      { getProcedureAndArgs: () => [togglePauseRequirements, { ticker, pause: true }] },
+      {
+        getProcedureAndArgs: () => [togglePauseRequirements, { ticker, pause: true }],
+        voidArgs: true,
+      },
       context
     );
     this.unpause = createProcedureMethod(
-      { getProcedureAndArgs: () => [togglePauseRequirements, { ticker, pause: false }] },
+      {
+        getProcedureAndArgs: () => [togglePauseRequirements, { ticker, pause: false }],
+        voidArgs: true,
+      },
       context
     );
   }
@@ -142,17 +158,17 @@ export class Requirements extends Namespace<SecurityToken> {
   /**
    * Detele all the current requirements for the Security Token.
    */
-  public reset: ProcedureMethod<void, SecurityToken>;
+  public reset: NoArgsProcedureMethod<SecurityToken>;
 
   /**
    * Pause all the Security Token's requirements. This means that all transfers will be allowed until requirements are unpaused
    */
-  public pause: ProcedureMethod<void, SecurityToken>;
+  public pause: NoArgsProcedureMethod<SecurityToken>;
 
   /**
    * Un-pause all the Security Token's current requirements
    */
-  public unpause: ProcedureMethod<void, SecurityToken>;
+  public unpause: NoArgsProcedureMethod<SecurityToken>;
 
   /**
    * Check whether the sender and receiver Identities in a transfer comply with all the requirements of this asset

--- a/src/api/entities/SecurityToken/CorporateActions/index.ts
+++ b/src/api/entities/SecurityToken/CorporateActions/index.ts
@@ -16,7 +16,7 @@ import {
   removeCorporateActionsAgent,
   SecurityToken,
 } from '~/internal';
-import { ProcedureMethod } from '~/types';
+import { NoArgsProcedureMethod, ProcedureMethod } from '~/types';
 import {
   identityIdToString,
   permillToBigNumber,
@@ -55,7 +55,7 @@ export class CorporateActions extends Namespace<SecurityToken> {
     );
 
     this.removeAgent = createProcedureMethod(
-      { getProcedureAndArgs: () => [removeCorporateActionsAgent, { ticker }] },
+      { getProcedureAndArgs: () => [removeCorporateActionsAgent, { ticker }], voidArgs: true },
       context
     );
 
@@ -92,7 +92,7 @@ export class CorporateActions extends Namespace<SecurityToken> {
    *
    * @deprecated
    */
-  public removeAgent: ProcedureMethod<void, void>;
+  public removeAgent: NoArgsProcedureMethod<void>;
 
   /**
    * Remove a Corporate Action

--- a/src/api/entities/SecurityToken/TransferRestrictions/Count.ts
+++ b/src/api/entities/SecurityToken/TransferRestrictions/Count.ts
@@ -3,6 +3,7 @@ import { AddCountTransferRestrictionParams, SetCountTransferRestrictionsParams }
 import {
   ActiveTransferRestrictions,
   CountTransferRestriction,
+  NoArgsProcedureMethod,
   ProcedureMethod,
   TransferRestrictionType,
 } from '~/types';
@@ -35,7 +36,7 @@ export class Count extends TransferRestrictionBase<TransferRestrictionType.Count
    *
    * @note the result is the total amount of restrictions after the procedure has run
    */
-  public removeRestrictions!: ProcedureMethod<void, number>;
+  public removeRestrictions!: NoArgsProcedureMethod<number>;
 
   /**
    * Retrieve all active Count Transfer Restrictions

--- a/src/api/entities/SecurityToken/TransferRestrictions/Percentage.ts
+++ b/src/api/entities/SecurityToken/TransferRestrictions/Percentage.ts
@@ -5,6 +5,7 @@ import {
 } from '~/internal';
 import {
   ActiveTransferRestrictions,
+  NoArgsProcedureMethod,
   PercentageTransferRestriction,
   ProcedureMethod,
   TransferRestrictionType,
@@ -41,7 +42,7 @@ export class Percentage extends TransferRestrictionBase<TransferRestrictionType.
    *
    * @note the result is the total amount of restrictions after the procedure has run
    */
-  public removeRestrictions!: ProcedureMethod<void, number>;
+  public removeRestrictions!: NoArgsProcedureMethod<number>;
 
   /**
    * Retrieve all active Percentage Transfer Restrictions

--- a/src/api/entities/SecurityToken/TransferRestrictions/TransferRestrictionBase.ts
+++ b/src/api/entities/SecurityToken/TransferRestrictions/TransferRestrictionBase.ts
@@ -15,6 +15,7 @@ import {
 import {
   ActiveTransferRestrictions,
   CountTransferRestriction,
+  NoArgsProcedureMethod,
   PercentageTransferRestriction,
   ProcedureMethod,
   TransferRestrictionType,
@@ -91,7 +92,6 @@ export abstract class TransferRestrictionBase<
     );
 
     this.removeRestrictions = createProcedureMethod<
-      void,
       SetTransferRestrictionsParams,
       number,
       SetTransferRestrictionsStorage
@@ -105,6 +105,7 @@ export abstract class TransferRestrictionBase<
             ticker,
           } as unknown) as SetTransferRestrictionsParams,
         ],
+        voidArgs: true,
       },
       context
     );
@@ -129,7 +130,7 @@ export abstract class TransferRestrictionBase<
    *
    * @note the result is the total amount of restrictions after the procedure has run
    */
-  public removeRestrictions: ProcedureMethod<void, number>;
+  public removeRestrictions: NoArgsProcedureMethod<number>;
 
   /**
    * Retrieve all active Transfer Restrictions of the corresponding type

--- a/src/api/entities/SecurityToken/index.ts
+++ b/src/api/entities/SecurityToken/index.ts
@@ -32,6 +32,7 @@ import {
   Ensured,
   EventIdentifier,
   HistoricAgentOperation,
+  NoArgsProcedureMethod,
   ProcedureMethod,
   SubCallback,
   TokenIdentifier,
@@ -144,11 +145,17 @@ export class SecurityToken extends Entity<UniqueIdentifiers, string> {
       context
     );
     this.freeze = createProcedureMethod(
-      { getProcedureAndArgs: () => [toggleFreezeTransfers, { ticker, freeze: true }] },
+      {
+        getProcedureAndArgs: () => [toggleFreezeTransfers, { ticker, freeze: true }],
+        voidArgs: true,
+      },
       context
     );
     this.unfreeze = createProcedureMethod(
-      { getProcedureAndArgs: () => [toggleFreezeTransfers, { ticker, freeze: false }] },
+      {
+        getProcedureAndArgs: () => [toggleFreezeTransfers, { ticker, freeze: false }],
+        voidArgs: true,
+      },
       context
     );
     this.modifyPrimaryIssuanceAgent = createProcedureMethod(
@@ -156,7 +163,7 @@ export class SecurityToken extends Entity<UniqueIdentifiers, string> {
       context
     );
     this.removePrimaryIssuanceAgent = createProcedureMethod(
-      { getProcedureAndArgs: () => [removePrimaryIssuanceAgent, { ticker }] },
+      { getProcedureAndArgs: () => [removePrimaryIssuanceAgent, { ticker }], voidArgs: true },
       context
     );
     this.redeem = createProcedureMethod(
@@ -379,12 +386,12 @@ export class SecurityToken extends Entity<UniqueIdentifiers, string> {
   /**
    * Freezes transfers and minting of the Security Token
    */
-  public freeze: ProcedureMethod<void, SecurityToken>;
+  public freeze: NoArgsProcedureMethod<SecurityToken>;
 
   /**
    * Unfreeze transfers and minting of the Security Token
    */
-  public unfreeze: ProcedureMethod<void, SecurityToken>;
+  public unfreeze: NoArgsProcedureMethod<SecurityToken>;
 
   /**
    * Check whether transfers are frozen for the Security Token
@@ -437,7 +444,7 @@ export class SecurityToken extends Entity<UniqueIdentifiers, string> {
    *
    * @deprecated
    */
-  public removePrimaryIssuanceAgent: ProcedureMethod<void, void>;
+  public removePrimaryIssuanceAgent: NoArgsProcedureMethod<void>;
 
   /**
    * Redeem (burn) an amount of this Security Token

--- a/src/api/entities/Sto/index.ts
+++ b/src/api/entities/Sto/index.ts
@@ -19,6 +19,7 @@ import { Query } from '~/middleware/types';
 import {
   Ensured,
   ErrorCode,
+  NoArgsProcedureMethod,
   ProcedureMethod,
   ResultSet,
   SubCallback,
@@ -75,15 +76,21 @@ export class Sto extends Entity<UniqueIdentifiers, HumanReadable> {
     this.ticker = ticker;
 
     this.freeze = createProcedureMethod(
-      { getProcedureAndArgs: () => [toggleFreezeSto, { ticker, id, freeze: true }] },
+      {
+        getProcedureAndArgs: () => [toggleFreezeSto, { ticker, id, freeze: true }],
+        voidArgs: true,
+      },
       context
     );
     this.unfreeze = createProcedureMethod(
-      { getProcedureAndArgs: () => [toggleFreezeSto, { ticker, id, freeze: false }] },
+      {
+        getProcedureAndArgs: () => [toggleFreezeSto, { ticker, id, freeze: false }],
+        voidArgs: true,
+      },
       context
     );
     this.close = createProcedureMethod(
-      { getProcedureAndArgs: () => [closeSto, { ticker, id }] },
+      { getProcedureAndArgs: () => [closeSto, { ticker, id }], voidArgs: true },
       context
     );
     this.modifyTimes = createProcedureMethod(
@@ -151,17 +158,17 @@ export class Sto extends Entity<UniqueIdentifiers, HumanReadable> {
   /**
    * Close the STO
    */
-  public close: ProcedureMethod<void, void>;
+  public close: NoArgsProcedureMethod<void>;
 
   /**
    * Freeze the STO
    */
-  public freeze: ProcedureMethod<void, Sto>;
+  public freeze: NoArgsProcedureMethod<Sto>;
 
   /**
    * Unfreeze the STO
    */
-  public unfreeze: ProcedureMethod<void, Sto>;
+  public unfreeze: NoArgsProcedureMethod<Sto>;
 
   /**
    * Modify the start/end time of the STO

--- a/src/api/entities/TickerReservation/index.ts
+++ b/src/api/entities/TickerReservation/index.ts
@@ -12,7 +12,7 @@ import {
   transferTickerOwnership,
   TransferTickerOwnershipParams,
 } from '~/internal';
-import { ProcedureMethod, SubCallback, UnsubCallback } from '~/types';
+import { NoArgsProcedureMethod, ProcedureMethod, SubCallback, UnsubCallback } from '~/types';
 import { identityIdToString, momentToDate, stringToTicker } from '~/utils/conversion';
 import { createProcedureMethod } from '~/utils/internal';
 
@@ -57,7 +57,10 @@ export class TickerReservation extends Entity<UniqueIdentifiers, string> {
     this.ticker = ticker;
 
     this.extend = createProcedureMethod(
-      { getProcedureAndArgs: () => [reserveTicker, { ticker, extendPeriod: true }] },
+      {
+        getProcedureAndArgs: () => [reserveTicker, { ticker, extendPeriod: true }],
+        voidArgs: true,
+      },
       context
     );
 
@@ -161,7 +164,7 @@ export class TickerReservation extends Entity<UniqueIdentifiers, string> {
    * @note required role:
    *   - Ticker Owner
    */
-  public extend: ProcedureMethod<void, TickerReservation>;
+  public extend: NoArgsProcedureMethod<TickerReservation>;
 
   /**
    * Create a Security Token using the reserved ticker

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1147,6 +1147,11 @@ export interface ProcedureMethod<
   ) => Promise<ProcedureAuthorizationStatus>;
 }
 
+export interface NoArgsProcedureMethod<ProcedureReturnValue, ReturnValue = ProcedureReturnValue> {
+  (opts?: ProcedureOpts): Promise<TransactionQueue<ProcedureReturnValue, ReturnValue>>;
+  checkAuthorization: (opts?: ProcedureOpts) => Promise<ProcedureAuthorizationStatus>;
+}
+
 export enum SignerType {
   /* eslint-disable @typescript-eslint/no-shadow */
   Identity = 'Identity',

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -9,7 +9,14 @@ import { SecurityToken } from '~/api/entities/SecurityToken';
 import { Context, PostTransactionValue, Procedure } from '~/internal';
 import { ClaimScopeTypeEnum } from '~/middleware/types';
 import { dsMockUtils, entityMockUtils } from '~/testUtils/mocks';
-import { CalendarPeriod, CalendarUnit, ClaimType, CommonKeyring, CountryCode } from '~/types';
+import {
+  CalendarPeriod,
+  CalendarUnit,
+  ClaimType,
+  CommonKeyring,
+  CountryCode,
+  ProcedureMethod,
+} from '~/types';
 import { tuple } from '~/types/utils';
 import { DEFAULT_MAX_BATCH_ELEMENTS, MAX_BATCH_ELEMENTS } from '~/utils/constants';
 
@@ -492,8 +499,8 @@ describe('createProcedureMethod', () => {
         checkAuthorization,
       } as unknown) as Procedure<number, void>);
 
-    const method = createProcedureMethod(
-      { getProcedureAndArgs: (args: number) => [fakeProcedure, args], transformer },
+    const method: ProcedureMethod<number, void> = createProcedureMethod(
+      { getProcedureAndArgs: args => [fakeProcedure, args], transformer },
       context
     );
 
@@ -505,6 +512,30 @@ describe('createProcedureMethod', () => {
     await method.checkAuthorization(procArgs);
 
     sinon.assert.calledWithExactly(checkAuthorization, procArgs, context, {});
+  });
+
+  test('should return a NoArgsProcedureMethod object', async () => {
+    const prepare = sinon.stub();
+    const checkAuthorization = sinon.stub();
+    const transformer = sinon.stub();
+    const fakeProcedure = (): Procedure<void, void> =>
+      (({
+        prepare,
+        checkAuthorization,
+      } as unknown) as Procedure<void, void>);
+
+    const method = createProcedureMethod(
+      { getProcedureAndArgs: () => [fakeProcedure, undefined], transformer, voidArgs: true },
+      context
+    );
+
+    await method();
+
+    sinon.assert.calledWithExactly(prepare, { transformer, args: undefined }, context, {});
+
+    await method.checkAuthorization();
+
+    sinon.assert.calledWithExactly(checkAuthorization, undefined, context, {});
   });
 });
 


### PR DESCRIPTION
Procedure methods that received no arguments had to be called with
`undefined` as the first argument if options wanted to be passed (such
as a custom signer). Now the opts object can be passed as the first arg

BREAKING CHANGE: 🧨 remove required `undefined` as first argument of procedures when passing
options