### PR TITLE
Fix/msdk 778 query exceptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "generate:middleware-types": "graphql-codegen -r dotenv/config",
     "fetch-definitions": "cross-env node scripts/fetchDefinitions.js",
     "generate:defs": "ts-node --skip-project node_modules/.bin/polkadot-types-from-defs --package polymesh-types --input ./src/polkadot",
-    "generate:meta": "ts-node --skip-project node_modules/.bin/polkadot-types-from-chain --package polymesh-types --endpoint wss://dev.polymesh.live --output ./src/polkadot --strict",
+    "generate:meta": "ts-node --skip-project node_modules/.bin/polkadot-types-from-chain --package polymesh-types --endpoint ws://localhost:9944 --output ./src/polkadot --strict",
     "generate:tags": "cross-env node scripts/generateTxTags.js",
     "generate:post-process": "cross-env node scripts/postProcessTypes.js",
     "test": "jest --detectOpenHandles --coverage",

--- a/scripts/fetchDefinitions.js
+++ b/scripts/fetchDefinitions.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-const https = require('https');
+const http = require('http');
 const path = require('path');
 const fs = require('fs');
 const rimraf = require('rimraf');
@@ -10,7 +10,7 @@ const definitionsDir = path.resolve('src', 'polkadot');
 const typesDir = path.resolve(definitionsDir, 'polymesh');
 const generatedDir = path.resolve('src', 'generated');
 
-const urlPath = 'https://dev.polymesh.live/code';
+const urlPath = 'http://localhost:3008';
 
 rimraf.sync(typesDir);
 fs.mkdirSync(typesDir);
@@ -126,7 +126,7 @@ export function meshCountryCodeToCountryCode(meshCountryCode: MeshCountryCode): 
   fs.writeFileSync(path.resolve(generatedDir, 'utils.ts'), utilsFile);
 }
 
-https.get(`${urlPath}/polymesh_schema.json`, res => {
+http.get(`${urlPath}/polymesh_schema.json`, res => {
   const chunks = [];
   res.on('data', chunk => {
     chunks.push(chunk);

--- a/scripts/generateTxTags.js
+++ b/scripts/generateTxTags.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 const path = require('path');
 const rimraf = require('rimraf');
 
-const websocket = new w3cwebsocket('wss://dev.polymesh.live');
+const websocket = new w3cwebsocket('ws://localhost:9944');
 websocket.onopen = () => {
   websocket.send('{"id":"1","jsonrpc":"2.0","method":"state_getMetadata","params":[]}');
 };

--- a/scripts/postProcessTypes.js
+++ b/scripts/postProcessTypes.js
@@ -4,6 +4,6 @@ const definitionsDir = path.resolve('src', 'polkadot');
 
 replace.sync({
   files: path.resolve(definitionsDir, 'augment-api-query.ts'),
-  from: /agIdSequence/g,
-  to: 'aGIdSequence',
+  from: [/agIdSequence/g, /caIdSequence/g, /caDocLink/g],
+  to: ['aGIdSequence', 'cAIdSequence', 'cADocLink'],
 });

--- a/scripts/transactions.json
+++ b/scripts/transactions.json
@@ -369,5 +369,11 @@
   "Rewards": {
     "claim_itn_reward": "claim_itn_reward",
     "set_itn_reward_status": "set_itn_reward_status"
+  },
+  "TestUtils": {
+    "register_did": "register_did",
+    "mock_cdd_register_did": "mock_cdd_register_did",
+    "get_my_did": "get_my_did",
+    "get_cdd_of": "get_cdd_of"
   }
 }

--- a/src/middleware/__tests__/queries.ts
+++ b/src/middleware/__tests__/queries.ts
@@ -23,8 +23,8 @@ import {
   proposalVotes,
   scopesByIdentity,
   settlements,
-  tickerExternalAgentHistory,
   tickerExternalAgentActions,
+  tickerExternalAgentHistory,
   tokensByTrustedClaimIssuer,
   tokensHeldByDid,
   transactionByHash,
@@ -288,7 +288,7 @@ describe('tickerExternalAgentHistory', () => {
     };
 
     const result = tickerExternalAgentHistory(variables);
-    
+
     expect(result.query).toBeDefined();
     expect(result.variables).toEqual(variables);
   });

--- a/src/polkadot/augment-api-events.ts
+++ b/src/polkadot/augment-api-events.ts
@@ -1495,6 +1495,24 @@ declare module '@polkadot/api/types/events' {
        **/
       MembersSwapped: AugmentedEvent<ApiType, [IdentityId, IdentityId, IdentityId]>;
     };
+    testUtils: {
+      /**
+       * Shows the `DID` associated to the `AccountId`, and a flag indicates if that DID has a
+       * valid CDD claim.
+       * (Target DID, Target Account, a valid CDD claim exists)
+       **/
+      CddStatus: AugmentedEvent<ApiType, [Option<IdentityId>, AccountId, bool]>;
+      /**
+       * Emits the `IdentityId` and the `AccountId` of the caller.
+       * (Caller DID, Caller account)
+       **/
+      DidStatus: AugmentedEvent<ApiType, [IdentityId, AccountId]>;
+      /**
+       * A new mocked `InvestorUid` has been created for the given Identity.
+       * (Target DID, New InvestorUid)
+       **/
+      MockInvestorUIDCreated: AugmentedEvent<ApiType, [IdentityId, InvestorUid]>;
+    };
     treasury: {
       /**
        * Disbursement to a target Identity.

--- a/src/polkadot/augment-api-query.ts
+++ b/src/polkadot/augment-api-query.ts
@@ -755,7 +755,7 @@ declare module '@polkadot/api/types/storage' {
        * The `CorporateActions` map stores `Ticker => LocalId => The CA`,
        * so we can infer `Ticker => CAId`. Therefore, we don't need a double map.
        **/
-      caDocLink: AugmentedQuery<
+      cADocLink: AugmentedQuery<
         ApiType,
         (
           arg: CAId | { ticker?: any; local_id?: any } | string | Uint8Array
@@ -766,7 +766,7 @@ declare module '@polkadot/api/types/storage' {
        * The next per-`Ticker` CA ID in the sequence.
        * The full ID is defined as a combination of `Ticker` and a number in this sequence.
        **/
-      caIdSequence: AugmentedQuery<
+      cAIdSequence: AugmentedQuery<
         ApiType,
         (arg: Ticker | string | Uint8Array) => Observable<LocalCAId>,
         [Ticker]
@@ -1186,7 +1186,7 @@ declare module '@polkadot/api/types/storage' {
     };
     multiSig: {
       /**
-       * Maps a multisig secondary key to a multisig address.
+       * Maps a multisig signer key to a multisig address.
        **/
       keyToMultiSig: AugmentedQuery<
         ApiType,
@@ -2440,6 +2440,7 @@ declare module '@polkadot/api/types/storage' {
        **/
       inactiveMembers: AugmentedQuery<ApiType, () => Observable<Vec<InactiveMember>>, []>;
     };
+    testUtils: {};
     timestamp: {
       /**
        * Did the timestamp get updated in this block?

--- a/src/polkadot/types.ts
+++ b/src/polkadot/types.ts
@@ -419,6 +419,13 @@ export enum RewardsTx {
   SetItnRewardStatus = 'rewards.setItnRewardStatus',
 }
 
+export enum TestUtilsTx {
+  RegisterDid = 'testUtils.registerDid',
+  MockCddRegisterDid = 'testUtils.mockCddRegisterDid',
+  GetMyDid = 'testUtils.getMyDid',
+  GetCddOf = 'testUtils.getCddOf',
+}
+
 export enum ModuleName {
   System = 'system',
   Babe = 'babe',
@@ -459,6 +466,7 @@ export enum ModuleName {
   ExternalAgents = 'externalAgents',
   Relayer = 'relayer',
   Rewards = 'rewards',
+  TestUtils = 'testUtils',
 }
 
 export type TxTag =
@@ -500,7 +508,8 @@ export type TxTag =
   | UtilityTx
   | ExternalAgentsTx
   | RelayerTx
-  | RewardsTx;
+  | RewardsTx
+  | TestUtilsTx;
 
 export const TxTags = {
   system: SystemTx,
@@ -542,4 +551,5 @@ export const TxTags = {
   externalAgents: ExternalAgentsTx,
   relayer: RelayerTx,
   rewards: RewardsTx,
+  testUtils: TestUtilsTx,
 };


### PR DESCRIPTION
This PR adds two exceptions to the type generator

`caDocLink` -> `cADocLink`
`caSequenceId` -> `cASequenceId`

It also updates chain types to the latest