### PR TITLE
fix: 🐛 use proper calculations for account balances

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Polymesh version
 
-This release is compatible with Polymesh v4.0.0
+This release is compatible with Polymesh v4.1.0
 
 ## Getting Started
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "generate:middleware-types": "graphql-codegen -r dotenv/config",
     "fetch-definitions": "cross-env node scripts/fetchDefinitions.js",
     "generate:defs": "ts-node --skip-project node_modules/.bin/polkadot-types-from-defs --package polymesh-types --input ./src/polkadot",
-    "generate:meta": "ts-node --skip-project node_modules/.bin/polkadot-types-from-chain --package polymesh-types --endpoint wss://dev.polymesh.live --output ./src/polkadot --strict",
+    "generate:meta": "ts-node --skip-project node_modules/.bin/polkadot-types-from-chain --package polymesh-types --endpoint ws://localhost:9944 --output ./src/polkadot --strict",
     "generate:tags": "cross-env node scripts/generateTxTags.js",
     "test": "jest --detectOpenHandles --coverage",
     "build:ts": "ttsc -b",

--- a/scripts/fetchDefinitions.js
+++ b/scripts/fetchDefinitions.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-const https = require('https');
+const http = require('http');
 const path = require('path');
 const fs = require('fs');
 const rimraf = require('rimraf');
@@ -10,7 +10,7 @@ const definitionsDir = path.resolve('src', 'polkadot');
 const typesDir = path.resolve(definitionsDir, 'polymesh');
 const generatedDir = path.resolve('src', 'generated');
 
-const urlPath = 'https://dev.polymesh.live/code';
+const urlPath = 'http://localhost:3008';
 
 rimraf.sync(typesDir);
 fs.mkdirSync(typesDir);
@@ -125,7 +125,7 @@ export function meshCountryCodeToCountryCode(meshCountryCode: MeshCountryCode): 
   fs.writeFileSync(path.resolve(generatedDir, 'utils.ts'), utilsFile);
 }
 
-https.get(`${urlPath}/polymesh_schema.json`, res => {
+http.get(`${urlPath}/polymesh_schema.json`, res => {
   const chunks = [];
   res.on('data', chunk => {
     chunks.push(chunk);

--- a/scripts/generateTxTags.js
+++ b/scripts/generateTxTags.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 const path = require('path');
 const rimraf = require('rimraf');
 
-const websocket = new w3cwebsocket('wss://dev.polymesh.live');
+const websocket = new w3cwebsocket('ws://localhost:9944');
 websocket.onopen = () => {
   websocket.send('{"id":"1","jsonrpc":"2.0","method":"state_getMetadata","params":[]}');
 };

--- a/scripts/transactions.json
+++ b/scripts/transactions.json
@@ -56,7 +56,8 @@
     "gc_add_cdd_claim": "gc_add_cdd_claim",
     "gc_revoke_cdd_claim": "gc_revoke_cdd_claim",
     "add_investor_uniqueness_claim_v2": "add_investor_uniqueness_claim_v2",
-    "revoke_claim_by_index": "revoke_claim_by_index"
+    "revoke_claim_by_index": "revoke_claim_by_index",
+    "rotate_primary_key_to_secondary": "rotate_primary_key_to_secondary"
   },
   "CddServiceProviders": {
     "set_active_members_limit": "set_active_members_limit",
@@ -152,7 +153,8 @@
     "unfreeze_txs": "unfreeze_txs",
     "handle_scheduled_bridge_tx": "handle_scheduled_bridge_tx",
     "add_freeze_admin": "add_freeze_admin",
-    "remove_freeze_admin": "remove_freeze_admin"
+    "remove_freeze_admin": "remove_freeze_admin",
+    "remove_txs": "remove_txs"
   },
   "Staking": {
     "bond": "bond",
@@ -369,5 +371,11 @@
   "Rewards": {
     "claim_itn_reward": "claim_itn_reward",
     "set_itn_reward_status": "set_itn_reward_status"
+  },
+  "TestUtils": {
+    "register_did": "register_did",
+    "mock_cdd_register_did": "mock_cdd_register_did",
+    "get_my_did": "get_my_did",
+    "get_cdd_of": "get_cdd_of"
   }
 }

--- a/src/api/procedures/__tests__/linkCaDocs.ts
+++ b/src/api/procedures/__tests__/linkCaDocs.ts
@@ -1,6 +1,6 @@
 import { Vec } from '@polkadot/types';
 import BigNumber from 'bignumber.js';
-import { Document, DocumentId, Ticker, TxTags } from 'polymesh-types/types';
+import { CAId, Document, DocumentId, Ticker, TxTags } from 'polymesh-types/types';
 import sinon from 'sinon';
 
 import { getAuthorization, Params, prepareLinkCaDocs } from '~/api/procedures/linkCaDocs';
@@ -28,6 +28,7 @@ describe('linkCaDocs procedure', () => {
   let rawDocumentIds: DocumentId[];
   let documentEntries: [[Ticker, DocumentId], Document][];
   let args: Params;
+  let rawCaId: CAId;
 
   beforeAll(() => {
     dsMockUtils.initMocks();
@@ -78,6 +79,9 @@ describe('linkCaDocs procedure', () => {
       ticker,
       documents,
     };
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    rawCaId = dsMockUtils.createMockCAId({ ticker, local_id: id.toNumber() });
+    sinon.stub(utilsConversionModule, 'corporateActionIdentifierToCaId').returns(rawCaId);
   });
 
   let addTransactionStub: sinon.SinonStub;
@@ -144,13 +148,7 @@ describe('linkCaDocs procedure', () => {
 
     await prepareLinkCaDocs.call(proc, args);
 
-    sinon.assert.calledWith(
-      addTransactionStub,
-      linkCaDocTransaction,
-      {},
-      { ticker, local_id: id },
-      rawDocumentIds
-    );
+    sinon.assert.calledWith(addTransactionStub, linkCaDocTransaction, {}, rawCaId, rawDocumentIds);
   });
 
   describe('getAuthorization', () => {

--- a/src/api/procedures/initiateCorporateAction.ts
+++ b/src/api/procedures/initiateCorporateAction.ts
@@ -54,12 +54,11 @@ export const createCaIdResolver = () => (receipt: ISubmittableResult): CAId => {
 export interface InitiateCorporateActionParams {
   kind: CorporateActionKind;
   /**
-   * date at which the issuer publicly declared the Distribution. Optional, defaults to the current date
+   * date at which the issuer publicly declared the Corporate Action. Optional, defaults to the current date
    */
   declarationDate?: Date;
   /**
-   * checkpoint to be used for share-related calculations. If a Schedule is passed, the next Checkpoint it creates will be used.
-   *   checkpoint to be used to calculate Dividends. If a Schedule is passed, the next Checkpoint it creates will be used.
+   * checkpoint to be used for share-related calculations. If a Schedule is passed, the next Checkpoint it creates will be used
    */
   checkpoint?: Checkpoint | CheckpointSchedule | Date;
   description: string;

--- a/src/api/procedures/linkCaDocs.ts
+++ b/src/api/procedures/linkCaDocs.ts
@@ -5,7 +5,11 @@ import { DocumentId, TxTags } from 'polymesh-types/types';
 import { PolymeshError, Procedure, SecurityToken } from '~/internal';
 import { ErrorCode, TokenDocument } from '~/types';
 import { ProcedureAuthorization } from '~/types/internal';
-import { documentToTokenDocument, stringToTicker } from '~/utils/conversion';
+import {
+  corporateActionIdentifierToCaId,
+  documentToTokenDocument,
+  stringToTicker,
+} from '~/utils/conversion';
 
 export interface LinkCaDocsParams {
   /**
@@ -67,10 +71,9 @@ export async function prepareLinkCaDocs(
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  const rawCAId = { ticker, local_id: caId };
+  const rawCaId = corporateActionIdentifierToCaId({ ticker, localId: caId }, context);
 
-  this.addTransaction(corporateAction.linkCaDoc, {}, rawCAId, docIdsToLink);
+  this.addTransaction(corporateAction.linkCaDoc, {}, rawCaId, docIdsToLink);
 }
 
 /**

--- a/src/base/Context.ts
+++ b/src/base/Context.ts
@@ -354,12 +354,16 @@ export class Context {
     const assembleResult = ({
       data: { free: rawFree, miscFrozen, feeFrozen },
     }: AccountInfo): AccountBalance => {
-      const free = balanceToBigNumber(rawFree);
+      /*
+       * This might seem counterintuitive, but that's how the chain
+       * stores balances
+       */
+      const total = balanceToBigNumber(rawFree);
       const locked = BigNumber.max(balanceToBigNumber(miscFrozen), balanceToBigNumber(feeFrozen));
       return {
-        free,
+        total,
         locked,
-        total: free.plus(locked),
+        free: total.minus(locked),
       };
     };
 

--- a/src/middleware/__tests__/queries.ts
+++ b/src/middleware/__tests__/queries.ts
@@ -23,8 +23,8 @@ import {
   proposalVotes,
   scopesByIdentity,
   settlements,
-  tickerExternalAgentHistory,
   tickerExternalAgentActions,
+  tickerExternalAgentHistory,
   tokensByTrustedClaimIssuer,
   tokensHeldByDid,
   transactionByHash,
@@ -288,7 +288,7 @@ describe('tickerExternalAgentHistory', () => {
     };
 
     const result = tickerExternalAgentHistory(variables);
-    
+
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);
   });

--- a/src/polkadot/augment-api-errors.ts
+++ b/src/polkadot/augment-api-errors.ts
@@ -31,10 +31,6 @@ declare module '@polkadot/api/types/errors' {
        **/
       BalanceOverflow: AugmentedError<ApiType>;
       /**
-       * An overflow while generating the next `CustomAssetTypeId`.
-       **/
-      CustomAssetTypeIdOverflow: AugmentedError<ApiType>;
-      /**
        * When extension is already added.
        **/
       ExtensionAlreadyPresent: AugmentedError<ApiType>;
@@ -55,6 +51,10 @@ declare module '@polkadot/api/types/errors' {
        **/
       InvalidAssetIdentifier: AugmentedError<ApiType>;
       /**
+       * Invalid `CustomAssetTypeId`.
+       **/
+      InvalidCustomAssetTypeId: AugmentedError<ApiType>;
+      /**
        * An invalid Ethereum `EcdsaSignature`.
        **/
       InvalidEthereumSignature: AugmentedError<ApiType>;
@@ -66,6 +66,10 @@ declare module '@polkadot/api/types/errors' {
        * Transfer validation check failed.
        **/
       InvalidTransfer: AugmentedError<ApiType>;
+      /**
+       * Investor Uniqueness claims are not allowed for this asset.
+       **/
+      InvestorUniquenessClaimNotAllowed: AugmentedError<ApiType>;
       /**
        * Number of Transfer Manager extensions attached to an asset is equal to MaxNumberOfTMExtensionForAsset.
        **/
@@ -87,7 +91,7 @@ declare module '@polkadot/api/types/errors' {
        **/
       NoSuchDoc: AugmentedError<ApiType>;
       /**
-       * Not an owner of the token.
+       * Not an owner of the token on Ethereum.
        **/
       NotAnOwner: AugmentedError<ApiType>;
       /**
@@ -181,6 +185,15 @@ declare module '@polkadot/api/types/errors' {
     };
     base: {
       /**
+       * The sequence counter for something overflowed.
+       *
+       * When this happens depends on e.g., the capacity of the identifier type.
+       * For example, we might have `pub struct PipId(u32);`, with `u32::MAX` capacity.
+       * In practice, these errors will never happen but no code path should result in a panic,
+       * so these corner cases need to be covered with an error variant.
+       **/
+      CounterOverflow: AugmentedError<ApiType>;
+      /**
        * Exceeded a generic length limit.
        * The limit could be for any sort of lists of things, including a string.
        **/
@@ -262,12 +275,12 @@ declare module '@polkadot/api/types/errors' {
        **/
       CannotClaimBeforeStart: AugmentedError<ApiType>;
       /**
-       * A corporate ballot was made for a non-benefit CA.
+       * A capital distribution was made for a non-benefit CA.
        **/
       CANotBenefit: AugmentedError<ApiType>;
       /**
        * Currency that is distributed is the same as the CA's ticker.
-       * CAA is attempting a form of stock split, which is not what the extrinsic is for.
+       * Calling agent is attempting a form of stock split, which is not what the extrinsic is for.
        **/
       DistributingAsset: AugmentedError<ApiType>;
       /**
@@ -332,10 +345,6 @@ declare module '@polkadot/api/types/errors' {
     };
     checkpoint: {
       /**
-       * An overflow while calculating the checkpoint ID.
-       **/
-      CheckpointOverflow: AugmentedError<ApiType>;
-      /**
        * Failed to compute the next checkpoint.
        * The schedule does not have any upcoming checkpoints.
        **/
@@ -352,10 +361,6 @@ declare module '@polkadot/api/types/errors' {
        * A checkpoint schedule is not removable as `ref_count(schedule_id) > 0`.
        **/
       ScheduleNotRemovable: AugmentedError<ApiType>;
-      /**
-       * An overflow while calculating the checkpoint schedule ID.
-       **/
-      ScheduleOverflow: AugmentedError<ApiType>;
       /**
        * The set of schedules taken together are too complex.
        * For example, they are too many, or they occurs too frequently.
@@ -440,11 +445,6 @@ declare module '@polkadot/api/types/errors' {
        * The chain refused to make a choice, and hence there was an error.
        **/
       DuplicateDidTax: AugmentedError<ApiType>;
-      /**
-       * There have been too many CAs for this ticker and the ID would overflow.
-       * This won't occur in practice.
-       **/
-      LocalCAIdOverflow: AugmentedError<ApiType>;
       /**
        * The CA did not have a record date.
        **/
@@ -540,11 +540,6 @@ declare module '@polkadot/api/types/errors' {
        **/
       AlreadyAnAgent: AugmentedError<ApiType>;
       /**
-       * There have been too many AGs for this ticker and the ID would overflow.
-       * This won't occur in practice.
-       **/
-      LocalAGIdOverflow: AugmentedError<ApiType>;
-      /**
        * An AG with the given `AGId` did not exist for the `Ticker`.
        **/
       NoSuchAG: AugmentedError<ApiType>;
@@ -552,11 +547,6 @@ declare module '@polkadot/api/types/errors' {
        * The provided `agent` is not an agent for the `Ticker`.
        **/
       NotAnAgent: AugmentedError<ApiType>;
-      /**
-       * The counter for full agents will overflow.
-       * This should never happen in practice, but is theoretically possible.
-       **/
-      NumFullAgentsOverflow: AugmentedError<ApiType>;
       /**
        * This agent is the last full one, and it's being removed,
        * making the asset orphaned.
@@ -1230,6 +1220,10 @@ declare module '@polkadot/api/types/errors' {
        **/
       BadState: AugmentedError<ApiType>;
       /**
+       * A nomination target was supplied that was blocked or otherwise not a validator.
+       **/
+      BadTarget: AugmentedError<ApiType>;
+      /**
        * When the amount to be bonded is less than `MinimumBond`
        **/
       BondTooSmall: AugmentedError<ApiType>;
@@ -1361,9 +1355,21 @@ declare module '@polkadot/api/types/errors' {
        **/
       SnapshotUnavailable: AugmentedError<ApiType>;
       /**
+       * Validator or nominator stash identity does not exist.
+       **/
+      StashIdentityDoesNotExist: AugmentedError<ApiType>;
+      /**
+       * Nominator stash was not CDDed.
+       **/
+      StashIdentityNotCDDed: AugmentedError<ApiType>;
+      /**
        * Validator stash identity was not permissioned.
        **/
       StashIdentityNotPermissioned: AugmentedError<ApiType>;
+      /**
+       * Too many nomination targets supplied.
+       **/
+      TooManyTargets: AugmentedError<ApiType>;
     };
     statistics: {
       /**

--- a/src/polkadot/augment-api-events.ts
+++ b/src/polkadot/augment-api-events.ts
@@ -53,12 +53,15 @@ import type {
   ExtrinsicPermissions,
   FundingRoundName,
   Fundraiser,
+  FundraiserId,
   FundraiserName,
   HandledTxStatus,
   IdentityClaim,
   IdentityId,
+  InstructionId,
   InvestorUid,
   Leg,
+  LegId,
   MaybeBlock,
   Memo,
   Permissions,
@@ -88,6 +91,7 @@ import type {
   TrustedIssuer,
   Url,
   VenueDetails,
+  VenueId,
   VenueType,
 } from 'polymesh-types/polymesh';
 import type { ApiTypes } from '@polkadot/api/types';
@@ -304,6 +308,10 @@ declare module '@polkadot/api/types/events' {
        **/
       TimelockChanged: AugmentedEvent<ApiType, [IdentityId, BlockNumber]>;
       /**
+       * Notification of removing a transaction.
+       **/
+      TxRemoved: AugmentedEvent<ApiType, [IdentityId, BridgeTx]>;
+      /**
        * An event emitted after a vector of transactions is handled. The parameter is a vector of
        * tuples of recipient account, its nonce, and the status of the processed transaction.
        **/
@@ -329,21 +337,21 @@ declare module '@polkadot/api/types/events' {
       >;
       /**
        * A capital distribution, with details included,
-       * was created by the DID (the CAA) for the CA specified by the `CAId`.
+       * was created by the DID (permissioned agent) for the CA identified by `CAId`.
        *
-       * (CAA of CAId's ticker, CA's ID, distribution details)
+       * (Agent DID, CA's ID, distribution details)
        **/
       Created: AugmentedEvent<ApiType, [EventDid, CAId, Distribution]>;
       /**
        * Stats from `push_benefit` was emitted.
        *
-       * (CAA/owner of CA's ticker, CA's ID, max requested DIDs, processed DIDs, failed DIDs)
+       * (Agent DID, CA's ID, max requested DIDs, processed DIDs, failed DIDs)
        **/
       Reclaimed: AugmentedEvent<ApiType, [EventDid, CAId, Balance]>;
       /**
        * A capital distribution was removed.
        *
-       * (Ticker's CAA, CA's ID)
+       * (Agent DID, CA's ID)
        **/
       Removed: AugmentedEvent<ApiType, [EventDid, CAId]>;
     };
@@ -510,22 +518,22 @@ declare module '@polkadot/api/types/events' {
       CAATransferred: AugmentedEvent<ApiType, [IdentityId, Ticker, IdentityId]>;
       /**
        * A CA was initiated.
-       * (CAA DID, CA id, the CA, the CA details)
+       * (Agent DID, CA id, the CA, the CA details)
        **/
       CAInitiated: AugmentedEvent<ApiType, [EventDid, CAId, CorporateAction, CADetails]>;
       /**
        * A CA was linked to a set of docs.
-       * (CAA, CA Id, List of doc identifiers)
+       * (Agent DID, CA Id, List of doc identifiers)
        **/
       CALinkedToDoc: AugmentedEvent<ApiType, [IdentityId, CAId, Vec<DocumentId>]>;
       /**
        * A CA was removed.
-       * (CAA, CA Id)
+       * (Agent DID, CA Id)
        **/
       CARemoved: AugmentedEvent<ApiType, [EventDid, CAId]>;
       /**
        * The set of default `TargetIdentities` for a ticker changed.
-       * (CAA DID, Ticker, New TargetIdentities)
+       * (Agent DID, Ticker, New TargetIdentities)
        **/
       DefaultTargetIdentitiesChanged: AugmentedEvent<
         ApiType,
@@ -533,12 +541,12 @@ declare module '@polkadot/api/types/events' {
       >;
       /**
        * The default withholding tax for a ticker changed.
-       * (CAA DID, Ticker, New Tax).
+       * (Agent DID, Ticker, New Tax).
        **/
       DefaultWithholdingTaxChanged: AugmentedEvent<ApiType, [IdentityId, Ticker, Tax]>;
       /**
        * The withholding tax specific to a DID for a ticker changed.
-       * (CAA DID, Ticker, Taxed DID, New Tax).
+       * (Agent DID, Ticker, Taxed DID, New Tax).
        **/
       DidWithholdingTaxChanged: AugmentedEvent<
         ApiType,
@@ -558,31 +566,31 @@ declare module '@polkadot/api/types/events' {
       /**
        * A corporate ballot was created.
        *
-       * (Ticker's CAA, CA's ID, Voting start/end, Ballot metadata, RCV enabled?)
+       * (Agent DID, CA's ID, Voting start/end, Ballot metadata, RCV enabled?)
        **/
       Created: AugmentedEvent<ApiType, [IdentityId, CAId, BallotTimeRange, BallotMeta, bool]>;
       /**
        * A corporate ballot changed its metadata.
        *
-       * (Ticker's CAA, CA's ID, New metadata)
+       * (Agent DID, CA's ID, New metadata)
        **/
       MetaChanged: AugmentedEvent<ApiType, [IdentityId, CAId, BallotMeta]>;
       /**
        * A corporate ballot changed its start/end date range.
        *
-       * (Ticker's CAA, CA's ID, Voting start/end)
+       * (Agent DID, CA's ID, Voting start/end)
        **/
       RangeChanged: AugmentedEvent<ApiType, [IdentityId, CAId, BallotTimeRange]>;
       /**
        * A corporate ballot changed its RCV support.
        *
-       * (Ticker's CAA, CA's ID, New support)
+       * (Agent DID, CA's ID, New support)
        **/
       RCVChanged: AugmentedEvent<ApiType, [IdentityId, CAId, bool]>;
       /**
        * A corporate ballot was removed.
        *
-       * (Ticker's CAA, CA's ID)
+       * (Agent DID, CA's ID)
        **/
       Removed: AugmentedEvent<ApiType, [EventDid, CAId]>;
       /**
@@ -1140,51 +1148,59 @@ declare module '@polkadot/api/types/events' {
       /**
        * An affirmation has been withdrawn (did, portfolio, instruction_id)
        **/
-      AffirmationWithdrawn: AugmentedEvent<ApiType, [IdentityId, PortfolioId, u64]>;
+      AffirmationWithdrawn: AugmentedEvent<ApiType, [IdentityId, PortfolioId, InstructionId]>;
       /**
        * An instruction has been affirmed (did, portfolio, instruction_id)
        **/
-      InstructionAffirmed: AugmentedEvent<ApiType, [IdentityId, PortfolioId, u64]>;
+      InstructionAffirmed: AugmentedEvent<ApiType, [IdentityId, PortfolioId, InstructionId]>;
       /**
        * A new instruction has been created
        * (did, venue_id, instruction_id, settlement_type, trade_date, value_date, legs)
        **/
       InstructionCreated: AugmentedEvent<
         ApiType,
-        [IdentityId, u64, u64, SettlementType, Option<Moment>, Option<Moment>, Vec<Leg>]
+        [
+          IdentityId,
+          VenueId,
+          InstructionId,
+          SettlementType,
+          Option<Moment>,
+          Option<Moment>,
+          Vec<Leg>
+        ]
       >;
       /**
        * Instruction executed successfully(did, instruction_id)
        **/
-      InstructionExecuted: AugmentedEvent<ApiType, [IdentityId, u64]>;
+      InstructionExecuted: AugmentedEvent<ApiType, [IdentityId, InstructionId]>;
       /**
        * Instruction failed execution (did, instruction_id)
        **/
-      InstructionFailed: AugmentedEvent<ApiType, [IdentityId, u64]>;
+      InstructionFailed: AugmentedEvent<ApiType, [IdentityId, InstructionId]>;
       /**
        * An instruction has been rejected (did, instruction_id)
        **/
-      InstructionRejected: AugmentedEvent<ApiType, [IdentityId, u64]>;
+      InstructionRejected: AugmentedEvent<ApiType, [IdentityId, InstructionId]>;
       /**
        * Instruction is rescheduled.
        * (caller DID, instruction_id)
        **/
-      InstructionRescheduled: AugmentedEvent<ApiType, [IdentityId, u64]>;
+      InstructionRescheduled: AugmentedEvent<ApiType, [IdentityId, InstructionId]>;
       /**
        * Execution of a leg failed (did, instruction_id, leg_id)
        **/
-      LegFailedExecution: AugmentedEvent<ApiType, [IdentityId, u64, u64]>;
+      LegFailedExecution: AugmentedEvent<ApiType, [IdentityId, InstructionId, LegId]>;
       /**
        * A receipt has been claimed (did, instruction_id, leg_id, receipt_uid, signer, receipt metadata)
        **/
       ReceiptClaimed: AugmentedEvent<
         ApiType,
-        [IdentityId, u64, u64, u64, AccountId, ReceiptMetadata]
+        [IdentityId, InstructionId, LegId, u64, AccountId, ReceiptMetadata]
       >;
       /**
        * A receipt has been unclaimed (did, instruction_id, leg_id, receipt_uid, signer)
        **/
-      ReceiptUnclaimed: AugmentedEvent<ApiType, [IdentityId, u64, u64, u64, AccountId]>;
+      ReceiptUnclaimed: AugmentedEvent<ApiType, [IdentityId, InstructionId, LegId, u64, AccountId]>;
       /**
        * A receipt has been invalidated (did, signer, receipt_uid, validity)
        **/
@@ -1196,11 +1212,11 @@ declare module '@polkadot/api/types/events' {
       /**
        * A new venue has been created (did, venue_id, details, type)
        **/
-      VenueCreated: AugmentedEvent<ApiType, [IdentityId, u64, VenueDetails, VenueType]>;
+      VenueCreated: AugmentedEvent<ApiType, [IdentityId, VenueId, VenueDetails, VenueType]>;
       /**
        * An existing venue's details has been updated (did, venue_id, details)
        **/
-      VenueDetailsUpdated: AugmentedEvent<ApiType, [IdentityId, u64, VenueDetails]>;
+      VenueDetailsUpdated: AugmentedEvent<ApiType, [IdentityId, VenueId, VenueDetails]>;
       /**
        * Venue filtering has been enabled or disabled for a ticker (did, ticker, filtering_enabled)
        **/
@@ -1208,19 +1224,19 @@ declare module '@polkadot/api/types/events' {
       /**
        * Venues added to allow list (did, ticker, vec<venue_id>)
        **/
-      VenuesAllowed: AugmentedEvent<ApiType, [IdentityId, Ticker, Vec<u64>]>;
+      VenuesAllowed: AugmentedEvent<ApiType, [IdentityId, Ticker, Vec<VenueId>]>;
       /**
        * Venues added to block list (did, ticker, vec<venue_id>)
        **/
-      VenuesBlocked: AugmentedEvent<ApiType, [IdentityId, Ticker, Vec<u64>]>;
+      VenuesBlocked: AugmentedEvent<ApiType, [IdentityId, Ticker, Vec<VenueId>]>;
       /**
        * An existing venue's type has been updated (did, venue_id, type)
        **/
-      VenueTypeUpdated: AugmentedEvent<ApiType, [IdentityId, u64, VenueType]>;
+      VenueTypeUpdated: AugmentedEvent<ApiType, [IdentityId, VenueId, VenueType]>;
       /**
-       * Venue unauthorized by ticker owner (did, Ticker, venue_id)
+       * Venue not part of the token's allow list (did, Ticker, venue_id)
        **/
-      VenueUnauthorized: AugmentedEvent<ApiType, [IdentityId, Ticker, u64]>;
+      VenueUnauthorized: AugmentedEvent<ApiType, [IdentityId, Ticker, VenueId]>;
     };
     staking: {
       /**
@@ -1331,37 +1347,43 @@ declare module '@polkadot/api/types/events' {
     sto: {
       /**
        * A fundraiser has been stopped.
-       * (primary issuance agent, fundraiser id)
+       * (Agent DID, fundraiser id)
        **/
-      FundraiserClosed: AugmentedEvent<ApiType, [IdentityId, u64]>;
+      FundraiserClosed: AugmentedEvent<ApiType, [IdentityId, FundraiserId]>;
       /**
        * A new fundraiser has been created.
-       * (primary issuance agent, fundraiser id, fundraiser name, fundraiser details)
+       * (Agent DID, fundraiser id, fundraiser name, fundraiser details)
        **/
-      FundraiserCreated: AugmentedEvent<ApiType, [IdentityId, u64, FundraiserName, Fundraiser]>;
+      FundraiserCreated: AugmentedEvent<
+        ApiType,
+        [IdentityId, FundraiserId, FundraiserName, Fundraiser]
+      >;
       /**
        * A fundraiser has been frozen.
-       * (primary issuance agent, fundraiser id)
+       * (Agent DID, fundraiser id)
        **/
-      FundraiserFrozen: AugmentedEvent<ApiType, [IdentityId, u64]>;
+      FundraiserFrozen: AugmentedEvent<ApiType, [IdentityId, FundraiserId]>;
       /**
        * A fundraiser has been unfrozen.
-       * (primary issuance agent, fundraiser id)
+       * (Agent DID, fundraiser id)
        **/
-      FundraiserUnfrozen: AugmentedEvent<ApiType, [IdentityId, u64]>;
+      FundraiserUnfrozen: AugmentedEvent<ApiType, [IdentityId, FundraiserId]>;
       /**
        * A fundraiser window has been modified.
-       * (primary issuance agent, fundraiser id, old_start, old_end, new_start, new_end)
+       * (Agent DID, fundraiser id, old_start, old_end, new_start, new_end)
        **/
       FundraiserWindowModified: AugmentedEvent<
         ApiType,
-        [EventDid, u64, Moment, Option<Moment>, Moment, Option<Moment>]
+        [EventDid, FundraiserId, Moment, Option<Moment>, Moment, Option<Moment>]
       >;
       /**
        * An investor invested in the fundraiser.
        * (Investor, fundraiser_id, offering token, raise token, offering_token_amount, raise_token_amount)
        **/
-      Invested: AugmentedEvent<ApiType, [IdentityId, u64, Ticker, Ticker, Balance, Balance]>;
+      Invested: AugmentedEvent<
+        ApiType,
+        [IdentityId, FundraiserId, Ticker, Ticker, Balance, Balance]
+      >;
     };
     sudo: {
       /**
@@ -1494,6 +1516,24 @@ declare module '@polkadot/api/types/events' {
        * caller DID, Removed DID, New add DID.
        **/
       MembersSwapped: AugmentedEvent<ApiType, [IdentityId, IdentityId, IdentityId]>;
+    };
+    testUtils: {
+      /**
+       * Shows the `DID` associated to the `AccountId`, and a flag indicates if that DID has a
+       * valid CDD claim.
+       * (Target DID, Target Account, a valid CDD claim exists)
+       **/
+      CddStatus: AugmentedEvent<ApiType, [Option<IdentityId>, AccountId, bool]>;
+      /**
+       * Emits the `IdentityId` and the `AccountId` of the caller.
+       * (Caller DID, Caller account)
+       **/
+      DidStatus: AugmentedEvent<ApiType, [IdentityId, AccountId]>;
+      /**
+       * A new mocked `InvestorUid` has been created for the given Identity.
+       * (Target DID, New InvestorUid)
+       **/
+      MockInvestorUIDCreated: AugmentedEvent<ApiType, [IdentityId, InvestorUid]>;
     };
     treasury: {
       /**

--- a/src/polkadot/augment-api-query.ts
+++ b/src/polkadot/augment-api-query.ts
@@ -99,13 +99,16 @@ import type {
   ExtrinsicPermissions,
   FundingRoundName,
   Fundraiser,
+  FundraiserId,
   FundraiserName,
   IdentityClaim,
   IdentityId,
   InactiveMember,
   Instruction,
+  InstructionId,
   ItnRewardStatus,
   Leg,
+  LegId,
   LegStatus,
   LocalCAId,
   MaybeBlock,
@@ -126,6 +129,7 @@ import type {
   Signatory,
   SkippedCount,
   SlashingSwitch,
+  SnapshotId,
   SnapshotMetadata,
   SnapshottedPip,
   StoredSchedule,
@@ -139,6 +143,7 @@ import type {
   TrustedIssuer,
   Venue,
   VenueDetails,
+  VenueId,
   Version,
   VotingResult,
 } from 'polymesh-types/polymesh';
@@ -1186,7 +1191,7 @@ declare module '@polkadot/api/types/storage' {
     };
     multiSig: {
       /**
-       * Maps a multisig secondary key to a multisig address.
+       * Maps a multisig signer key to a multisig address.
        **/
       keyToMultiSig: AugmentedQuery<
         ApiType,
@@ -1391,7 +1396,7 @@ declare module '@polkadot/api/types/storage' {
       /**
        * Proposals so far. id can be used to keep track of PIPs off-chain.
        **/
-      pipIdSequence: AugmentedQuery<ApiType, () => Observable<u32>, []>;
+      pipIdSequence: AugmentedQuery<ApiType, () => Observable<PipId>, []>;
       /**
        * The number of times a certain PIP has been skipped.
        * Once a (configurable) threshhold is exceeded, a PIP cannot be skipped again.
@@ -1454,7 +1459,7 @@ declare module '@polkadot/api/types/storage' {
       /**
        * Snapshots so far. id can be used to keep track of snapshots off-chain.
        **/
-      snapshotIdSequence: AugmentedQuery<ApiType, () => Observable<u32>, []>;
+      snapshotIdSequence: AugmentedQuery<ApiType, () => Observable<SnapshotId>, []>;
       /**
        * The metadata of the snapshot, if there is one.
        **/
@@ -1467,6 +1472,7 @@ declare module '@polkadot/api/types/storage' {
        * Once a (configurable) threshhold is exceeded, a PIP cannot be skipped again.
        **/
       snapshotQueue: AugmentedQuery<ApiType, () => Observable<Vec<SnapshottedPip>>, []>;
+      storageVersion: AugmentedQuery<ApiType, () => Observable<Version>, []>;
     };
     polymeshCommittee: {
       /**
@@ -1749,10 +1755,10 @@ declare module '@polkadot/api/types/storage' {
       affirmsReceived: AugmentedQuery<
         ApiType,
         (
-          arg1: u64 | AnyNumber | Uint8Array,
+          arg1: InstructionId | AnyNumber | Uint8Array,
           arg2: PortfolioId | { did?: any; kind?: any } | string | Uint8Array
         ) => Observable<AffirmationStatus>,
-        [u64, PortfolioId]
+        [InstructionId, PortfolioId]
       >;
       /**
        * Free-form text about a venue. venue_id -> `VenueDetails`
@@ -1760,36 +1766,39 @@ declare module '@polkadot/api/types/storage' {
        **/
       details: AugmentedQuery<
         ApiType,
-        (arg: u64 | AnyNumber | Uint8Array) => Observable<VenueDetails>,
-        [u64]
+        (arg: VenueId | AnyNumber | Uint8Array) => Observable<VenueDetails>,
+        [VenueId]
       >;
       /**
        * Number of affirmations pending before instruction is executed. instruction_id -> affirm_pending
        **/
       instructionAffirmsPending: AugmentedQuery<
         ApiType,
-        (arg: u64 | AnyNumber | Uint8Array) => Observable<u64>,
-        [u64]
+        (arg: InstructionId | AnyNumber | Uint8Array) => Observable<u64>,
+        [InstructionId]
       >;
       /**
        * Number of instructions in the system (It's one more than the actual number)
        **/
-      instructionCounter: AugmentedQuery<ApiType, () => Observable<u64>, []>;
+      instructionCounter: AugmentedQuery<ApiType, () => Observable<InstructionId>, []>;
       /**
        * Details about an instruction. instruction_id -> instruction_details
        **/
       instructionDetails: AugmentedQuery<
         ApiType,
-        (arg: u64 | AnyNumber | Uint8Array) => Observable<Instruction>,
-        [u64]
+        (arg: InstructionId | AnyNumber | Uint8Array) => Observable<Instruction>,
+        [InstructionId]
       >;
       /**
        * Legs under an instruction. (instruction_id, leg_id) -> Leg
        **/
       instructionLegs: AugmentedQuery<
         ApiType,
-        (arg1: u64 | AnyNumber | Uint8Array, arg2: u64 | AnyNumber | Uint8Array) => Observable<Leg>,
-        [u64, u64]
+        (
+          arg1: InstructionId | AnyNumber | Uint8Array,
+          arg2: LegId | AnyNumber | Uint8Array
+        ) => Observable<Leg>,
+        [InstructionId, LegId]
       >;
       /**
        * Status of a leg under an instruction. (instruction_id, leg_id) -> LegStatus
@@ -1797,10 +1806,10 @@ declare module '@polkadot/api/types/storage' {
       instructionLegStatus: AugmentedQuery<
         ApiType,
         (
-          arg1: u64 | AnyNumber | Uint8Array,
-          arg2: u64 | AnyNumber | Uint8Array
+          arg1: InstructionId | AnyNumber | Uint8Array,
+          arg2: LegId | AnyNumber | Uint8Array
         ) => Observable<LegStatus>,
-        [u64, u64]
+        [InstructionId, LegId]
       >;
       /**
        * Tracks redemption of receipts. (signer, receipt_uid) -> receipt_used
@@ -1825,34 +1834,34 @@ declare module '@polkadot/api/types/storage' {
         ApiType,
         (
           arg1: PortfolioId | { did?: any; kind?: any } | string | Uint8Array,
-          arg2: u64 | AnyNumber | Uint8Array
+          arg2: InstructionId | AnyNumber | Uint8Array
         ) => Observable<AffirmationStatus>,
-        [PortfolioId, u64]
+        [PortfolioId, InstructionId]
       >;
       /**
        * Array of venues created by an identity. Only needed for the UI. IdentityId -> Vec<venue_id>
        **/
       userVenues: AugmentedQuery<
         ApiType,
-        (arg: IdentityId | string | Uint8Array) => Observable<Vec<u64>>,
+        (arg: IdentityId | string | Uint8Array) => Observable<Vec<VenueId>>,
         [IdentityId]
       >;
       /**
-       * Venues that are allowed to create instructions involving a particular ticker. Oly used if filtering is enabled.
+       * Venues that are allowed to create instructions involving a particular ticker. Only used if filtering is enabled.
        * (ticker, venue_id) -> allowed
        **/
       venueAllowList: AugmentedQuery<
         ApiType,
         (
           arg1: Ticker | string | Uint8Array,
-          arg2: u64 | AnyNumber | Uint8Array
+          arg2: VenueId | AnyNumber | Uint8Array
         ) => Observable<bool>,
-        [Ticker, u64]
+        [Ticker, VenueId]
       >;
       /**
        * Number of venues in the system (It's one more than the actual number)
        **/
-      venueCounter: AugmentedQuery<ApiType, () => Observable<u64>, []>;
+      venueCounter: AugmentedQuery<ApiType, () => Observable<VenueId>, []>;
       /**
        * Tracks if a token has enabled filtering venues that can create instructions involving their token. Ticker -> filtering_enabled
        **/
@@ -1866,8 +1875,8 @@ declare module '@polkadot/api/types/storage' {
        **/
       venueInfo: AugmentedQuery<
         ApiType,
-        (arg: u64 | AnyNumber | Uint8Array) => Observable<Option<Venue>>,
-        [u64]
+        (arg: VenueId | AnyNumber | Uint8Array) => Observable<Option<Venue>>,
+        [VenueId]
       >;
       /**
        * Instructions under a venue.
@@ -1878,10 +1887,10 @@ declare module '@polkadot/api/types/storage' {
       venueInstructions: AugmentedQuery<
         ApiType,
         (
-          arg1: u64 | AnyNumber | Uint8Array,
-          arg2: u64 | AnyNumber | Uint8Array
+          arg1: VenueId | AnyNumber | Uint8Array,
+          arg2: InstructionId | AnyNumber | Uint8Array
         ) => Observable<ITuple<[]>>,
-        [u64, u64]
+        [VenueId, InstructionId]
       >;
       /**
        * Signers allowed by the venue. (venue_id, signer) -> bool
@@ -1889,10 +1898,10 @@ declare module '@polkadot/api/types/storage' {
       venueSigners: AugmentedQuery<
         ApiType,
         (
-          arg1: u64 | AnyNumber | Uint8Array,
+          arg1: VenueId | AnyNumber | Uint8Array,
           arg2: AccountId | string | Uint8Array
         ) => Observable<bool>,
-        [u64, AccountId]
+        [VenueId, AccountId]
       >;
     };
     staking: {
@@ -2250,20 +2259,20 @@ declare module '@polkadot/api/types/storage' {
        **/
       fundraiserCount: AugmentedQuery<
         ApiType,
-        (arg: Ticker | string | Uint8Array) => Observable<u64>,
+        (arg: Ticker | string | Uint8Array) => Observable<FundraiserId>,
         [Ticker]
       >;
       /**
-       * Name for the Fundraiser. It is only used offchain.
+       * Name for the Fundraiser. Only used offchain.
        * (ticker, fundraiser_id) -> Fundraiser name
        **/
       fundraiserNames: AugmentedQuery<
         ApiType,
         (
           arg1: Ticker | string | Uint8Array,
-          arg2: u64 | AnyNumber | Uint8Array
+          arg2: FundraiserId | AnyNumber | Uint8Array
         ) => Observable<FundraiserName>,
-        [Ticker, u64]
+        [Ticker, FundraiserId]
       >;
       /**
        * All fundraisers that are currently running.
@@ -2273,9 +2282,9 @@ declare module '@polkadot/api/types/storage' {
         ApiType,
         (
           arg1: Ticker | string | Uint8Array,
-          arg2: u64 | AnyNumber | Uint8Array
+          arg2: FundraiserId | AnyNumber | Uint8Array
         ) => Observable<Option<Fundraiser>>,
-        [Ticker, u64]
+        [Ticker, FundraiserId]
       >;
     };
     sudo: {
@@ -2440,6 +2449,7 @@ declare module '@polkadot/api/types/storage' {
        **/
       inactiveMembers: AugmentedQuery<ApiType, () => Observable<Vec<InactiveMember>>, []>;
     };
+    testUtils: {};
     timestamp: {
       /**
        * Did the timestamp get updated in this block?

--- a/src/polkadot/augment-api-rpc.ts
+++ b/src/polkadot/augment-api-rpc.ts
@@ -100,6 +100,7 @@ import type {
   GranularCanTransferResult,
   IdentityId,
   KeyIdentityData,
+  PipId,
   PortfolioId,
   ProtocolOp,
   Signatory,
@@ -755,6 +756,7 @@ declare module '@polkadot/rpc-core/types.jsonrpc' {
             | 'PortfolioCustody'
             | 'BecomeAgent'
             | 'AddRelayerPayingKey'
+            | 'RotatePrimaryKeyToSecondary'
             | number
             | Uint8Array,
           blockHash?: Hash | string | Uint8Array
@@ -852,7 +854,7 @@ declare module '@polkadot/rpc-core/types.jsonrpc' {
        **/
       getVotes: AugmentedRpc<
         (
-          index: u32 | AnyNumber | Uint8Array,
+          index: PipId | AnyNumber | Uint8Array,
           blockHash?: Hash | string | Uint8Array
         ) => Observable<VoteCount>
       >;
@@ -863,7 +865,7 @@ declare module '@polkadot/rpc-core/types.jsonrpc' {
         (
           address: AccountId | string | Uint8Array,
           blockHash?: Hash | string | Uint8Array
-        ) => Observable<Vec<u32>>
+        ) => Observable<Vec<PipId>>
       >;
       /**
        * Retrieves proposal address indices voted on
@@ -872,7 +874,7 @@ declare module '@polkadot/rpc-core/types.jsonrpc' {
         (
           address: AccountId | string | Uint8Array,
           blockHash?: Hash | string | Uint8Array
-        ) => Observable<Vec<u32>>
+        ) => Observable<Vec<PipId>>
       >;
     };
     protocolFee: {

--- a/src/polkadot/augment-api-tx.ts
+++ b/src/polkadot/augment-api-tx.ts
@@ -62,11 +62,15 @@ import type {
   DocumentId,
   ExtrinsicPermissions,
   FundingRoundName,
+  FundraiserId,
   FundraiserName,
   IdentityId,
+  InstructionId,
+  InvestorUid,
   InvestorZKProofData,
   ItnRewardStatus,
   Leg,
+  LegId,
   LegacyPermissions,
   MaybeBlock,
   Memo,
@@ -104,6 +108,7 @@ import type {
   UniqueCall,
   Url,
   VenueDetails,
+  VenueId,
   VenueType,
 } from 'polymesh-types/polymesh';
 import type { ApiTypes, SubmittableExtrinsic } from '@polkadot/api/types';
@@ -142,10 +147,10 @@ declare module '@polkadot/api/types/submittable' {
         [u64]
       >;
       /**
-       * Add documents for a given token. To be called only by the token owner.
+       * Add documents for a given token.
        *
        * # Arguments
-       * * `origin` Secondary key of the token owner.
+       * * `origin` is a signer that has permissions to act as an agent of `ticker`.
        * * `ticker` Ticker of the token.
        * * `docs` Documents to be attached to `ticker`.
        *
@@ -190,11 +195,10 @@ declare module '@polkadot/api/types/submittable' {
         [Ticker, EcdsaSignature]
       >;
       /**
-       * Forces a transfer of token from `from_portfolio` to the PIA's default portfolio.
-       * Only PIA is allowed to execute this.
+       * Forces a transfer of token from `from_portfolio` to the caller's default portfolio.
        *
        * # Arguments
-       * * `origin` Must be a PIA for a given ticker.
+       * * `origin` Must be an external agent with appropriate permissions for a given ticker.
        * * `ticker` Ticker symbol of the asset.
        * * `value`  Amount of tokens need to force transfer.
        * * `from_portfolio` From whom portfolio tokens gets transferred.
@@ -290,10 +294,10 @@ declare module '@polkadot/api/types/submittable' {
       >;
       /**
        * Issue, or mint, new tokens to the caller,
-       * which must be an authorized agent, e.g., a primary issuance agent.
+       * which must be an authorized external agent.
        *
        * # Arguments
-       * * `origin` must be the secondary key of token owner.
+       * * `origin` is a signer that has permissions to act as an agent of `ticker`.
        * * `ticker` of the token.
        * * `amount` of tokens that get issued.
        *
@@ -309,10 +313,10 @@ declare module '@polkadot/api/types/submittable' {
         [Ticker, Balance]
       >;
       /**
-       * Makes an indivisible token divisible. Only called by the token owner.
+       * Makes an indivisible token divisible.
        *
        * # Arguments
-       * * `origin` Secondary key of the token owner.
+       * * `origin` is a signer that has permissions to act as an agent of `ticker`.
        * * `ticker` Ticker of the token.
        *
        * ## Errors
@@ -326,17 +330,17 @@ declare module '@polkadot/api/types/submittable' {
         [Ticker]
       >;
       /**
-       * Redeems existing tokens by reducing the balance of the PIA's default portfolio and the total supply of the token
+       * Redeems existing tokens by reducing the balance of the caller's default portfolio and the total supply of the token
        *
        * # Arguments
-       * * `origin` Secondary key of token owner.
+       * * `origin` is a signer that has permissions to act as an agent of `ticker`.
        * * `ticker` Ticker of the token.
        * * `value` Amount of tokens to redeem.
        *
        * # Errors
-       * - `Unauthorized` If called by someone other than the token owner or the PIA
+       * - `Unauthorized` If called by someone without the appropriate external agent permissions
        * - `InvalidGranularity` If the amount is not divisible by 10^6 for non-divisible tokens
-       * - `InsufficientPortfolioBalance` If the PIA's default portfolio doesn't have enough free balance
+       * - `InsufficientPortfolioBalance` If the caller's default portfolio doesn't have enough free balance
        *
        * # Permissions
        * * Asset
@@ -380,10 +384,10 @@ declare module '@polkadot/api/types/submittable' {
         [Ticker]
       >;
       /**
-       * Remove documents for a given token. To be called only by the token owner.
+       * Remove documents for a given token.
        *
        * # Arguments
-       * * `origin` Secondary key of the token owner.
+       * * `origin` is a signer that has permissions to act as an agent of `ticker`.
        * * `ticker` Ticker of the token.
        * * `ids` Documents ids to be removed from `ticker`.
        *
@@ -454,7 +458,7 @@ declare module '@polkadot/api/types/submittable' {
        * Sets the name of the current funding round.
        *
        * # Arguments
-       * * `origin` - the secondary key of the token owner DID.
+       * * `origin` - a signer that has permissions to act as an agent of `ticker`.
        * * `ticker` - the ticker of the token.
        * * `name` - the desired name of the current funding round.
        *
@@ -490,10 +494,10 @@ declare module '@polkadot/api/types/submittable' {
         [Ticker]
       >;
       /**
-       * Updates the asset identifiers. Can only be called by the token owner.
+       * Updates the asset identifiers.
        *
        * # Arguments
-       * * `origin` - the secondary key of the token owner.
+       * * `origin` - a signer that has permissions to act as an agent of `ticker`.
        * * `ticker` - the ticker of the token.
        * * `identifiers` - the asset identifiers to be updated in the form of a vector of pairs
        * of `IdentifierType` and `AssetIdentifier` value.
@@ -938,6 +942,26 @@ declare module '@polkadot/api/types/submittable' {
         [AccountId]
       >;
       /**
+       * Remove given bridge transactions.
+       *
+       * ## Errors
+       * - `BadAdmin` if `origin` is not `Self::admin()` account.
+       * - `NotFrozen` if a tx in `bridge_txs` is not frozen.
+       **/
+      removeTxs: AugmentedSubmittable<
+        (
+          bridgeTxs:
+            | Vec<BridgeTx>
+            | (
+                | BridgeTx
+                | { nonce?: any; recipient?: any; amount?: any; tx_hash?: any }
+                | string
+                | Uint8Array
+              )[]
+        ) => SubmittableExtrinsic<ApiType>,
+        [Vec<BridgeTx>]
+      >;
+      /**
        * Unfreezes transaction handling in the bridge module if it is frozen.
        *
        * ## Errors
@@ -980,7 +1004,7 @@ declare module '@polkadot/api/types/submittable' {
        * they are rounded down to a whole unit.
        *
        * ## Arguments
-       * - `origin` which must be a holder of for a CAA of `ca_id`.
+       * - `origin` which must be a holder of the asset and eligible for the distribution.
        * - `ca_id` identifies the CA to start a capital distribution for.
        *
        * # Errors
@@ -1017,9 +1041,9 @@ declare module '@polkadot/api/types/submittable' {
        * which is now transferrable.
        *
        * ## Arguments
-       * - `origin` which must be a signer for a CAA of `ca_id`.
+       * - `origin` is a signer that has permissions to act as an agent of `ca_id.ticker`.
        * - `ca_id` identifies the CA to start a capital distribution for.
-       * - `portfolio` specifies the portfolio number of the CAA to distribute `amount` from.
+       * - `portfolio` specifies the portfolio number of the agent to distribute `amount` from.
        * - `currency` to withdraw and distribute from the `portfolio`.
        * - `per_share` amount of `currency` to withdraw and distribute.
        * Specified as a per-million, i.e. `1 / 10^6`th of one `currency` token.
@@ -1035,9 +1059,10 @@ declare module '@polkadot/api/types/submittable' {
        * - `NoSuchCA` if `ca_id` does not identify an existing CA.
        * - `NoRecordDate` if CA has no record date.
        * - `RecordDateAfterStart` if CA's record date > payment_at.
-       * - `UnauthorizedCustodian` if CAA is not the custodian of `portfolio`.
+       * - `UnauthorizedCustodian` if the caller is not the custodian of `portfolio`.
        * - `InsufficientPortfolioBalance` if `portfolio` has less than `amount` of `currency`.
        * - `InsufficientBalance` if the protocol fee couldn't be charged.
+       * - `CANotBenefit` if the CA is not of kind PredictableBenefit/UnpredictableBenefit
        *
        * # Permissions
        * * Asset
@@ -1066,7 +1091,7 @@ declare module '@polkadot/api/types/submittable' {
        * they are rounded down to a whole unit.
        *
        * ## Arguments
-       * - `origin` which must be a holder of for a CAA of `ca_id`.
+       * - `origin` is a signer that has permissions to act as an agent of `ca_id.ticker`.
        * - `ca_id` identifies the CA with a capital distributions to push benefits for.
        * - `holder` to push benefits to.
        *
@@ -1112,7 +1137,7 @@ declare module '@polkadot/api/types/submittable' {
        * unlocking the full amount in the distributor portfolio.
        *
        * ## Arguments
-       * - `origin` which must be a signer for a CAA of `ca_id`.
+       * - `origin` is a signer that has permissions to act as an agent of `ca_id.ticker`.
        * - `ca_id` identifies the CA with a not-yet-started capital distribution to remove.
        *
        * # Errors
@@ -1241,12 +1266,12 @@ declare module '@polkadot/api/types/submittable' {
        * Creates a single checkpoint at the current time.
        *
        * # Arguments
-       * - `origin` is a signer that has permissions to act as owner of `ticker`.
+       * - `origin` is a signer that has permissions to act as an agent of `ticker`.
        * - `ticker` to create the checkpoint for.
        *
        * # Errors
        * - `UnauthorizedAgent` if the DID of `origin` isn't a permissioned agent for `ticker`.
-       * - `CheckpointOverflow` if the total checkpoint counter would overflow.
+       * - `CounterOverflow` if the total checkpoint counter would overflow.
        **/
       createCheckpoint: AugmentedSubmittable<
         (ticker: Ticker | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
@@ -1267,8 +1292,7 @@ declare module '@polkadot/api/types/submittable' {
        * - `UnauthorizedAgent` if the DID of `origin` isn't a permissioned agent for `ticker`.
        * - `ScheduleDurationTooShort` if the schedule duration is too short.
        * - `InsufficientAccountBalance` if the protocol fee could not be charged.
-       * - `ScheduleOverflow` if the schedule ID counter would overflow.
-       * - `CheckpointOverflow` if the total checkpoint counter would overflow.
+       * - `CounterOverflow` if the schedule ID or total checkpoint counters would overflow.
        * - `FailedToComputeNextCheckpoint` if the next checkpoint for `schedule` is in the past.
        *
        * # Permissions
@@ -1552,6 +1576,9 @@ declare module '@polkadot/api/types/submittable' {
       /**
        * Replaces an asset's compliance by ticker with a new compliance.
        *
+       * Compliance requirements will be sorted (ascending by id) before
+       * replacing the current requirements.
+       *
        * # Arguments
        * * `ticker` - the asset ticker,
        * * `asset_compliance - the new asset compliance.
@@ -1611,7 +1638,7 @@ declare module '@polkadot/api/types/submittable' {
        * Changes the record date of the CA identified by `ca_id`.
        *
        * ## Arguments
-       * - `origin` which must be a signer for a CAA of `ca_id`.
+       * - `origin` which must be an external agent of `ca_id.ticker` with relevant permissions.
        * - `ca_id` of the CA to alter.
        * - `record_date`, if any, to calculate the impact of the CA.
        * If provided, this results in a scheduled balance snapshot ("checkpoint") at the date.
@@ -1635,7 +1662,7 @@ declare module '@polkadot/api/types/submittable' {
        * Initiates a CA for `ticker` of `kind` with `details` and other provided arguments.
        *
        * ## Arguments
-       * - `origin` which must be a signer for a CAA of `ca_id`.
+       * - `origin` which must be an external agent of `ticker` with relevant permissions.
        * - `ticker` that the CA is made for.
        * - `kind` of CA being initiated.
        * - `decl_date` of CA bring initialized.
@@ -1652,7 +1679,7 @@ declare module '@polkadot/api/types/submittable' {
        * # Errors
        * - `DetailsTooLong` if `details.len()` goes beyond `max_details_length`.
        * - `UnauthorizedAgent` if `origin` is not agent-permissioned for `ticker`.
-       * - `LocalCAIdOverflow` in the unlikely event that so many CAs were created for this `ticker`,
+       * - `CounterOverflow` in the unlikely event that so many CAs were created for this `ticker`,
        * that integer overflow would have occured if instead allowed.
        * - `TooManyDidTaxes` if `withholding_tax.unwrap().len()` would go over the limit `MaxDidWhts`.
        * - `DuplicateDidTax` if a DID is included more than once in `wt`.
@@ -1706,7 +1733,7 @@ declare module '@polkadot/api/types/submittable' {
        * Once both exist, they can now be linked together.
        *
        * ## Arguments
-       * - `origin` which must be a signer for a CAA of `ca_id`.
+       * - `origin` which must be an external agent of `id.ticker` with relevant permissions.
        * - `id` of the CA to associate with `docs`.
        * - `docs` to associate with the CA with `id`.
        *
@@ -1735,7 +1762,7 @@ declare module '@polkadot/api/types/submittable' {
        * `strong_ref_count(schedule_id)` decremented.
        *
        * ## Arguments
-       * - `origin` which must be a signer for a CAA of `ca_id`.
+       * - `origin` which must be an external agent of `ca_id.ticker` with relevant permissions.
        * - `ca_id` of the CA to remove.
        *
        * # Errors
@@ -1755,7 +1782,7 @@ declare module '@polkadot/api/types/submittable' {
        * Set the default CA `TargetIdentities` to `targets`.
        *
        * ## Arguments
-       * - `origin` which must be a signer for the CAA of `ca_id`.
+       * - `origin` which must be an external agent of `ticker` with relevant permissions.
        * - `ticker` for which the default identities are changing.
        * - `targets` the default target identities for a CA.
        *
@@ -1777,7 +1804,7 @@ declare module '@polkadot/api/types/submittable' {
        * Set the default withholding tax for all DIDs and CAs relevant to this `ticker`.
        *
        * ## Arguments
-       * - `origin` which must be a signer for a CAA of `ca_id`.
+       * - `origin` which must be an external agent of `ticker` with relevant permissions.
        * - `ticker` that the withholding tax will apply to.
        * - `tax` that should be withheld when distributing dividends, etc.
        *
@@ -1800,7 +1827,7 @@ declare module '@polkadot/api/types/submittable' {
        * Otherwise, if `None`, the default withholding tax will be used.
        *
        * ## Arguments
-       * - `origin` which must be a signer for a CAA of `ca_id`.
+       * - `origin` which must be an external agent of `ticker` with relevant permissions.
        * - `ticker` that the withholding tax will apply to.
        * - `taxed_did` that will have its withholding tax updated.
        * - `tax` that should be withheld when distributing dividends, etc.
@@ -1839,7 +1866,7 @@ declare module '@polkadot/api/types/submittable' {
        * See the `BallotMeta` for more.
        *
        * ## Arguments
-       * - `origin` which must be a signer for a CAA of `ca_id`.
+       * - `origin` is a signer that has permissions to act as an agent of `ca_id.ticker`.
        * - `ca_id` identifies the CA to attach the ballot to.
        * - `range` specifies when voting starts and ends.
        * - `meta` specifies the ballot's metadata as aforementioned.
@@ -1871,7 +1898,7 @@ declare module '@polkadot/api/types/submittable' {
        * Amend the end date of the ballot of the CA identified by `ca_id`.
        *
        * ## Arguments
-       * - `origin` which must be a signer for a CAA of `ca_id`.
+       * - `origin` is a signer that has permissions to act as an agent of `ca_id.ticker`.
        * - `ca_id` identifies the attached ballot's CA.
        * - `end` specifies the new end date of the ballot.
        *
@@ -1892,7 +1919,7 @@ declare module '@polkadot/api/types/submittable' {
        * Amend the metadata (title, motions, etc.) of the ballot of the CA identified by `ca_id`.
        *
        * ## Arguments
-       * - `origin` which must be a signer for a CAA of `ca_id`.
+       * - `origin` is a signer that has permissions to act as an agent of `ca_id.ticker`.
        * - `ca_id` identifies the attached ballot's CA.
        * - `meta` specifies the new metadata.
        *
@@ -1914,7 +1941,7 @@ declare module '@polkadot/api/types/submittable' {
        * Amend RCV support for the ballot of the CA identified by `ca_id`.
        *
        * ## Arguments
-       * - `origin` which must be a signer for a CAA of `ca_id`.
+       * - `origin` is a signer that has permissions to act as an agent of `ca_id.ticker`.
        * - `ca_id` identifies the attached ballot's CA.
        * - `rcv` specifies if RCV is to be supported or not.
        *
@@ -1934,7 +1961,7 @@ declare module '@polkadot/api/types/submittable' {
        * Remove the ballot of the CA identified by `ca_id`.
        *
        * ## Arguments
-       * - `origin` which must be a signer for a CAA of `ca_id`.
+       * - `origin` is a signer that has permissions to act as an agent of `ca_id.ticker`.
        * - `ca_id` identifies the attached ballot's CA.
        *
        * # Errors
@@ -2065,7 +2092,7 @@ declare module '@polkadot/api/types/submittable' {
        * # Errors
        * - `UnauthorizedAgent` if `origin` was not authorized as an agent to call this.
        * - `TooLong` if `perms` had some string or list length that was too long.
-       * - `LocalAGIdOverflow` if `AGIdSequence::get() + 1` would exceed `u32::MAX`.
+       * - `CounterOverflow` if `AGIdSequence::get() + 1` would exceed `u32::MAX`.
        *
        * # Permissions
        * * Asset
@@ -2207,8 +2234,14 @@ declare module '@polkadot/api/types/submittable' {
     identity: {
       /**
        * Call this with the new primary key. By invoking this method, caller accepts authorization
-       * with the new primary key. If a CDD service provider approved this change, primary key of
-       * the DID is updated.
+       * to become the new primary key of the issuing identity. If a CDD service provider approved
+       * this change (or this is not required), primary key of the DID is updated.
+       *
+       * The caller (new primary key) must be either a secondary key of the issuing identity, or
+       * unlinked to any identity.
+       *
+       * Differs from rotate_primary_key_to_secondary in that it will unlink the old primary key
+       * instead of leaving it as a secondary key.
        *
        * # Arguments
        * * `owner_auth_id` Authorization from the owner who initiated the change
@@ -2227,7 +2260,7 @@ declare module '@polkadot/api/types/submittable' {
       addAuthorization: AugmentedSubmittable<
         (
           target: Signatory | { Identity: any } | { Account: any } | string | Uint8Array,
-          authorizationData:
+          data:
             | AuthorizationData
             | { AttestPrimaryKeyRotation: any }
             | { RotatePrimaryKey: any }
@@ -2238,6 +2271,7 @@ declare module '@polkadot/api/types/submittable' {
             | { PortfolioCustody: any }
             | { BecomeAgent: any }
             | { AddRelayerPayingKey: any }
+            | { RotatePrimaryKeyToSecondary: any }
             | string
             | Uint8Array,
           expiry: Option<Moment> | null | object | string | Uint8Array
@@ -2435,9 +2469,10 @@ declare module '@polkadot/api/types/submittable' {
         [IdentityId]
       >;
       /**
-       * It invalidates any claim generated by `cdd` from `disable_from` timestamps.
-       * You can also define an expiration time, which will invalidate all claims generated by
-       * that `cdd` and remove it as CDD member group.
+       * Invalidates any claim generated by `cdd` from `disable_from` timestamps.
+       *
+       * You can also define an expiration time,
+       * which will invalidate all claims generated by that `cdd` and remove it as CDD member group.
        **/
       invalidateCddClaims: AugmentedSubmittable<
         (
@@ -2562,13 +2597,37 @@ declare module '@polkadot/api/types/submittable' {
         [IdentityId, ClaimType, Option<Scope>]
       >;
       /**
-       * It sets permissions for an specific `target_key` key.
+       * Call this with the new primary key. By invoking this method, caller accepts authorization
+       * to become the new primary key of the issuing identity. If a CDD service provider approved
+       * this change, (or this is not required), primary key of the DID is updated.
+       *
+       * The caller (new primary key) must be either a secondary key of the issuing identity, or
+       * unlinked to any identity.
+       *
+       * Differs from accept_primary_key in that it will leave the old primary key as a secondary
+       * key with the permissions specified in the corresponding RotatePrimaryKeyToSecondary authorization
+       * instead of unlinking the old primary key.
+       *
+       * # Arguments
+       * * `owner_auth_id` Authorization from the owner who initiated the change
+       * * `cdd_auth_id` Authorization from a CDD service provider
+       **/
+      rotatePrimaryKeyToSecondary: AugmentedSubmittable<
+        (
+          authId: u64 | AnyNumber | Uint8Array,
+          optionalCddAuthId: Option<u64> | null | object | string | Uint8Array
+        ) => SubmittableExtrinsic<ApiType>,
+        [u64, Option<u64>]
+      >;
+      /**
+       * Sets permissions for an specific `target_key` key.
+       *
        * Only the primary key of an identity is able to set secondary key permissions.
        **/
       setPermissionToSigner: AugmentedSubmittable<
         (
           signer: Signatory | { Identity: any } | { Account: any } | string | Uint8Array,
-          permissions:
+          perms:
             | Permissions
             | { asset?: any; extrinsic?: any; portfolio?: any }
             | string
@@ -3818,7 +3877,7 @@ declare module '@polkadot/api/types/submittable' {
        **/
       addAndAffirmInstruction: AugmentedSubmittable<
         (
-          venueId: u64 | AnyNumber | Uint8Array,
+          venueId: VenueId | AnyNumber | Uint8Array,
           settlementType:
             | SettlementType
             | { SettleOnAffirmation: any }
@@ -3834,7 +3893,7 @@ declare module '@polkadot/api/types/submittable' {
             | Vec<PortfolioId>
             | (PortfolioId | { did?: any; kind?: any } | string | Uint8Array)[]
         ) => SubmittableExtrinsic<ApiType>,
-        [u64, SettlementType, Option<Moment>, Option<Moment>, Vec<Leg>, Vec<PortfolioId>]
+        [VenueId, SettlementType, Option<Moment>, Option<Moment>, Vec<Leg>, Vec<PortfolioId>]
       >;
       /**
        * Adds a new instruction.
@@ -3852,7 +3911,7 @@ declare module '@polkadot/api/types/submittable' {
        **/
       addInstruction: AugmentedSubmittable<
         (
-          venueId: u64 | AnyNumber | Uint8Array,
+          venueId: VenueId | AnyNumber | Uint8Array,
           settlementType:
             | SettlementType
             | { SettleOnAffirmation: any }
@@ -3865,34 +3924,34 @@ declare module '@polkadot/api/types/submittable' {
             | Vec<Leg>
             | (Leg | { from?: any; to?: any; asset?: any; amount?: any } | string | Uint8Array)[]
         ) => SubmittableExtrinsic<ApiType>,
-        [u64, SettlementType, Option<Moment>, Option<Moment>, Vec<Leg>]
+        [VenueId, SettlementType, Option<Moment>, Option<Moment>, Vec<Leg>]
       >;
       /**
        * Provide affirmation to an existing instruction.
        *
        * # Arguments
-       * * `instruction_id` - Instruction id to affirm.
+       * * `id` - Instruction id to affirm.
        * * `portfolios` - Portfolios that the sender controls and wants to affirm this instruction.
-       * * `legs` - List of legs needs to affirmed.
+       * * `max_legs_count` - Number of legs that need to be  affirmed.
        *
        * # Permissions
        * * Portfolio
        **/
       affirmInstruction: AugmentedSubmittable<
         (
-          instructionId: u64 | AnyNumber | Uint8Array,
+          id: InstructionId | AnyNumber | Uint8Array,
           portfolios:
             | Vec<PortfolioId>
             | (PortfolioId | { did?: any; kind?: any } | string | Uint8Array)[],
           maxLegsCount: u32 | AnyNumber | Uint8Array
         ) => SubmittableExtrinsic<ApiType>,
-        [u64, Vec<PortfolioId>, u32]
+        [InstructionId, Vec<PortfolioId>, u32]
       >;
       /**
        * Accepts an instruction and claims a signed receipt.
        *
        * # Arguments
-       * * `instruction_id` - Target instruction id.
+       * * `id` - Target instruction id.
        * * `leg_id` - Target leg id for the receipt
        * * `receipt_uid` - Receipt ID generated by the signer.
        * * `signer` - Signer of the receipt.
@@ -3904,7 +3963,7 @@ declare module '@polkadot/api/types/submittable' {
        **/
       affirmWithReceipts: AugmentedSubmittable<
         (
-          instructionId: u64 | AnyNumber | Uint8Array,
+          id: InstructionId | AnyNumber | Uint8Array,
           receiptDetails:
             | Vec<ReceiptDetails>
             | (
@@ -3918,7 +3977,7 @@ declare module '@polkadot/api/types/submittable' {
             | (PortfolioId | { did?: any; kind?: any } | string | Uint8Array)[],
           maxLegsCount: u32 | AnyNumber | Uint8Array
         ) => SubmittableExtrinsic<ApiType>,
-        [u64, Vec<ReceiptDetails>, Vec<PortfolioId>, u32]
+        [InstructionId, Vec<ReceiptDetails>, Vec<PortfolioId>, u32]
       >;
       /**
        * Allows additional venues to create instructions involving an asset.
@@ -3932,9 +3991,9 @@ declare module '@polkadot/api/types/submittable' {
       allowVenues: AugmentedSubmittable<
         (
           ticker: Ticker | string | Uint8Array,
-          venues: Vec<u64> | (u64 | AnyNumber | Uint8Array)[]
+          venues: Vec<VenueId> | (VenueId | AnyNumber | Uint8Array)[]
         ) => SubmittableExtrinsic<ApiType>,
-        [Ticker, Vec<u64>]
+        [Ticker, Vec<VenueId>]
       >;
       /**
        * Marks a receipt issued by the caller as claimed or not claimed.
@@ -3954,7 +4013,7 @@ declare module '@polkadot/api/types/submittable' {
        * Claims a signed receipt.
        *
        * # Arguments
-       * * `instruction_id` - Target instruction id for the receipt.
+       * * `id` - Target instruction id for the receipt.
        * * `leg_id` - Target leg id for the receipt
        * * `receipt_uid` - Receipt ID generated by the signer.
        * * `signer` - Signer of the receipt.
@@ -3965,14 +4024,14 @@ declare module '@polkadot/api/types/submittable' {
        **/
       claimReceipt: AugmentedSubmittable<
         (
-          instructionId: u64 | AnyNumber | Uint8Array,
+          id: InstructionId | AnyNumber | Uint8Array,
           receiptDetails:
             | ReceiptDetails
             | { receipt_uid?: any; leg_id?: any; signer?: any; signature?: any; metadata?: any }
             | string
             | Uint8Array
         ) => SubmittableExtrinsic<ApiType>,
-        [u64, ReceiptDetails]
+        [InstructionId, ReceiptDetails]
       >;
       /**
        * Registers a new venue.
@@ -4001,25 +4060,25 @@ declare module '@polkadot/api/types/submittable' {
       disallowVenues: AugmentedSubmittable<
         (
           ticker: Ticker | string | Uint8Array,
-          venues: Vec<u64> | (u64 | AnyNumber | Uint8Array)[]
+          venues: Vec<VenueId> | (VenueId | AnyNumber | Uint8Array)[]
         ) => SubmittableExtrinsic<ApiType>,
-        [Ticker, Vec<u64>]
+        [Ticker, Vec<VenueId>]
       >;
       /**
        * Root callable extrinsic, used as an internal call to execute a scheduled settlement instruction.
        **/
       executeScheduledInstruction: AugmentedSubmittable<
         (
-          instructionId: u64 | AnyNumber | Uint8Array,
+          id: InstructionId | AnyNumber | Uint8Array,
           legsCount: u32 | AnyNumber | Uint8Array
         ) => SubmittableExtrinsic<ApiType>,
-        [u64, u32]
+        [InstructionId, u32]
       >;
       /**
        * Rejects an existing instruction.
        *
        * # Arguments
-       * * `instruction_id` - Instruction id to reject.
+       * * `id` - Instruction id to reject.
        * * `portfolio` - Portfolio to reject the instruction.
        * * `num_of_legs` - Number of legs in the instruction.
        *
@@ -4028,17 +4087,17 @@ declare module '@polkadot/api/types/submittable' {
        **/
       rejectInstruction: AugmentedSubmittable<
         (
-          instructionId: u64 | AnyNumber | Uint8Array,
+          id: InstructionId | AnyNumber | Uint8Array,
           portfolio: PortfolioId | { did?: any; kind?: any } | string | Uint8Array,
           numOfLegs: u32 | AnyNumber | Uint8Array
         ) => SubmittableExtrinsic<ApiType>,
-        [u64, PortfolioId, u32]
+        [InstructionId, PortfolioId, u32]
       >;
       /**
        * Reschedules a failed instruction.
        *
        * # Arguments
-       * * `instruction_id` - Target instruction id to reschedule.
+       * * `id` - Target instruction id to reschedule.
        *
        * # Permissions
        * * Portfolio
@@ -4047,8 +4106,8 @@ declare module '@polkadot/api/types/submittable' {
        * * `InstructionNotFailed` - Instruction not in a failed state or does not exist.
        **/
       rescheduleInstruction: AugmentedSubmittable<
-        (instructionId: u64 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
-        [u64]
+        (id: InstructionId | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [InstructionId]
       >;
       /**
        * Enables or disabled venue filtering for a token.
@@ -4079,10 +4138,10 @@ declare module '@polkadot/api/types/submittable' {
        **/
       unclaimReceipt: AugmentedSubmittable<
         (
-          instructionId: u64 | AnyNumber | Uint8Array,
-          legId: u64 | AnyNumber | Uint8Array
+          instructionId: InstructionId | AnyNumber | Uint8Array,
+          legId: LegId | AnyNumber | Uint8Array
         ) => SubmittableExtrinsic<ApiType>,
-        [u64, u64]
+        [InstructionId, LegId]
       >;
       /**
        * Edit a venue's details.
@@ -4092,10 +4151,10 @@ declare module '@polkadot/api/types/submittable' {
        **/
       updateVenueDetails: AugmentedSubmittable<
         (
-          id: u64 | AnyNumber | Uint8Array,
+          id: VenueId | AnyNumber | Uint8Array,
           details: VenueDetails | string
         ) => SubmittableExtrinsic<ApiType>,
-        [u64, VenueDetails]
+        [VenueId, VenueDetails]
       >;
       /**
        * Edit a venue's type.
@@ -4105,30 +4164,31 @@ declare module '@polkadot/api/types/submittable' {
        **/
       updateVenueType: AugmentedSubmittable<
         (
-          id: u64 | AnyNumber | Uint8Array,
+          id: VenueId | AnyNumber | Uint8Array,
           typ: VenueType | 'Other' | 'Distribution' | 'Sto' | 'Exchange' | number | Uint8Array
         ) => SubmittableExtrinsic<ApiType>,
-        [u64, VenueType]
+        [VenueId, VenueType]
       >;
       /**
        * Withdraw an affirmation for a given instruction.
        *
        * # Arguments
-       * * `instruction_id` - Instruction id for that affirmation get withdrawn.
+       * * `id` - Instruction id for that affirmation get withdrawn.
        * * `portfolios` - Portfolios that the sender controls and wants to withdraw affirmation.
+       * * `max_legs_count` - Number of legs that need to be un-affirmed.
        *
        * # Permissions
        * * Portfolio
        **/
       withdrawAffirmation: AugmentedSubmittable<
         (
-          instructionId: u64 | AnyNumber | Uint8Array,
+          id: InstructionId | AnyNumber | Uint8Array,
           portfolios:
             | Vec<PortfolioId>
             | (PortfolioId | { did?: any; kind?: any } | string | Uint8Array)[],
           maxLegsCount: u32 | AnyNumber | Uint8Array
         ) => SubmittableExtrinsic<ApiType>,
-        [u64, Vec<PortfolioId>, u32]
+        [InstructionId, Vec<PortfolioId>, u32]
       >;
     };
     staking: {
@@ -4172,10 +4232,6 @@ declare module '@polkadot/api/types/submittable' {
        * - Read: Bonded, Ledger, [Origin Account], Current Era, History Depth, Locks
        * - Write: Bonded, Payee, [Origin Account], Locks, Ledger
        * # </weight>
-       * # Arguments
-       * * origin Stash account (signer of the extrinsic).
-       * * controller Account that controls the operation of stash.
-       * * payee Destination where reward can be transferred.
        **/
       bond: AugmentedSubmittable<
         (
@@ -4223,10 +4279,6 @@ declare module '@polkadot/api/types/submittable' {
        * - Read: Era Election Status, Bonded, Ledger, [Origin Account], Locks
        * - Write: [Origin Account], Locks, Ledger
        * # </weight>
-       *
-       * # Arguments
-       * * origin Stash account (signer of the extrinsic).
-       * * max_additional Extra amount that need to be bonded.
        **/
       bondExtra: AugmentedSubmittable<
         (
@@ -4402,9 +4454,6 @@ declare module '@polkadot/api/types/submittable' {
         [Vec<LookupSource>]
       >;
       /**
-       * Polymesh-Note - Weight changes to 1/4 of the actual weight that is calculated using the
-       * upstream benchmarking process.
-       *
        * Pay out all the stakers behind a single validator for a single era.
        *
        * - `validator_stash` is the stash account of the validator. Their nominators, up to
@@ -4449,9 +4498,9 @@ declare module '@polkadot/api/types/submittable' {
         [AccountId, EraIndex]
       >;
       /**
-       * Remove all data structure concerning a staker/stash once its balance is zero.
+       * Remove all data structure concerning a staker/stash once its balance is at the minimum.
        * This is essentially equivalent to `withdraw_unbonded` except it can be called by anyone
-       * and the target `stash` must have no funds left.
+       * and the target `stash` must have no funds left beyond the ED.
        *
        * This can be called from any origin.
        *
@@ -4608,7 +4657,7 @@ declare module '@polkadot/api/types/submittable' {
         [Vec<AccountId>]
       >;
       /**
-       * Changes min bond value to be used in bond(). Only Governance
+       * Changes min bond value to be used in validate(). Only Governance
        * committee is allowed to change this value.
        *
        * # Arguments
@@ -4821,10 +4870,6 @@ declare module '@polkadot/api/types/submittable' {
        * - Read: EraElectionStatus, Ledger, CurrentEra, Locks, \[Origin Account\]
        * - Write: Locks, Ledger, \[Origin Account\]
        * </weight>
-       *
-       * # Arguments
-       * * origin Controller (Signer of the extrinsic).
-       * * value Balance needs to be unbonded.
        **/
       unbond: AugmentedSubmittable<
         (value: Compact<BalanceOf> | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>,
@@ -4913,8 +4958,10 @@ declare module '@polkadot/api/types/submittable' {
        * - Reads: EraElectionStatus, Ledger, Current Era, Locks, [Origin Account]
        * - Writes: [Origin Account], Locks, Ledger
        * Kill:
-       * - Reads: EraElectionStatus, Ledger, Current Era, Bonded, Slashing Spans, \[Origin Account\], Locks
-       * - Writes: Bonded, Slashing Spans (if S > 0), Ledger, Payee, Validators, Nominators, [Origin Account], Locks
+       * - Reads: EraElectionStatus, Ledger, Current Era, Bonded, Slashing Spans, [Origin
+       * Account], Locks
+       * - Writes: Bonded, Slashing Spans (if S > 0), Ledger, Payee, Validators, Nominators,
+       * [Origin Account], Locks
        * - Writes Each: SpanSlash * S
        * NOTE: Weight annotation is the kill scenario, we refund otherwise.
        * # </weight>
@@ -5065,7 +5112,7 @@ declare module '@polkadot/api/types/submittable' {
           tiers:
             | Vec<PriceTier>
             | (PriceTier | { total?: any; price?: any } | string | Uint8Array)[],
-          venueId: u64 | AnyNumber | Uint8Array,
+          venueId: VenueId | AnyNumber | Uint8Array,
           start: Option<Moment> | null | object | string | Uint8Array,
           end: Option<Moment> | null | object | string | Uint8Array,
           minimumInvestment: Balance | AnyNumber | Uint8Array,
@@ -5077,7 +5124,7 @@ declare module '@polkadot/api/types/submittable' {
           PortfolioId,
           Ticker,
           Vec<PriceTier>,
-          u64,
+          VenueId,
           Option<Moment>,
           Option<Moment>,
           Balance,
@@ -5088,7 +5135,7 @@ declare module '@polkadot/api/types/submittable' {
        * Freeze a fundraiser.
        *
        * * `offering_asset` - Asset to freeze.
-       * * `fundraiser_id` - ID of the fundraiser to freeze.
+       * * `id` - ID of the fundraiser to freeze.
        *
        * # Permissions
        * * Asset
@@ -5096,9 +5143,9 @@ declare module '@polkadot/api/types/submittable' {
       freezeFundraiser: AugmentedSubmittable<
         (
           offeringAsset: Ticker | string | Uint8Array,
-          fundraiserId: u64 | AnyNumber | Uint8Array
+          id: FundraiserId | AnyNumber | Uint8Array
         ) => SubmittableExtrinsic<ApiType>,
-        [Ticker, u64]
+        [Ticker, FundraiserId]
       >;
       /**
        * Invest in a fundraiser.
@@ -5106,7 +5153,7 @@ declare module '@polkadot/api/types/submittable' {
        * * `investment_portfolio` - Portfolio that `offering_asset` will be deposited in.
        * * `funding_portfolio` - Portfolio that will fund the investment.
        * * `offering_asset` - Asset to invest in.
-       * * `fundraiser_id` - ID of the fundraiser to invest in.
+       * * `id` - ID of the fundraiser to invest in.
        * * `purchase_amount` - Amount of `offering_asset` to purchase.
        * * `max_price` - Maximum price to pay per unit of `offering_asset`, If `None`there are no constraints on price.
        * * `receipt` - Off-chain receipt to use instead of on-chain balance in `funding_portfolio`.
@@ -5119,18 +5166,26 @@ declare module '@polkadot/api/types/submittable' {
           investmentPortfolio: PortfolioId | { did?: any; kind?: any } | string | Uint8Array,
           fundingPortfolio: PortfolioId | { did?: any; kind?: any } | string | Uint8Array,
           offeringAsset: Ticker | string | Uint8Array,
-          fundraiserId: u64 | AnyNumber | Uint8Array,
+          id: FundraiserId | AnyNumber | Uint8Array,
           purchaseAmount: Balance | AnyNumber | Uint8Array,
           maxPrice: Option<Balance> | null | object | string | Uint8Array,
           receipt: Option<ReceiptDetails> | null | object | string | Uint8Array
         ) => SubmittableExtrinsic<ApiType>,
-        [PortfolioId, PortfolioId, Ticker, u64, Balance, Option<Balance>, Option<ReceiptDetails>]
+        [
+          PortfolioId,
+          PortfolioId,
+          Ticker,
+          FundraiserId,
+          Balance,
+          Option<Balance>,
+          Option<ReceiptDetails>
+        ]
       >;
       /**
        * Modify the time window a fundraiser is active
        *
        * * `offering_asset` - Asset to modify.
-       * * `fundraiser_id` - ID of the fundraiser to modify.
+       * * `id` - ID of the fundraiser to modify.
        * * `start` - New start of the fundraiser.
        * * `end` - New end of the fundraiser to modify.
        *
@@ -5140,17 +5195,17 @@ declare module '@polkadot/api/types/submittable' {
       modifyFundraiserWindow: AugmentedSubmittable<
         (
           offeringAsset: Ticker | string | Uint8Array,
-          fundraiserId: u64 | AnyNumber | Uint8Array,
+          id: FundraiserId | AnyNumber | Uint8Array,
           start: Moment | AnyNumber | Uint8Array,
           end: Option<Moment> | null | object | string | Uint8Array
         ) => SubmittableExtrinsic<ApiType>,
-        [Ticker, u64, Moment, Option<Moment>]
+        [Ticker, FundraiserId, Moment, Option<Moment>]
       >;
       /**
        * Stop a fundraiser.
        *
        * * `offering_asset` - Asset to stop.
-       * * `fundraiser_id` - ID of the fundraiser to stop.
+       * * `id` - ID of the fundraiser to stop.
        *
        * # Permissions
        * * Asset
@@ -5158,15 +5213,15 @@ declare module '@polkadot/api/types/submittable' {
       stop: AugmentedSubmittable<
         (
           offeringAsset: Ticker | string | Uint8Array,
-          fundraiserId: u64 | AnyNumber | Uint8Array
+          id: FundraiserId | AnyNumber | Uint8Array
         ) => SubmittableExtrinsic<ApiType>,
-        [Ticker, u64]
+        [Ticker, FundraiserId]
       >;
       /**
        * Unfreeze a fundraiser.
        *
        * * `offering_asset` - Asset to unfreeze.
-       * * `fundraiser_id` - ID of the fundraiser to unfreeze.
+       * * `id` - ID of the fundraiser to unfreeze.
        *
        * # Permissions
        * * Asset
@@ -5174,9 +5229,9 @@ declare module '@polkadot/api/types/submittable' {
       unfreezeFundraiser: AugmentedSubmittable<
         (
           offeringAsset: Ticker | string | Uint8Array,
-          fundraiserId: u64 | AnyNumber | Uint8Array
+          id: FundraiserId | AnyNumber | Uint8Array
         ) => SubmittableExtrinsic<ApiType>,
-        [Ticker, u64]
+        [Ticker, FundraiserId]
       >;
     };
     sudo: {
@@ -5598,6 +5653,58 @@ declare module '@polkadot/api/types/submittable' {
           add: IdentityId | string | Uint8Array
         ) => SubmittableExtrinsic<ApiType>,
         [IdentityId, IdentityId]
+      >;
+    };
+    testUtils: {
+      /**
+       * Emits an event with caller's identity and CDD status.
+       **/
+      getCddOf: AugmentedSubmittable<
+        (of: AccountId | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [AccountId]
+      >;
+      /**
+       * Emits an event with caller's identity.
+       **/
+      getMyDid: AugmentedSubmittable<() => SubmittableExtrinsic<ApiType>, []>;
+      /**
+       * Registers a new Identity for the `target_account` and issues a CDD claim to it.
+       * The Investor UID is generated deterministically by the hash of the generated DID and
+       * then we fix it to be compliant with UUID v4.
+       *
+       * # See
+       * - [RFC 4122: UUID](https://tools.ietf.org/html/rfc4122)
+       *
+       * # Failure
+       * - `origin` has to be an active CDD provider. Inactive CDD providers cannot add new
+       * claims.
+       * - `target_account` (primary key of the new Identity) can be linked to just one and only
+       * one identity.
+       **/
+      mockCddRegisterDid: AugmentedSubmittable<
+        (targetAccount: AccountId | string | Uint8Array) => SubmittableExtrinsic<ApiType>,
+        [AccountId]
+      >;
+      /**
+       * Generates a new `IdentityID` for the caller, and issues a self-generated CDD claim.
+       *
+       * The caller account will be the primary key of that identity.
+       * For each account of `secondary_keys`, a new `JoinIdentity` authorization is created, so
+       * each of them will need to accept it before become part of this new `IdentityID`.
+       *
+       * # Errors
+       * - `AlreadyLinked` if the caller account or if any of the given `secondary_keys` has already linked to an `IdentityID`
+       * - `SecondaryKeysContainPrimaryKey` if `secondary_keys` contains the caller account.
+       * - `DidAlreadyExists` if auto-generated DID already exists.
+       **/
+      registerDid: AugmentedSubmittable<
+        (
+          uid: InvestorUid | string | Uint8Array,
+          secondaryKeys:
+            | Vec<SecondaryKey>
+            | (SecondaryKey | { signer?: any; permissions?: any } | string | Uint8Array)[]
+        ) => SubmittableExtrinsic<ApiType>,
+        [InvestorUid, Vec<SecondaryKey>]
       >;
     };
     timestamp: {

--- a/src/polkadot/augment-types.ts
+++ b/src/polkadot/augment-types.ts
@@ -981,6 +981,7 @@ import type {
   ExtrinsicPermissions,
   FundingRoundName,
   Fundraiser,
+  FundraiserId,
   FundraiserName,
   FundraiserStatus,
   FundraiserTier,
@@ -991,12 +992,14 @@ import type {
   IdentityRole,
   InactiveMember,
   Instruction,
+  InstructionId,
   InstructionStatus,
   InvestorUid,
   InvestorZKProofData,
   ItnRewardStatus,
   KeyIdentityData,
   Leg,
+  LegId,
   LegStatus,
   LegacyPalletPermissions,
   LegacyPermissions,
@@ -1083,6 +1086,7 @@ import type {
   Url,
   Venue,
   VenueDetails,
+  VenueId,
   VenueType,
   Version,
   VoteByPip,
@@ -1129,13 +1133,16 @@ declare module '@polkadot/types/types/registry' {
     'Compact<FixedU128>': Compact<FixedU128>;
     'Compact<FixedU64>': Compact<FixedU64>;
     'Compact<FundIndex>': Compact<FundIndex>;
+    'Compact<FundraiserId>': Compact<FundraiserId>;
     'Compact<Gas>': Compact<Gas>;
     'Compact<GroupIndex>': Compact<GroupIndex>;
     'Compact<Index>': Compact<Index>;
     'Compact<InstanceId>': Compact<InstanceId>;
+    'Compact<InstructionId>': Compact<InstructionId>;
     'Compact<KeyTypeId>': Compact<KeyTypeId>;
     'Compact<LeasePeriod>': Compact<LeasePeriod>;
     'Compact<LeasePeriodOf>': Compact<LeasePeriodOf>;
+    'Compact<LegId>': Compact<LegId>;
     'Compact<LocalCAId>': Compact<LocalCAId>;
     'Compact<MemberCount>': Compact<MemberCount>;
     'Compact<MetaVersion>': Compact<MetaVersion>;
@@ -1194,6 +1201,7 @@ declare module '@polkadot/types/types/registry' {
     'Compact<USize>': Compact<USize>;
     'Compact<ValidatorCount>': Compact<ValidatorCount>;
     'Compact<ValidatorSetId>': Compact<ValidatorSetId>;
+    'Compact<VenueId>': Compact<VenueId>;
     'Compact<Version>': Compact<Version>;
     'Compact<VoteIndex>': Compact<VoteIndex>;
     'Compact<Weight>': Compact<Weight>;
@@ -1585,6 +1593,7 @@ declare module '@polkadot/types/types/registry' {
     'Option<FundInfo>': Option<FundInfo>;
     'Option<FundingRoundName>': Option<FundingRoundName>;
     'Option<Fundraiser>': Option<Fundraiser>;
+    'Option<FundraiserId>': Option<FundraiserId>;
     'Option<FundraiserName>': Option<FundraiserName>;
     'Option<FundraiserStatus>': Option<FundraiserStatus>;
     'Option<FundraiserTier>': Option<FundraiserTier>;
@@ -1662,6 +1671,7 @@ declare module '@polkadot/types/types/registry' {
     'Option<InstantiateRequest>': Option<InstantiateRequest>;
     'Option<InstantiateReturnValue>': Option<InstantiateReturnValue>;
     'Option<Instruction>': Option<Instruction>;
+    'Option<InstructionId>': Option<InstructionId>;
     'Option<InstructionStatus>': Option<InstructionStatus>;
     'Option<InstructionWeights>': Option<InstructionWeights>;
     'Option<InvalidDisputeStatementKind>': Option<InvalidDisputeStatementKind>;
@@ -1689,6 +1699,7 @@ declare module '@polkadot/types/types/registry' {
     'Option<Leg>': Option<Leg>;
     'Option<LegacyPalletPermissions>': Option<LegacyPalletPermissions>;
     'Option<LegacyPermissions>': Option<LegacyPermissions>;
+    'Option<LegId>': Option<LegId>;
     'Option<LegStatus>': Option<LegStatus>;
     'Option<Limits>': Option<Limits>;
     'Option<LimitsTo264>': Option<LimitsTo264>;
@@ -2157,6 +2168,7 @@ declare module '@polkadot/types/types/registry' {
     'Option<VecInboundHrmpMessage>': Option<VecInboundHrmpMessage>;
     'Option<Venue>': Option<Venue>;
     'Option<VenueDetails>': Option<VenueDetails>;
+    'Option<VenueId>': Option<VenueId>;
     'Option<VenueType>': Option<VenueType>;
     'Option<Version>': Option<Version>;
     'Option<VersionedMultiAsset>': Option<VersionedMultiAsset>;
@@ -2606,6 +2618,7 @@ declare module '@polkadot/types/types/registry' {
     'Vec<FundInfo>': Vec<FundInfo>;
     'Vec<FundingRoundName>': Vec<FundingRoundName>;
     'Vec<Fundraiser>': Vec<Fundraiser>;
+    'Vec<FundraiserId>': Vec<FundraiserId>;
     'Vec<FundraiserName>': Vec<FundraiserName>;
     'Vec<FundraiserStatus>': Vec<FundraiserStatus>;
     'Vec<FundraiserTier>': Vec<FundraiserTier>;
@@ -2683,6 +2696,7 @@ declare module '@polkadot/types/types/registry' {
     'Vec<InstantiateRequest>': Vec<InstantiateRequest>;
     'Vec<InstantiateReturnValue>': Vec<InstantiateReturnValue>;
     'Vec<Instruction>': Vec<Instruction>;
+    'Vec<InstructionId>': Vec<InstructionId>;
     'Vec<InstructionStatus>': Vec<InstructionStatus>;
     'Vec<InstructionWeights>': Vec<InstructionWeights>;
     'Vec<InvalidDisputeStatementKind>': Vec<InvalidDisputeStatementKind>;
@@ -2710,6 +2724,7 @@ declare module '@polkadot/types/types/registry' {
     'Vec<Leg>': Vec<Leg>;
     'Vec<LegacyPalletPermissions>': Vec<LegacyPalletPermissions>;
     'Vec<LegacyPermissions>': Vec<LegacyPermissions>;
+    'Vec<LegId>': Vec<LegId>;
     'Vec<LegStatus>': Vec<LegStatus>;
     'Vec<Limits>': Vec<Limits>;
     'Vec<LimitsTo264>': Vec<LimitsTo264>;
@@ -3178,6 +3193,7 @@ declare module '@polkadot/types/types/registry' {
     'Vec<VecInboundHrmpMessage>': Vec<VecInboundHrmpMessage>;
     'Vec<Venue>': Vec<Venue>;
     'Vec<VenueDetails>': Vec<VenueDetails>;
+    'Vec<VenueId>': Vec<VenueId>;
     'Vec<VenueType>': Vec<VenueType>;
     'Vec<Version>': Vec<Version>;
     'Vec<VersionedMultiAsset>': Vec<VersionedMultiAsset>;
@@ -3627,6 +3643,7 @@ declare module '@polkadot/types/types/registry' {
     FundInfo: FundInfo;
     FundingRoundName: FundingRoundName;
     Fundraiser: Fundraiser;
+    FundraiserId: FundraiserId;
     FundraiserName: FundraiserName;
     FundraiserStatus: FundraiserStatus;
     FundraiserTier: FundraiserTier;
@@ -3704,6 +3721,7 @@ declare module '@polkadot/types/types/registry' {
     InstantiateRequest: InstantiateRequest;
     InstantiateReturnValue: InstantiateReturnValue;
     Instruction: Instruction;
+    InstructionId: InstructionId;
     InstructionStatus: InstructionStatus;
     InstructionWeights: InstructionWeights;
     InvalidDisputeStatementKind: InvalidDisputeStatementKind;
@@ -3731,6 +3749,7 @@ declare module '@polkadot/types/types/registry' {
     Leg: Leg;
     LegacyPalletPermissions: LegacyPalletPermissions;
     LegacyPermissions: LegacyPermissions;
+    LegId: LegId;
     LegStatus: LegStatus;
     Limits: Limits;
     LimitsTo264: LimitsTo264;
@@ -4199,6 +4218,7 @@ declare module '@polkadot/types/types/registry' {
     VecInboundHrmpMessage: VecInboundHrmpMessage;
     Venue: Venue;
     VenueDetails: VenueDetails;
+    VenueId: VenueId;
     VenueType: VenueType;
     Version: Version;
     VersionedMultiAsset: VersionedMultiAsset;

--- a/src/polkadot/pips/definitions.ts
+++ b/src/polkadot/pips/definitions.ts
@@ -6,7 +6,7 @@ export default {
       params: [
         {
           name: 'index',
-          type: 'u32',
+          type: 'PipId',
           isOptional: false,
         },
         {
@@ -31,7 +31,7 @@ export default {
           isOptional: true,
         },
       ],
-      type: 'Vec<u32>',
+      type: 'Vec<PipId>',
     },
     votedOn: {
       description: 'Retrieves proposal address indices voted on',
@@ -47,7 +47,7 @@ export default {
           isOptional: true,
         },
       ],
-      type: 'Vec<u32>',
+      type: 'Vec<PipId>',
     },
   },
   types: {},

--- a/src/polkadot/polymesh/definitions.ts
+++ b/src/polkadot/polymesh/definitions.ts
@@ -625,8 +625,8 @@ export default {
     },
     PolymeshVotes: {
       index: 'u32',
-      ayes: 'Vec<(IdentityId, Balance)>',
-      nays: 'Vec<(IdentityId, Balance)>',
+      ayes: 'Vec<IdentityId>',
+      nays: 'Vec<IdentityId>',
       expiry: 'MaybeBlock',
     },
     PipId: 'u32',
@@ -669,6 +669,7 @@ export default {
         PortfolioCustody: 'PortfolioId',
         BecomeAgent: '(Ticker, AgentGroup)',
         AddRelayerPayingKey: '(AccountId, AccountId, Balance)',
+        RotatePrimaryKeyToSecondary: 'Permissions',
       },
     },
     SmartExtensionType: {
@@ -842,6 +843,7 @@ export default {
         PortfolioCustody: '',
         BecomeAgent: '',
         AddRelayerPayingKey: '',
+        RotatePrimaryKeyToSecondary: '',
       },
     },
     ProposalDetails: {
@@ -931,9 +933,11 @@ export default {
         SettleOnBlock: 'BlockNumber',
       },
     },
+    LegId: 'u64',
+    InstructionId: 'u64',
     Instruction: {
-      instruction_id: 'u64',
-      venue_id: 'u64',
+      instruction_id: 'InstructionId',
+      venue_id: 'VenueId',
       status: 'InstructionStatus',
       settlement_type: 'SettlementType',
       created_at: 'Option<Moment>',
@@ -960,7 +964,7 @@ export default {
     ReceiptMetadata: 'Text',
     ReceiptDetails: {
       receipt_uid: 'u64',
-      leg_id: 'u64',
+      leg_id: 'LegId',
       signer: 'AccountId',
       signature: 'OffChainSignature',
       metadata: 'ReceiptMetadata',
@@ -986,6 +990,7 @@ export default {
         Specific: 'IdentityId',
       },
     },
+    FundraiserId: 'u64',
     FundraiserName: 'Text',
     FundraiserStatus: {
       _enum: ['Live', 'Frozen', 'Closed', 'ClosedEarly'],
@@ -1002,12 +1007,13 @@ export default {
       raising_portfolio: 'PortfolioId',
       raising_asset: 'Ticker',
       tiers: 'Vec<FundraiserTier>',
-      venue_id: 'u64',
+      venue_id: 'VenueId',
       start: 'Moment',
       end: 'Option<Moment>',
       status: 'FundraiserStatus',
       minimum_investment: 'Balance',
     },
+    VenueId: 'u64',
     VenueType: {
       _enum: ['Other', 'Distribution', 'Sto', 'Exchange'],
     },

--- a/src/polkadot/polymesh/types.ts
+++ b/src/polkadot/polymesh/types.ts
@@ -152,6 +152,8 @@ export interface AuthorizationData extends Enum {
   readonly asBecomeAgent: ITuple<[Ticker, AgentGroup]>;
   readonly isAddRelayerPayingKey: boolean;
   readonly asAddRelayerPayingKey: ITuple<[AccountId, AccountId, Balance]>;
+  readonly isRotatePrimaryKeyToSecondary: boolean;
+  readonly asRotatePrimaryKeyToSecondary: Permissions;
 }
 
 /** @name AuthorizationNonce */
@@ -168,6 +170,7 @@ export interface AuthorizationType extends Enum {
   readonly isPortfolioCustody: boolean;
   readonly isBecomeAgent: boolean;
   readonly isAddRelayerPayingKey: boolean;
+  readonly isRotatePrimaryKeyToSecondary: boolean;
 }
 
 /** @name BallotMeta */
@@ -829,12 +832,15 @@ export interface Fundraiser extends Struct {
   readonly raising_portfolio: PortfolioId;
   readonly raising_asset: Ticker;
   readonly tiers: Vec<FundraiserTier>;
-  readonly venue_id: u64;
+  readonly venue_id: VenueId;
   readonly start: Moment;
   readonly end: Option<Moment>;
   readonly status: FundraiserStatus;
   readonly minimum_investment: Balance;
 }
+
+/** @name FundraiserId */
+export interface FundraiserId extends u64 {}
 
 /** @name FundraiserName */
 export interface FundraiserName extends Text {}
@@ -913,14 +919,17 @@ export interface InactiveMember extends Struct {
 
 /** @name Instruction */
 export interface Instruction extends Struct {
-  readonly instruction_id: u64;
-  readonly venue_id: u64;
+  readonly instruction_id: InstructionId;
+  readonly venue_id: VenueId;
   readonly status: InstructionStatus;
   readonly settlement_type: SettlementType;
   readonly created_at: Option<Moment>;
   readonly trade_date: Option<Moment>;
   readonly value_date: Option<Moment>;
 }
+
+/** @name InstructionId */
+export interface InstructionId extends u64 {}
 
 /** @name InstructionStatus */
 export interface InstructionStatus extends Enum {
@@ -969,6 +978,9 @@ export interface LegacyPermissions extends Struct {
   readonly extrinsic: Option<Vec<LegacyPalletPermissions>>;
   readonly portfolio: Option<Vec<PortfolioId>>;
 }
+
+/** @name LegId */
+export interface LegId extends u64 {}
 
 /** @name LegStatus */
 export interface LegStatus extends Enum {
@@ -1088,8 +1100,8 @@ export interface PipsMetadata extends Struct {
 /** @name PolymeshVotes */
 export interface PolymeshVotes extends Struct {
   readonly index: u32;
-  readonly ayes: Vec<ITuple<[IdentityId, Balance]>>;
-  readonly nays: Vec<ITuple<[IdentityId, Balance]>>;
+  readonly ayes: Vec<IdentityId>;
+  readonly nays: Vec<IdentityId>;
   readonly expiry: MaybeBlock;
 }
 
@@ -1218,7 +1230,7 @@ export interface Receipt extends Struct {
 /** @name ReceiptDetails */
 export interface ReceiptDetails extends Struct {
   readonly receipt_uid: u64;
-  readonly leg_id: u64;
+  readonly leg_id: LegId;
   readonly signer: AccountId;
   readonly signature: OffChainSignature;
   readonly metadata: ReceiptMetadata;
@@ -1492,6 +1504,9 @@ export interface Venue extends Struct {
 
 /** @name VenueDetails */
 export interface VenueDetails extends Text {}
+
+/** @name VenueId */
+export interface VenueId extends u64 {}
 
 /** @name VenueType */
 export interface VenueType extends Enum {

--- a/src/polkadot/schema.ts
+++ b/src/polkadot/schema.ts
@@ -624,8 +624,8 @@ export default {
     },
     PolymeshVotes: {
       index: 'u32',
-      ayes: 'Vec<(IdentityId, Balance)>',
-      nays: 'Vec<(IdentityId, Balance)>',
+      ayes: 'Vec<IdentityId>',
+      nays: 'Vec<IdentityId>',
       expiry: 'MaybeBlock',
     },
     PipId: 'u32',
@@ -668,6 +668,7 @@ export default {
         PortfolioCustody: 'PortfolioId',
         BecomeAgent: '(Ticker, AgentGroup)',
         AddRelayerPayingKey: '(AccountId, AccountId, Balance)',
+        RotatePrimaryKeyToSecondary: 'Permissions',
       },
     },
     SmartExtensionType: {
@@ -841,6 +842,7 @@ export default {
         PortfolioCustody: '',
         BecomeAgent: '',
         AddRelayerPayingKey: '',
+        RotatePrimaryKeyToSecondary: '',
       },
     },
     ProposalDetails: {
@@ -930,9 +932,11 @@ export default {
         SettleOnBlock: 'BlockNumber',
       },
     },
+    LegId: 'u64',
+    InstructionId: 'u64',
     Instruction: {
-      instruction_id: 'u64',
-      venue_id: 'u64',
+      instruction_id: 'InstructionId',
+      venue_id: 'VenueId',
       status: 'InstructionStatus',
       settlement_type: 'SettlementType',
       created_at: 'Option<Moment>',
@@ -959,7 +963,7 @@ export default {
     ReceiptMetadata: 'Text',
     ReceiptDetails: {
       receipt_uid: 'u64',
-      leg_id: 'u64',
+      leg_id: 'LegId',
       signer: 'AccountId',
       signature: 'OffChainSignature',
       metadata: 'ReceiptMetadata',
@@ -985,6 +989,7 @@ export default {
         Specific: 'IdentityId',
       },
     },
+    FundraiserId: 'u64',
     FundraiserName: 'Text',
     FundraiserStatus: {
       _enum: ['Live', 'Frozen', 'Closed', 'ClosedEarly'],
@@ -1001,12 +1006,13 @@ export default {
       raising_portfolio: 'PortfolioId',
       raising_asset: 'Ticker',
       tiers: 'Vec<FundraiserTier>',
-      venue_id: 'u64',
+      venue_id: 'VenueId',
       start: 'Moment',
       end: 'Option<Moment>',
       status: 'FundraiserStatus',
       minimum_investment: 'Balance',
     },
+    VenueId: 'u64',
     VenueType: {
       _enum: ['Other', 'Distribution', 'Sto', 'Exchange'],
     },
@@ -1276,7 +1282,7 @@ export default {
         params: [
           {
             name: 'index',
-            type: 'u32',
+            type: 'PipId',
             isOptional: false,
           },
           {
@@ -1301,7 +1307,7 @@ export default {
             isOptional: true,
           },
         ],
-        type: 'Vec<u32>',
+        type: 'Vec<PipId>',
       },
       votedOn: {
         description: 'Retrieves proposal address indices voted on',
@@ -1317,7 +1323,7 @@ export default {
             isOptional: true,
           },
         ],
-        type: 'Vec<u32>',
+        type: 'Vec<PipId>',
       },
     },
     protocolFee: {

--- a/src/polkadot/types.ts
+++ b/src/polkadot/types.ts
@@ -73,6 +73,7 @@ export enum IdentityTx {
   GcRevokeCddClaim = 'identity.gcRevokeCddClaim',
   AddInvestorUniquenessClaimV2 = 'identity.addInvestorUniquenessClaimV2',
   RevokeClaimByIndex = 'identity.revokeClaimByIndex',
+  RotatePrimaryKeyToSecondary = 'identity.rotatePrimaryKeyToSecondary',
 }
 
 export enum CddServiceProvidersTx {
@@ -178,6 +179,7 @@ export enum BridgeTx {
   HandleScheduledBridgeTx = 'bridge.handleScheduledBridgeTx',
   AddFreezeAdmin = 'bridge.addFreezeAdmin',
   RemoveFreezeAdmin = 'bridge.removeFreezeAdmin',
+  RemoveTxs = 'bridge.removeTxs',
 }
 
 export enum StakingTx {
@@ -419,6 +421,13 @@ export enum RewardsTx {
   SetItnRewardStatus = 'rewards.setItnRewardStatus',
 }
 
+export enum TestUtilsTx {
+  RegisterDid = 'testUtils.registerDid',
+  MockCddRegisterDid = 'testUtils.mockCddRegisterDid',
+  GetMyDid = 'testUtils.getMyDid',
+  GetCddOf = 'testUtils.getCddOf',
+}
+
 export enum ModuleName {
   System = 'system',
   Babe = 'babe',
@@ -459,6 +468,7 @@ export enum ModuleName {
   ExternalAgents = 'externalAgents',
   Relayer = 'relayer',
   Rewards = 'rewards',
+  TestUtils = 'testUtils',
 }
 
 export type TxTag =
@@ -500,7 +510,8 @@ export type TxTag =
   | UtilityTx
   | ExternalAgentsTx
   | RelayerTx
-  | RewardsTx;
+  | RewardsTx
+  | TestUtilsTx;
 
 export const TxTags = {
   system: SystemTx,
@@ -542,4 +553,5 @@ export const TxTags = {
   externalAgents: ExternalAgentsTx,
   relayer: RelayerTx,
   rewards: RewardsTx,
+  testUtils: TestUtilsTx,
 };

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -193,7 +193,7 @@ function createWebSocketAsPromised(): WebSocketAsPromised {
   return ({
     open: sinon.stub(),
     send: sinon.stub(),
-    sendRequest: sinon.stub().resolves({ result: '4.0.0' }),
+    sendRequest: sinon.stub().resolves({ result: '4.1.0' }),
     close: sinon.stub(),
   } as unknown) as WebSocketAsPromised;
 }

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -1895,13 +1895,35 @@ export const createMockDocument = (document?: {
  * @hidden
  * NOTE: `isEmpty` will be set to true if no value is passed
  */
+export const createMockPalletPermissions = (permissions?: {
+  pallet_name: PalletName | Parameters<typeof createMockPalletName>[0];
+  dispatchable_names: DispatchableNames | Parameters<typeof createMockDispatchableNames>[0];
+}): PalletPermissions => {
+  const { pallet_name, dispatchable_names } = permissions || {
+    pallet_name: createMockPalletName(),
+    dispatchable_names: createMockDispatchableNames(),
+  };
+
+  return createMockCodec(
+    {
+      pallet_name: createMockPalletName(pallet_name),
+      dispatchable_names: createMockDispatchableNames(dispatchable_names),
+    },
+    !permissions
+  ) as PalletPermissions;
+};
+
+/**
+ * @hidden
+ * NOTE: `isEmpty` will be set to true if no value is passed
+ */
 export const createMockAccountData = (accountData?: {
-  free: Balance;
-  reserved: Balance;
-  miscFrozen: Balance;
-  feeFrozen: Balance;
+  free: Balance | Parameters<typeof createMockBalance>[0];
+  reserved: Balance | Parameters<typeof createMockBalance>[0];
+  miscFrozen: Balance | Parameters<typeof createMockBalance>[0];
+  feeFrozen: Balance | Parameters<typeof createMockBalance>[0];
 }): AccountData => {
-  const data = accountData || {
+  const { free, reserved, miscFrozen, feeFrozen } = accountData || {
     free: createMockBalance(),
     reserved: createMockBalance(),
     miscFrozen: createMockBalance(),
@@ -1910,7 +1932,10 @@ export const createMockAccountData = (accountData?: {
 
   return createMockCodec(
     {
-      ...data,
+      free: createMockBalance(free),
+      reserved: createMockBalance(reserved),
+      miscFrozen: createMockBalance(miscFrozen),
+      feeFrozen: createMockBalance(feeFrozen),
     },
     !accountData
   ) as AccountData;
@@ -2053,28 +2078,6 @@ export const createMockDispatchableName = (name?: string | DispatchableName): Di
  */
 export const createMockFundraiserName = (name?: string): FundraiserName =>
   createMockStringCodec(name) as FundraiserName;
-
-/**
- * @hidden
- * NOTE: `isEmpty` will be set to true if no value is passed
- */
-export const createMockPalletPermissions = (permissions?: {
-  pallet_name: PalletName | Parameters<typeof createMockPalletName>[0];
-  dispatchable_names: DispatchableNames | Parameters<typeof createMockDispatchableNames>[0];
-}): PalletPermissions => {
-  const { pallet_name, dispatchable_names } = permissions || {
-    pallet_name: createMockPalletName(),
-    dispatchable_names: createMockDispatchableNames(),
-  };
-
-  return createMockCodec(
-    {
-      pallet_name: createMockPalletName(pallet_name),
-      dispatchable_names: createMockDispatchableNames(dispatchable_names),
-    },
-    !permissions
-  ) as PalletPermissions;
-};
 
 /**
  * @hidden

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -569,8 +569,17 @@ export interface KeyringPair extends IKeyringPair {
 }
 
 export interface Balance {
+  /**
+   * balance available for transferring and paying fees
+   */
   free: BigNumber;
+  /**
+   * unavailable balance, either bonded for staking or locked for some other purpose
+   */
   locked: BigNumber;
+  /**
+   * free + locked
+   */
   total: BigNumber;
 }
 

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -1145,9 +1145,26 @@ describe('authorizationToAuthorizationData and authorizationDataToAuthorization'
 
     result = authorizationDataToAuthorization(authorizationData, context);
     expect(result).toEqual(fakeResult);
+
+    const ticker = 'SOME_TICKER';
+    const type = PermissionGroupType.Full;
+    fakeResult = {
+      type: AuthorizationType.BecomeAgent,
+      value: entityMockUtils.getKnownPermissionGroupInstance({
+        ticker,
+        type,
+      }),
+    };
+
+    authorizationData = dsMockUtils.createMockAuthorizationData({
+      BecomeAgent: [dsMockUtils.createMockTicker(ticker), dsMockUtils.createMockAgentGroup(type)],
+    });
+
+    result = authorizationDataToAuthorization(authorizationData, context);
+    expect(result).toEqual(fakeResult);
   });
 
-  test('shoould throw an error if the authorization has an unsupported type', () => {
+  test('should throw an error if the authorization has an unsupported type', () => {
     const context = dsMockUtils.getContextInstance();
     const authorizationData = dsMockUtils.createMockAuthorizationData(
       'Whatever' as 'RotatePrimaryKey'

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -127,7 +127,7 @@ export const ROOT_TYPES = rootTypes;
 /**
  * The Polymesh version range that is compatible with this version of the SDK
  */
-export const SUPPORTED_VERSION_RANGE = '4.0.x';
+export const SUPPORTED_VERSION_RANGE = '4.1.x';
 
 export const SYSTEM_VERSION_RPC_CALL = {
   jsonrpc: '2.0',

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -1167,6 +1167,15 @@ export function authorizationDataToAuthorization(
     };
   }
 
+  if (auth.isBecomeAgent) {
+    const [ticker, agentGroup] = auth.asBecomeAgent;
+
+    return {
+      type: AuthorizationType.BecomeAgent,
+      value: agentGroupToPermissionGroup(agentGroup, tickerToString(ticker), context),
+    };
+  }
+
   throw new PolymeshError({
     code: ErrorCode.FatalError,
     message: 'Unsupported Authorization Type. Please contact the Polymath team',


### PR DESCRIPTION
BREAKING CHANGE: 🧨 change the `Balance` interface's `free` balance to represent actual free
balance (to pay fees or transfer), and `total` to represent actual total
balance. This affects the `Account.getBalance` method