### PR TITLE
feat: 🎸 MSDK-754 Allow non-entities as checkpoints while creating a DividendDistribution

### DIFF
--- a/src/api/entities/SecurityToken/Checkpoints/types.ts
+++ b/src/api/entities/SecurityToken/Checkpoints/types.ts
@@ -1,0 +1,21 @@
+import { BigNumber } from 'bignumber.js';
+
+import { Checkpoint, CheckpointSchedule } from '~/types';
+
+export enum CaCheckpointType {
+  Existing = 'Existing',
+  Schedule = 'Schedule',
+}
+
+export type CaCheckpointTypeParams =
+  | Checkpoint
+  | CheckpointSchedule
+  | Date
+  | {
+      type: CaCheckpointType.Existing;
+      id: BigNumber;
+    }
+  | {
+      type: CaCheckpointType.Schedule;
+      id: BigNumber;
+    };

--- a/src/api/entities/SecurityToken/types.ts
+++ b/src/api/entities/SecurityToken/types.ts
@@ -58,3 +58,4 @@ export interface AgentWithGroup {
 }
 
 export * from './CorporateActions/types';
+export * from './Checkpoints/types';

--- a/src/api/procedures/configureDividendDistribution.ts
+++ b/src/api/procedures/configureDividendDistribution.ts
@@ -4,7 +4,6 @@ import BigNumber from 'bignumber.js';
 import { assertDistributionDatesValid } from '~/api/procedures/utils';
 import {
   Checkpoint,
-  CheckpointSchedule,
   Context,
   DefaultPortfolio,
   DividendDistribution,
@@ -16,7 +15,7 @@ import {
   Procedure,
   SecurityToken,
 } from '~/internal';
-import { CorporateActionKind, ErrorCode, RoleType, TxTags } from '~/types';
+import { CaCheckpointTypeParams, CorporateActionKind, ErrorCode, RoleType, TxTags } from '~/types';
 import { ProcedureAuthorization } from '~/types/internal';
 import {
   dateToMoment,
@@ -29,7 +28,7 @@ import {
   tickerToString,
   u32ToBigNumber,
 } from '~/utils/conversion';
-import { filterEventRecords, optionize } from '~/utils/internal';
+import { filterEventRecords, getCheckpointValue, optionize } from '~/utils/internal';
 
 /**
  * @hidden
@@ -67,7 +66,7 @@ export type ConfigureDividendDistributionParams = Omit<
    * checkpoint to be used to calculate Dividends. If a Schedule is passed, the next Checkpoint it creates will be used.
    *   If a Date is passed, a Checkpoint will be created at that date and used
    */
-  checkpoint: Checkpoint | Date | CheckpointSchedule;
+  checkpoint: CaCheckpointTypeParams;
   /**
    * portfolio from which the Dividends will be distributed. Optional, defaults to the Corporate Actions Agent's Default Portfolio
    */
@@ -155,8 +154,10 @@ export async function prepareConfigureDividendDistribution(
     });
   }
 
-  if (!(checkpoint instanceof Checkpoint)) {
-    await assertDistributionDatesValid(checkpoint, paymentDate, expiryDate);
+  const checkpointValue = await getCheckpointValue(checkpoint, ticker, context);
+
+  if (!(checkpointValue instanceof Checkpoint)) {
+    await assertDistributionDatesValid(checkpointValue, paymentDate, expiryDate);
   }
 
   if (portfolio instanceof NumberedPortfolio) {
@@ -185,7 +186,7 @@ export async function prepareConfigureDividendDistribution(
   const caId = await this.addProcedure(initiateCorporateAction(), {
     ticker,
     kind: CorporateActionKind.UnpredictableBenefit,
-    checkpoint,
+    checkpoint: checkpointValue,
     ...corporateActionArgs,
   });
 


### PR DESCRIPTION
### JIRA Link

https://polymath.atlassian.net/browse/MSDK-754

### Change Description

This allows passing an object with `id` and `type` as checkpoint value while creating `DividendDistribution` along with already supported types `Checkpoint` , `CheckpointSchedule` and `Date`.
The `type` can be have either of two values -
* `Existing` - if `id` value defines a `Checkpoint`
* `Scheduled`- if `id` value defines a `CheckpointSchedule`