### PR TITLE
chore: 🤖 Tighten middleware lint ignore rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -85,5 +85,5 @@
     "project": "./tsconfig.json"
   },
   "extends": ["standard", "semistandard", "plugin:@typescript-eslint/recommended", "prettier"],
-  "ignorePatterns": ["src/polkadot/", "src/middleware/", "docs/*"]
+  "ignorePatterns": ["src/polkadot/", "src/middleware/types.ts", "docs/*"]
 }

--- a/src/middleware/__tests__/queries.ts
+++ b/src/middleware/__tests__/queries.ts
@@ -297,6 +297,7 @@ describe('tickerExternalAgentActions', () => {
   test('should pass the variables to the grapqhl query', () => {
     const variables = {
       ticker: 'SOMETICKER',
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       caller_did: 'someDid',
     };
 


### PR DESCRIPTION
For linting ignore only the types.ts file in middleware instead the
entire directory.