### PR TITLE
feat: 🎸 export typeguards for every Entity

### DIFF
--- a/src/api/entities/__tests__/Entity.ts
+++ b/src/api/entities/__tests__/Entity.ts
@@ -1,7 +1,6 @@
 import sinon from 'sinon';
 
 import { Context, Entity } from '~/internal';
-import { isEntity } from '~/types';
 import * as utilsInternalModule from '~/utils/internal';
 
 // eslint-disable-next-line require-jsdoc
@@ -68,21 +67,5 @@ describe('Entity class', () => {
       expect(first.isEqual(second)).toBe(false);
       expect(second.isEqual(first)).toBe(false);
     });
-  });
-});
-
-describe('isEntity', () => {
-  afterAll(() => {
-    sinon.restore();
-  });
-
-  test('should return whether the value is an Entity', () => {
-    const serializeStub = sinon.stub(utilsInternalModule, 'serialize');
-
-    serializeStub.withArgs('NonAbstract', { foo: 'bar' }).returns('uuid');
-
-    const entity = new NonAbstract({ foo: 'bar' }, {} as Context);
-
-    expect(isEntity(entity)).toBe(true);
   });
 });

--- a/src/api/entities/types.ts
+++ b/src/api/entities/types.ts
@@ -1,14 +1,16 @@
 import {
   Account as AccountClass,
   AuthorizationRequest as AuthorizationRequestClass,
+  Checkpoint as CheckpointClass,
   CheckpointSchedule as CheckpointScheduleClass,
   CorporateAction as CorporateActionClass,
+  CustomPermissionGroup as CustomPermissionGroupClass,
   DefaultPortfolio as DefaultPortfolioClass,
   DefaultTrustedClaimIssuer as DefaultTrustedClaimIssuerClass,
   DividendDistribution as DividendDistributionClass,
-  Entity as EntityClass,
   Identity as IdentityClass,
   Instruction as InstructionClass,
+  KnownPermissionGroup as KnownPermissionGroupClass,
   NumberedPortfolio as NumberedPortfolioClass,
   // Proposal as ProposalClass,
   SecurityToken as SecurityTokenClass,
@@ -17,39 +19,32 @@ import {
   Venue as VenueClass,
 } from '~/internal';
 
-export type SecurityToken = InstanceType<typeof SecurityTokenClass>;
-export type TickerReservation = InstanceType<typeof TickerReservationClass>;
-export type AuthorizationRequest = InstanceType<typeof AuthorizationRequestClass>;
-export type Identity = InstanceType<typeof IdentityClass>;
-export type Account = InstanceType<typeof AccountClass>;
-export type Venue = InstanceType<typeof VenueClass>;
-export type Instruction = InstanceType<typeof InstructionClass>;
-export type DefaultPortfolio = InstanceType<typeof DefaultPortfolioClass>;
-export type NumberedPortfolio = InstanceType<typeof NumberedPortfolioClass>;
-export type DefaultTrustedClaimIssuer = InstanceType<typeof DefaultTrustedClaimIssuerClass>;
-export type Sto = InstanceType<typeof StoClass>;
-export type CheckpointSchedule = InstanceType<typeof CheckpointScheduleClass>;
-export type CorporateAction = InstanceType<typeof CorporateActionClass>;
-export type DividendDistribution = InstanceType<typeof DividendDistributionClass>;
+export type Account = AccountClass;
+export type AuthorizationRequest = AuthorizationRequestClass;
+export type Checkpoint = CheckpointClass;
+export type CheckpointSchedule = CheckpointScheduleClass;
+export type CorporateAction = CorporateActionClass;
+export type CustomPermissionGroup = CustomPermissionGroupClass;
+export type DefaultPortfolio = DefaultPortfolioClass;
+export type DefaultTrustedClaimIssuer = DefaultTrustedClaimIssuerClass;
+export type DividendDistribution = DividendDistributionClass;
+export type Identity = IdentityClass;
+export type Instruction = InstructionClass;
+export type KnownPermissionGroup = KnownPermissionGroupClass;
+export type NumberedPortfolio = NumberedPortfolioClass;
+export type SecurityToken = SecurityTokenClass;
+export type Sto = StoClass;
+export type TickerReservation = TickerReservationClass;
+export type Venue = VenueClass;
 // export type Proposal = InstanceType<typeof ProposalClass>;
 
-export * from './TickerReservation/types';
-export * from './SecurityToken/types';
-export * from './Venue/types';
-export * from './Instruction/types';
-export * from './Portfolio/types';
-export * from './Sto/types';
 export * from './CheckpointSchedule/types';
 export * from './CorporateAction/types';
 export * from './DividendDistribution/types';
+export * from './Instruction/types';
+export * from './Portfolio/types';
+export * from './SecurityToken/types';
+export * from './Sto/types';
+export * from './TickerReservation/types';
+export * from './Venue/types';
 // export * from './Proposal/types';
-
-/**
- * Return if value is an Entity
- */
-export function isEntity<Identifiers = unknown, HumanReadable = unknown>(
-  value: unknown
-): value is EntityClass<Identifiers, HumanReadable> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return !!value && typeof (value as any).uuid === 'string';
-}

--- a/src/api/procedures/setPermissionGroup.ts
+++ b/src/api/procedures/setPermissionGroup.ts
@@ -11,8 +11,9 @@ import {
   Procedure,
   SecurityToken,
 } from '~/internal';
-import { ErrorCode, Identity, isEntity, TransactionPermissions, TxGroup } from '~/types';
+import { ErrorCode, Identity, TransactionPermissions, TxGroup } from '~/types';
 import { MaybePostTransactionValue, ProcedureAuthorization } from '~/types/internal';
+import { isEntity } from '~/utils';
 import {
   permissionGroupIdentifierToAgentGroup,
   stringToIdentityId,

--- a/src/base/PolymeshError.ts
+++ b/src/base/PolymeshError.ts
@@ -35,12 +35,3 @@ export class PolymeshError extends Error {
     this.data = data;
   }
 }
-
-/**
- * @hidden
- */
-export function isPolymeshError(err: unknown): err is PolymeshError {
-  const error = err as PolymeshError;
-
-  return typeof error.code === 'string' && typeof error.message === 'string';
-}

--- a/src/base/__tests__/PolymeshError.ts
+++ b/src/base/__tests__/PolymeshError.ts
@@ -1,6 +1,6 @@
 import { ErrorCode } from '~/types';
 
-import { isPolymeshError, PolymeshError } from '../PolymeshError';
+import { PolymeshError } from '../PolymeshError';
 
 describe('Polymesh Error class', () => {
   test('should extend error', () => {
@@ -24,17 +24,5 @@ describe('Polymesh Error class', () => {
       expect(err.code).toBe(code);
       expect(err.message).toBe(`Unknown error, code: ${code}`);
     });
-  });
-});
-
-describe('isPolymeshError', () => {
-  test('should return whether the input is a PolymeshError object', () => {
-    let result = isPolymeshError(new PolymeshError({ code: ErrorCode.FatalError }));
-
-    expect(result).toBe(true);
-
-    result = isPolymeshError('Hello');
-
-    expect(result).toBe(false);
   });
 });

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -7,4 +7,3 @@ import { TransactionQueue as TransactionQueueClass } from './TransactionQueue';
 export type PolymeshTransaction = InstanceType<typeof PolymeshTransactionClass>;
 export type TransactionQueue = InstanceType<typeof TransactionQueueClass>;
 export type PolymeshError = InstanceType<typeof PolymeshErrorClass>;
-export { isPolymeshError } from './PolymeshError';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,5 @@
+/* istanbul ignore file */
+
 export { tickerToDid, isCusipValid, isLeiValid, isIsinValid, txGroupToTxTags } from './conversion';
+export * from './typeguards';
 export { cryptoWaitReady } from '@polkadot/util-crypto';

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -32,7 +32,6 @@ import {
   CommonKeyring,
   CountryCode,
   ErrorCode,
-  isEntity,
   NextKey,
   PaginationOptions,
   ProcedureAuthorizationStatus,
@@ -54,6 +53,7 @@ import {
   MAX_BATCH_ELEMENTS,
 } from '~/utils/constants';
 import { middlewareScopeToScope, signerToString } from '~/utils/conversion';
+import { isEntity } from '~/utils/typeguards';
 
 export * from '~/generated/utils';
 

--- a/src/utils/typeguards.ts
+++ b/src/utils/typeguards.ts
@@ -1,0 +1,158 @@
+/* istanbul ignore file */
+
+import {
+  Account,
+  AuthorizationRequest,
+  Checkpoint,
+  CheckpointSchedule,
+  CorporateAction,
+  CustomPermissionGroup,
+  DefaultPortfolio,
+  DefaultTrustedClaimIssuer,
+  DividendDistribution,
+  Entity,
+  Identity,
+  Instruction,
+  KnownPermissionGroup,
+  NumberedPortfolio,
+  PolymeshError,
+  SecurityToken,
+  Sto,
+  TickerReservation,
+  Venue,
+} from '~/internal';
+
+/**
+ * Return whether value is an Entity
+ */
+export function isEntity<Identifiers = unknown, HumanReadable = unknown>(
+  value: unknown
+): value is Entity<Identifiers, HumanReadable> {
+  return value instanceof Entity;
+}
+
+/**
+ * Return whether value is an Account
+ */
+export function isAccount(value: unknown): value is Account {
+  return value instanceof Account;
+}
+
+/**
+ * Return whether value is an AuthorizationRequest
+ */
+export function isAuthorizationRequest(value: unknown): value is AuthorizationRequest {
+  return value instanceof AuthorizationRequest;
+}
+
+/**
+ * Return whether value is a Checkpoint
+ */
+export function isCheckpoint(value: unknown): value is Checkpoint {
+  return value instanceof Checkpoint;
+}
+
+/**
+ * Return whether value is a CheckpointSchedule
+ */
+export function isCheckpointSchedule(value: unknown): value is CheckpointSchedule {
+  return value instanceof CheckpointSchedule;
+}
+
+/**
+ * Return whether value is a CorporateAction
+ */
+export function isCorporateAction(value: unknown): value is CorporateAction {
+  return value instanceof CorporateAction;
+}
+
+/**
+ * Return whether value is a CustomPermissionGroup
+ */
+export function isCustomPermissionGroup(value: unknown): value is CustomPermissionGroup {
+  return value instanceof CustomPermissionGroup;
+}
+
+/**
+ * Return whether value is a DefaultPortfolio
+ */
+export function isDefaultPortfolio(value: unknown): value is DefaultPortfolio {
+  return value instanceof DefaultPortfolio;
+}
+
+/**
+ * Return whether value is a DefaultTrustedClaimIssuer
+ */
+export function isDefaultTrustedClaimIssuer(value: unknown): value is DefaultTrustedClaimIssuer {
+  return value instanceof DefaultTrustedClaimIssuer;
+}
+
+/**
+ * Return whether value is a DividendDistribution
+ */
+export function isDividendDistribution(value: unknown): value is DividendDistribution {
+  return value instanceof DividendDistribution;
+}
+
+/**
+ * Return whether value is an Identity
+ */
+export function isIdentity(value: unknown): value is Identity {
+  return value instanceof Identity;
+}
+
+/**
+ * Return whether value is an Instruction
+ */
+export function isInstruction(value: unknown): value is Instruction {
+  return value instanceof Instruction;
+}
+
+/**
+ * Return whether value is a KnownPermissionGroup
+ */
+export function isKnownPermissionGroup(value: unknown): value is KnownPermissionGroup {
+  return value instanceof KnownPermissionGroup;
+}
+
+/**
+ * Return whether value is a NumberedPortfolio
+ */
+export function isNumberedPortfolio(value: unknown): value is NumberedPortfolio {
+  return value instanceof NumberedPortfolio;
+}
+
+/**
+ * Return whether value is a SecurityToken
+ */
+export function isSecurityToken(value: unknown): value is SecurityToken {
+  return value instanceof SecurityToken;
+}
+
+/**
+ * Return whether value is an Sto
+ */
+export function isSto(value: unknown): value is Sto {
+  return value instanceof Sto;
+}
+
+/**
+ * Return whether value is a TickerReservation
+ */
+export function isTickerReservation(value: unknown): value is TickerReservation {
+  return value instanceof TickerReservation;
+}
+
+/**
+ * Return whether value is a Venue
+ */
+export function isVenue(value: unknown): value is Venue {
+  return value instanceof Venue;
+}
+
+/**
+ * Return whether value is a PolymeshError
+ */
+export function isPolymeshError(value: unknown): value is PolymeshError {
+  return value instanceof PolymeshError;
+}


### PR DESCRIPTION
They are now exported from `/utils`

BREAKING CHANGE: 🧨 move `isEntity` and `isPolymeshError` from `/types` to `/utils`