### PR TITLE
fix: 🐛 support fetching `BecomeAgent` authorizations

### DIFF
--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -1145,9 +1145,26 @@ describe('authorizationToAuthorizationData and authorizationDataToAuthorization'
 
     result = authorizationDataToAuthorization(authorizationData, context);
     expect(result).toEqual(fakeResult);
+
+    const ticker = 'SOME_TICKER';
+    const type = PermissionGroupType.Full;
+    fakeResult = {
+      type: AuthorizationType.BecomeAgent,
+      value: entityMockUtils.getKnownPermissionGroupInstance({
+        ticker,
+        type,
+      }),
+    };
+
+    authorizationData = dsMockUtils.createMockAuthorizationData({
+      BecomeAgent: [dsMockUtils.createMockTicker(ticker), dsMockUtils.createMockAgentGroup(type)],
+    });
+
+    result = authorizationDataToAuthorization(authorizationData, context);
+    expect(result).toEqual(fakeResult);
   });
 
-  test('shoould throw an error if the authorization has an unsupported type', () => {
+  test('should throw an error if the authorization has an unsupported type', () => {
     const context = dsMockUtils.getContextInstance();
     const authorizationData = dsMockUtils.createMockAuthorizationData(
       'Whatever' as 'RotatePrimaryKey'

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -1167,6 +1167,15 @@ export function authorizationDataToAuthorization(
     };
   }
 
+  if (auth.isBecomeAgent) {
+    const [ticker, agentGroup] = auth.asBecomeAgent;
+
+    return {
+      type: AuthorizationType.BecomeAgent,
+      value: agentGroupToPermissionGroup(agentGroup, tickerToString(ticker), context),
+    };
+  }
+
   throw new PolymeshError({
     code: ErrorCode.FatalError,
     message: 'Unsupported Authorization Type. Please contact the Polymath team',


### PR DESCRIPTION
`authorizationDataToAuthorizationType` didn't have a code branch for
this type of authorization, causing errors when fetching