### PR TITLE
fix: 🐛 use correct type when fetching sent authorizations

### DIFF
--- a/src/api/entities/Identity/IdentityAuthorizations.ts
+++ b/src/api/entities/Identity/IdentityAuthorizations.ts
@@ -1,3 +1,4 @@
+import { Option } from '@polkadot/types';
 import { Authorization } from 'polymesh-types/types';
 
 import { AuthorizationRequest, Authorizations, Identity } from '~/internal';
@@ -36,13 +37,13 @@ export class IdentityAuthorizations extends Authorizations<Identity> {
       tuple(signatory, storageKey.args[1])
     );
 
-    const authorizations = await polymeshApi.query.identity.authorizations.multi<Authorization>(
-      authQueryParams
-    );
+    const authorizations = await polymeshApi.query.identity.authorizations.multi<
+      Option<Authorization>
+    >(authQueryParams);
 
     const data = this.createAuthorizationRequests(
       authorizations.map((auth, index) => ({
-        auth,
+        auth: auth.unwrap(),
         target: signatoryToSignerValue(authQueryParams[index][0]),
       }))
     );

--- a/src/api/entities/Identity/__tests__/IdentityAuthorizations.ts
+++ b/src/api/entities/Identity/__tests__/IdentityAuthorizations.ts
@@ -108,7 +108,9 @@ describe('IdentityAuthorizations class', () => {
       );
 
       const authorizationsStub = dsMockUtils.createQueryStub('identity', 'authorizations');
-      authorizationsStub.multi.withArgs(authsMultiArgs).resolves(authorizations);
+      authorizationsStub.multi
+        .withArgs(authsMultiArgs)
+        .resolves(authorizations.map(dsMockUtils.createMockOption));
 
       const expectedAuthorizations = authParams.map(({ authId, target, issuer, expiry, data }) =>
         entityMockUtils.getAuthorizationRequestInstance({


### PR DESCRIPTION
The recent type change from `Authorization` to `Option<Authorization>`
wasn't being properly handled