### PR TITLE
feat: 🎸 MSDK-756 Change `totalSupply` to `initialSupply` on asset creation

### DIFF
--- a/src/api/procedures/__tests__/createSecurityToken.ts
+++ b/src/api/procedures/__tests__/createSecurityToken.ts
@@ -62,7 +62,7 @@ describe('createSecurityToken procedure', () => {
   let tokenDocumentToDocumentStub: sinon.SinonStub<[TokenDocument, Context], Document>;
   let ticker: string;
   let name: string;
-  let totalSupply: BigNumber;
+  let initialSupply: BigNumber;
   let isDivisible: boolean;
   let tokenType: string;
   let tokenIdentifiers: TokenIdentifier[];
@@ -71,7 +71,7 @@ describe('createSecurityToken procedure', () => {
   let documents: TokenDocument[];
   let rawTicker: Ticker;
   let rawName: AssetName;
-  let rawTotalSupply: Balance;
+  let rawInitialSupply: Balance;
   let rawIsDivisible: bool;
   let rawType: AssetType;
   let rawIdentifiers: AssetIdentifier[];
@@ -108,7 +108,7 @@ describe('createSecurityToken procedure', () => {
     tokenDocumentToDocumentStub = sinon.stub(utilsConversionModule, 'tokenDocumentToDocument');
     ticker = 'someTicker';
     name = 'someName';
-    totalSupply = new BigNumber(100);
+    initialSupply = new BigNumber(100);
     isDivisible = true;
     tokenType = KnownTokenType.EquityCommon;
     tokenIdentifiers = [
@@ -128,7 +128,7 @@ describe('createSecurityToken procedure', () => {
     ];
     rawTicker = dsMockUtils.createMockTicker(ticker);
     rawName = dsMockUtils.createMockAssetName(name);
-    rawTotalSupply = dsMockUtils.createMockBalance(totalSupply.toNumber());
+    rawInitialSupply = dsMockUtils.createMockBalance(initialSupply.toNumber());
     rawIsDivisible = dsMockUtils.createMockBool(isDivisible);
     rawType = dsMockUtils.createMockAssetType(tokenType as KnownTokenType);
     rawIdentifiers = tokenIdentifiers.map(({ type, value }) =>
@@ -187,7 +187,7 @@ describe('createSecurityToken procedure', () => {
     mockContext = dsMockUtils.getContextInstance();
 
     stringToTickerStub.withArgs(ticker, mockContext).returns(rawTicker);
-    numberToBalanceStub.withArgs(totalSupply, mockContext, isDivisible).returns(rawTotalSupply);
+    numberToBalanceStub.withArgs(initialSupply, mockContext, isDivisible).returns(rawInitialSupply);
     stringToAssetNameStub.withArgs(name, mockContext).returns(rawName);
     booleanToBoolStub.withArgs(isDivisible, mockContext).returns(rawIsDivisible);
     booleanToBoolStub.withArgs(!requireInvestorUniqueness, mockContext).returns(rawDisableIu);
@@ -271,7 +271,7 @@ describe('createSecurityToken procedure', () => {
 
     await prepareCreateSecurityToken.call(proc, {
       ...args,
-      totalSupply: new BigNumber(0),
+      initialSupply: new BigNumber(0),
       tokenIdentifiers: undefined,
       fundingRound: undefined,
       requireInvestorUniqueness: false,
@@ -292,9 +292,9 @@ describe('createSecurityToken procedure', () => {
 
     const issueTransaction = dsMockUtils.createTxStub('asset', 'issue');
 
-    await prepareCreateSecurityToken.call(proc, { ...args, totalSupply });
+    await prepareCreateSecurityToken.call(proc, { ...args, initialSupply });
 
-    sinon.assert.calledWith(addTransactionStub, issueTransaction, {}, rawTicker, rawTotalSupply);
+    sinon.assert.calledWith(addTransactionStub, issueTransaction, {}, rawTicker, rawInitialSupply);
   });
 
   test('should waive protocol fees if the token was created in Ethereum', async () => {

--- a/src/api/procedures/createSecurityToken.ts
+++ b/src/api/procedures/createSecurityToken.ts
@@ -44,7 +44,7 @@ export interface CreateSecurityTokenParams {
   /**
    * amount of tokens that will be minted on creation (optional, default doesn't mint)
    */
-  totalSupply?: BigNumber;
+  initialSupply?: BigNumber;
   /**
    * whether a single token can be divided into decimal parts
    */
@@ -112,7 +112,7 @@ export async function prepareCreateSecurityToken(
   const {
     ticker,
     name,
-    totalSupply,
+    initialSupply,
     isDivisible,
     tokenType,
     tokenIdentifiers = [],
@@ -194,10 +194,10 @@ export async function prepareCreateSecurityToken(
     rawDisableIu
   );
 
-  if (totalSupply && totalSupply.gt(0)) {
-    const rawTotalSupply = numberToBalance(totalSupply, context, isDivisible);
+  if (initialSupply && initialSupply.gt(0)) {
+    const rawInitialSupply = numberToBalance(initialSupply, context, isDivisible);
 
-    this.addTransaction(tx.asset.issue, {}, rawTicker, rawTotalSupply);
+    this.addTransaction(tx.asset.issue, {}, rawTicker, rawInitialSupply);
   }
 
   if (documents?.length) {


### PR DESCRIPTION
BREAKING CHANGE: 🧨 `TickerReservation.createToken` now takes `initialSupply` instead of
`totalSupply` parameter for specifying amount of tokens that will be
minted on creation