### PR TITLE
fix: 🐛 Transfer Ownership method

### DIFF
--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -573,7 +573,7 @@ describe('stringToTicker and tickerToString', () => {
     const context = dsMockUtils.getContextInstance();
 
     expect(() => stringToTicker(value, context)).toThrow(
-      'Only printable ASCII is alowed as ticker name'
+      'Only printable ASCII is allowed as ticker name'
     );
   });
 
@@ -1018,6 +1018,24 @@ describe('authorizationToAuthorizationData and authorizationDataToAuthorization'
     dsMockUtils
       .getCreateTypeStub()
       .withArgs('AuthorizationData', { [value.type]: [fakeTicker, rawAgentGroup] })
+      .returns(fakeResult);
+
+    result = authorizationToAuthorizationData(value, context);
+    expect(result).toBe(fakeResult);
+
+    value = {
+      type: AuthorizationType.TransferAssetOwnership,
+      value: 'TICKER',
+    };
+
+    dsMockUtils
+      .getCreateTypeStub()
+      .withArgs('Ticker', padString('TICKER', MAX_TICKER_LENGTH))
+      .returns(fakeTicker);
+
+    dsMockUtils
+      .getCreateTypeStub()
+      .withArgs('AuthorizationData', { [value.type]: fakeTicker })
       .returns(fakeResult);
 
     result = authorizationToAuthorizationData(value, context);

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -289,7 +289,7 @@ export function stringToTicker(ticker: string, context: Context): Ticker {
   if (!isPrintableAscii(ticker)) {
     throw new PolymeshError({
       code: ErrorCode.ValidationError,
-      message: 'Only printable ASCII is alowed as ticker name',
+      message: 'Only printable ASCII is allowed as ticker name',
     });
   }
 
@@ -1071,6 +1071,8 @@ export function authorizationToAuthorizationData(
     value = permissionsToMeshPermissions(auth.value, context);
   } else if (auth.type === AuthorizationType.PortfolioCustody) {
     value = portfolioIdToMeshPortfolioId(portfolioToPortfolioId(auth.value), context);
+  } else if (auth.type === AuthorizationType.TransferAssetOwnership) {
+    value = stringToTicker(auth.value, context);
   } else if (auth.type === AuthorizationType.BecomeAgent) {
     const ticker = stringToTicker(auth.value.ticker, context);
     if (auth.value instanceof CustomPermissionGroup) {


### PR DESCRIPTION
Pads the ticker that is passed to the token.transferOwnership method to
prevent an incorrect length error from being thrown