### PR TITLE
refactor: 💡 MSDK-750 Rename CADefaults to CADefaultConfig

### DIFF
--- a/src/api/entities/SecurityToken/CorporateActions/__tests__/index.ts
+++ b/src/api/entities/SecurityToken/CorporateActions/__tests__/index.ts
@@ -64,7 +64,7 @@ describe('CorporateActions class', () => {
     expect(CorporateActions.prototype instanceof Namespace).toBe(true);
   });
 
-  describe('method: setDefaults', () => {
+  describe('method: setDefaultConfig', () => {
     test('should prepare the procedure with the correct arguments and context, and return the resulting transaction queue', async () => {
       const targets = {
         identities: ['someDid'],
@@ -90,7 +90,7 @@ describe('CorporateActions class', () => {
         )
         .resolves(expectedQueue);
 
-      const queue = await corporateActions.setDefaults({
+      const queue = await corporateActions.setDefaultConfig({
         targets,
         taxWithholdings,
         defaultTaxWithholding,
@@ -178,8 +178,8 @@ describe('CorporateActions class', () => {
     });
   });
 
-  describe('method: getDefaults', () => {
-    test("should retrieve the Security Token's Corporate Actions defaults", async () => {
+  describe('method: getDefaultConfig', () => {
+    test("should retrieve the Security Token's Corporate Actions Default Config", async () => {
       const dids = ['someDid', 'otherDid'];
       const targets = {
         identities: [
@@ -204,7 +204,7 @@ describe('CorporateActions class', () => {
         [[dsMockUtils.createMockIdentityId(dids[0]), dsMockUtils.createMockPermill(15 * 10000)]],
       ]);
 
-      const result = await corporateActions.getDefaults();
+      const result = await corporateActions.getDefaultConfig();
 
       expect(result).toEqual({
         targets,

--- a/src/api/entities/SecurityToken/CorporateActions/index.ts
+++ b/src/api/entities/SecurityToken/CorporateActions/index.ts
@@ -3,8 +3,8 @@ import { QueryableStorageEntry } from '@polkadot/api/types';
 import {
   Context,
   Identity,
-  modifyCaDefaults,
-  ModifyCaDefaultsParams,
+  modifyCaDefaultConfig,
+  ModifyCaDefaultConfigParams,
   modifyCorporateActionsAgent,
   ModifyCorporateActionsAgentParams,
   Namespace,
@@ -24,7 +24,7 @@ import {
 import { createProcedureMethod } from '~/utils/internal';
 
 import { Distributions } from './Distributions';
-import { CorporateActionDefaults } from './types';
+import { CorporateActionDefaultConfig } from './types';
 
 /**
  * Handles all Security Token Corporate Actions related functionality
@@ -42,8 +42,8 @@ export class CorporateActions extends Namespace<SecurityToken> {
 
     this.distributions = new Distributions(parent, context);
 
-    this.setDefaults = createProcedureMethod(
-      { getProcedureAndArgs: args => [modifyCaDefaults, { ticker, ...args }] },
+    this.setDefaultConfig = createProcedureMethod(
+      { getProcedureAndArgs: args => [modifyCaDefaultConfig, { ticker, ...args }] },
       context
     );
 
@@ -64,13 +64,13 @@ export class CorporateActions extends Namespace<SecurityToken> {
   }
 
   /**
-   * Assign default values for targets, global tax withholding percentage and per-identity tax withholding perecentages.
+   * Assign default config values(targets, global tax withholding percentage and per-identity tax withholding perecentages).
    *
-   * @note These values are applied to every Corporate Action that is created until they are modified. Modifying these values
+   * @note These config values are applied to every Corporate Action that is created until they are modified. Modifying these values
    *   does not impact existing Corporate Actions.
-   *   When creating a Corporate Action, values passed explicitly will override these defaults
+   *   When creating a Corporate Action, values passed explicitly will override these default config values
    */
-  public setDefaults: ProcedureMethod<ModifyCaDefaultsParams, void>;
+  public setDefaultConfig: ProcedureMethod<ModifyCaDefaultConfigParams, void>;
 
   /**
    * Assign a new Corporate Actions Agent for the Security Token
@@ -128,14 +128,14 @@ export class CorporateActions extends Namespace<SecurityToken> {
   }
 
   /**
-   * Retrieve default values for targets, global tax withholding percentage and per-identity tax withholding percentages.
+   * Retrieve default config comprising of targets, global tax withholding percentage and per-identity tax withholding percentages.
    *
    *
-   * @note These values are applied to every Corporate Action that is created until they are modified. Modifying these values
+   * @note This config is applied to every Corporate Action that is created until they are modified. Modifying the default config
    *   does not impact existing Corporate Actions.
-   *   When creating a Corporate Action, values passed explicitly will override these defaults
+   *   When creating a Corporate Action, values passed explicitly will override this default config
    */
-  public async getDefaults(): Promise<CorporateActionDefaults> {
+  public async getDefaultConfig(): Promise<CorporateActionDefaultConfig> {
     const {
       parent: { ticker },
       context: {

--- a/src/api/entities/SecurityToken/CorporateActions/types.ts
+++ b/src/api/entities/SecurityToken/CorporateActions/types.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 
 import { CorporateActionTargets, TaxWithholding } from '~/types';
 
-export interface CorporateActionDefaults {
+export interface CorporateActionDefaultConfig {
   targets: CorporateActionTargets;
   defaultTaxWithholding: BigNumber;
   taxWithholdings: TaxWithholding[];

--- a/src/api/procedures/__tests__/modifyCaDefaultConfig.ts
+++ b/src/api/procedures/__tests__/modifyCaDefaultConfig.ts
@@ -5,8 +5,8 @@ import sinon from 'sinon';
 import {
   getAuthorization,
   Params,
-  prepareModifyCaDefaults,
-} from '~/api/procedures/modifyCaDefaults';
+  prepareModifyCaDefaultConfig,
+} from '~/api/procedures/modifyCaDefaultConfig';
 import * as utilsProcedureModule from '~/api/procedures/utils';
 import { Context } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
@@ -19,7 +19,7 @@ jest.mock(
   require('~/testUtils/mocks/entities').mockSecurityTokenModule('~/api/entities/SecurityToken')
 );
 
-describe('modifyCaDefaults procedure', () => {
+describe('modifyCaDefaultConfig procedure', () => {
   let mockContext: Mocked<Context>;
   let stringToTickerStub: sinon.SinonStub;
   let targetsToTargetIdentitiesStub: sinon.SinonStub;
@@ -73,9 +73,9 @@ describe('modifyCaDefaults procedure', () => {
   test('should throw an error if the user has not passed any arguments', () => {
     const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
 
-    return expect(prepareModifyCaDefaults.call(proc, ({} as unknown) as Params)).rejects.toThrow(
-      'Nothing to modify'
-    );
+    return expect(
+      prepareModifyCaDefaultConfig.call(proc, ({} as unknown) as Params)
+    ).rejects.toThrow('Nothing to modify');
   });
 
   test('should throw an error if the new targets are the same as the current ones', () => {
@@ -86,11 +86,11 @@ describe('modifyCaDefaults procedure', () => {
       treatment: TargetTreatment.Exclude,
     };
     entityMockUtils.configureMocks({
-      securityTokenOptions: { corporateActionsGetDefaults: { targets } },
+      securityTokenOptions: { corporateActionsGetDefaultConfig: { targets } },
     });
 
     return expect(
-      prepareModifyCaDefaults.call(proc, {
+      prepareModifyCaDefaultConfig.call(proc, {
         ticker,
         targets,
       })
@@ -102,11 +102,11 @@ describe('modifyCaDefaults procedure', () => {
 
     const defaultTaxWithholding = new BigNumber(10);
     entityMockUtils.configureMocks({
-      securityTokenOptions: { corporateActionsGetDefaults: { defaultTaxWithholding } },
+      securityTokenOptions: { corporateActionsGetDefaultConfig: { defaultTaxWithholding } },
     });
 
     return expect(
-      prepareModifyCaDefaults.call(proc, {
+      prepareModifyCaDefaultConfig.call(proc, {
         ticker,
         defaultTaxWithholding,
       })
@@ -123,11 +123,11 @@ describe('modifyCaDefaults procedure', () => {
       },
     ];
     entityMockUtils.configureMocks({
-      securityTokenOptions: { corporateActionsGetDefaults: { taxWithholdings } },
+      securityTokenOptions: { corporateActionsGetDefaultConfig: { taxWithholdings } },
     });
 
     return expect(
-      prepareModifyCaDefaults.call(proc, {
+      prepareModifyCaDefaultConfig.call(proc, {
         ticker,
         taxWithholdings,
       })
@@ -146,7 +146,7 @@ describe('modifyCaDefaults procedure', () => {
 
     entityMockUtils.configureMocks({
       securityTokenOptions: {
-        corporateActionsGetDefaults: {
+        corporateActionsGetDefaultConfig: {
           targets: {
             identities: [entityMockUtils.getIdentityInstance({ did: 'someDid' })],
             treatment: TargetTreatment.Include,
@@ -161,7 +161,7 @@ describe('modifyCaDefaults procedure', () => {
     });
     targetsToTargetIdentitiesStub.withArgs(targets, mockContext).returns(rawTargets);
 
-    await prepareModifyCaDefaults.call(proc, {
+    await prepareModifyCaDefaultConfig.call(proc, {
       ticker,
       targets,
     });
@@ -186,7 +186,7 @@ describe('modifyCaDefaults procedure', () => {
     };
     targetsToTargetIdentitiesStub.withArgs(targets, mockContext).returns(rawTargets);
 
-    await prepareModifyCaDefaults.call(proc, {
+    await prepareModifyCaDefaultConfig.call(proc, {
       ticker,
       targets,
     });
@@ -208,7 +208,7 @@ describe('modifyCaDefaults procedure', () => {
 
     entityMockUtils.configureMocks({
       securityTokenOptions: {
-        corporateActionsGetDefaults: {
+        corporateActionsGetDefaultConfig: {
           defaultTaxWithholding: new BigNumber(10),
         },
       },
@@ -217,7 +217,7 @@ describe('modifyCaDefaults procedure', () => {
     const rawPercentage = dsMockUtils.createMockPermill(150000);
     percentageToPermillStub.withArgs(new BigNumber(15), mockContext).returns(rawPercentage);
 
-    await prepareModifyCaDefaults.call(proc, {
+    await prepareModifyCaDefaultConfig.call(proc, {
       ticker,
       defaultTaxWithholding: new BigNumber(15),
     });
@@ -238,7 +238,7 @@ describe('modifyCaDefaults procedure', () => {
 
     entityMockUtils.configureMocks({
       securityTokenOptions: {
-        corporateActionsGetDefaults: {
+        corporateActionsGetDefaultConfig: {
           taxWithholdings: [],
         },
       },
@@ -256,7 +256,7 @@ describe('modifyCaDefaults procedure', () => {
         percentage: new BigNumber(25),
       },
     ];
-    await prepareModifyCaDefaults.call(proc, {
+    await prepareModifyCaDefaultConfig.call(proc, {
       ticker,
       taxWithholdings,
     });

--- a/src/api/procedures/modifyCaDefaultConfig.ts
+++ b/src/api/procedures/modifyCaDefaultConfig.ts
@@ -20,7 +20,7 @@ import {
   targetsToTargetIdentities,
 } from '~/utils/conversion';
 
-export type ModifyCaDefaultsParams =
+export type ModifyCaDefaultConfigParams =
   | {
       targets?: InputTargets;
       defaultTaxWithholding: BigNumber;
@@ -40,7 +40,7 @@ export type ModifyCaDefaultsParams =
 /**
  * @hidden
  */
-export type Params = { ticker: string } & ModifyCaDefaultsParams;
+export type Params = { ticker: string } & ModifyCaDefaultConfigParams;
 
 const areSameTargets = (targets: CorporateActionTargets, newTargets: InputTargets): boolean => {
   const { identities: newIdentities, treatment: newTreatment } = newTargets;
@@ -60,7 +60,7 @@ const areSameTargets = (targets: CorporateActionTargets, newTargets: InputTarget
 /**
  * @hidden
  */
-export async function prepareModifyCaDefaults(
+export async function prepareModifyCaDefaultConfig(
   this: Procedure<Params, void>,
   args: Params
 ): Promise<void> {
@@ -104,7 +104,7 @@ export async function prepareModifyCaDefaults(
     targets,
     defaultTaxWithholding,
     taxWithholdings,
-  } = await securityToken.corporateActions.getDefaults();
+  } = await securityToken.corporateActions.getDefaultConfig();
 
   if (newTargets) {
     if (areSameTargets(targets, newTargets)) {
@@ -199,5 +199,5 @@ export function getAuthorization(
 /**
  * @hidden
  */
-export const modifyCaDefaults = (): Procedure<Params, void> =>
-  new Procedure(prepareModifyCaDefaults, getAuthorization);
+export const modifyCaDefaultConfig = (): Procedure<Params, void> =>
+  new Procedure(prepareModifyCaDefaultConfig, getAuthorization);

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -160,7 +160,10 @@ export { claimDividends } from '~/api/procedures/claimDividends';
 export { removeCorporateActionsAgent } from '~/api/procedures/removeCorporateActionsAgent';
 export { modifyCaCheckpoint, ModifyCaCheckpointParams } from '~/api/procedures/modifyCaCheckpoint';
 export { payDividends, PayDividendsParams } from '~/api/procedures/payDividends';
-export { modifyCaDefaults, ModifyCaDefaultsParams } from '~/api/procedures/modifyCaDefaults';
+export {
+  modifyCaDefaultConfig,
+  ModifyCaDefaultConfigParams,
+} from '~/api/procedures/modifyCaDefaultConfig';
 export {
   removeCorporateAction,
   RemoveCorporateActionParams,

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -38,7 +38,7 @@ import {
   CalendarUnit,
   CheckPermissionsResult,
   CheckRolesResult,
-  CorporateActionDefaults,
+  CorporateActionDefaultConfig,
   CorporateActionKind,
   CorporateActionTargets,
   CountTransferRestriction,
@@ -158,7 +158,7 @@ interface SecurityTokenOptions {
   transferRestrictionsCountGet?: ActiveTransferRestrictions<CountTransferRestriction>;
   transferRestrictionsPercentageGet?: ActiveTransferRestrictions<PercentageTransferRestriction>;
   corporateActionsGetAgents?: Identity[];
-  corporateActionsGetDefaults?: Partial<CorporateActionDefaults>;
+  corporateActionsGetDefaultConfig?: Partial<CorporateActionDefaultConfig>;
   permissionsGetAgents?: AgentWithGroup[];
   permissionsGetGroups?: { known: KnownPermissionGroup[]; custom: CustomPermissionGroup[] };
   isEqual?: boolean;
@@ -355,7 +355,7 @@ let securityTokenGetIdentifiersStub: SinonStub;
 let securityTokenTransferRestrictionsCountGetStub: SinonStub;
 let securityTokenTransferRestrictionsPercentageGetStub: SinonStub;
 let securityTokenCorporateActionsGetAgentsStub: SinonStub;
-let securityTokenCorporateActionsGetDefaultsStub: SinonStub;
+let securityTokenCorporateActionsGetDefaultConfigStub: SinonStub;
 let securityTokenPermissionsGetGroupsStub: SinonStub;
 let securityTokenPermissionsGetAgentsStub: SinonStub;
 let securityTokenIsEqualStub: SinonStub;
@@ -765,7 +765,7 @@ const defaultSecurityTokenOptions: SecurityTokenOptions = {
     availableSlots: 3,
   },
   corporateActionsGetAgents: [],
-  corporateActionsGetDefaults: {
+  corporateActionsGetDefaultConfig: {
     targets: { identities: [], treatment: TargetTreatment.Exclude },
     defaultTaxWithholding: new BigNumber(10),
     taxWithholdings: [],
@@ -1301,8 +1301,8 @@ function configureSecurityToken(opts: SecurityTokenOptions): void {
       getAgents: securityTokenCorporateActionsGetAgentsStub.resolves(
         opts.corporateActionsGetAgents
       ),
-      getDefaults: securityTokenCorporateActionsGetDefaultsStub.resolves(
-        opts.corporateActionsGetDefaults
+      getDefaultConfig: securityTokenCorporateActionsGetDefaultConfigStub.resolves(
+        opts.corporateActionsGetDefaultConfig
       ),
     },
     permissions: {
@@ -1339,7 +1339,7 @@ function initSecurityToken(opts?: SecurityTokenOptions): void {
   securityTokenTransferRestrictionsCountGetStub = sinon.stub();
   securityTokenTransferRestrictionsPercentageGetStub = sinon.stub();
   securityTokenCorporateActionsGetAgentsStub = sinon.stub();
-  securityTokenCorporateActionsGetDefaultsStub = sinon.stub();
+  securityTokenCorporateActionsGetDefaultConfigStub = sinon.stub();
   securityTokenPermissionsGetGroupsStub = sinon.stub();
   securityTokenPermissionsGetAgentsStub = sinon.stub();
   securityTokenIsEqualStub = sinon.stub();
@@ -2421,16 +2421,16 @@ export function getSecurityTokenCorporateActionsGetAgentsStub(agent?: Identity):
 
 /**
  * @hidden
- * Retrieve the stub of the `SecurityToken.corporateActions.getDefaults` method
+ * Retrieve the stub of the `SecurityToken.corporateActions.getDefaultConfig` method
  */
-export function getSecurityTokenCorporateActionsGetDefaultsStub(
-  defaults?: Partial<CorporateActionDefaults>
+export function getSecurityTokenCorporateActionsGetDefaultConfigStub(
+  defaults?: Partial<CorporateActionDefaultConfig>
 ): SinonStub {
   if (defaults) {
-    return securityTokenCorporateActionsGetDefaultsStub.resolves(defaults);
+    return securityTokenCorporateActionsGetDefaultConfigStub.resolves(defaults);
   }
 
-  return securityTokenCorporateActionsGetDefaultsStub;
+  return securityTokenCorporateActionsGetDefaultConfigStub;
 }
 
 /**


### PR DESCRIPTION
BREAKING CHANGE: 🧨 rename `CorporateActionDefaults` to `CorporateActionDefaultConfig`,
`setDefaults` to `setDefaultConfig`, `getDefaults` to `getDefaultConfig`
within the `CorporateActions` entity.