### PR TITLE
chore: 🤖 Remove redundant expiry date check

### DIFF
--- a/src/api/procedures/__tests__/modifyDistributionCheckpoint.ts
+++ b/src/api/procedures/__tests__/modifyDistributionCheckpoint.ts
@@ -72,7 +72,7 @@ describe('modifyDistributionCheckpoint procedure', () => {
       err = error;
     }
 
-    expect(err.message).toBe('Distribution is already in its payment period');
+    expect(err.message).toBe('Cannot modify a Distribution checkpoint after the payment date');
   });
 
   test('should throw an error if the payment date is earlier than the Checkpoint date', async () => {
@@ -123,35 +123,6 @@ describe('modifyDistributionCheckpoint procedure', () => {
     }
 
     expect(err.message).toBe('Expiry date must be after the Checkpoint date');
-  });
-
-  test('should throw an error if the distribution has already expired', async () => {
-    const checkpoint = new Date(new Date().getTime() - 100000);
-    const expiryDate = new Date(checkpoint.getTime() + 10000);
-    const paymentDate = new Date(new Date().getTime() + 20000);
-
-    const args = {
-      distribution: entityMockUtils.getDividendDistributionInstance({
-        expiryDate,
-        paymentDate,
-      }),
-      checkpoint,
-    };
-
-    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
-
-    let err;
-
-    try {
-      await prepareModifyDistributionCheckpoint.call(proc, args);
-    } catch (error) {
-      err = error;
-    }
-
-    expect(err.message).toBe('Distribution has already expired');
-    expect(err.data).toEqual({
-      expiryDate,
-    });
   });
 
   test('should add a modifyCaCheckpoint procedure transaction to the queue', async () => {

--- a/src/api/procedures/modifyDistributionCheckpoint.ts
+++ b/src/api/procedures/modifyDistributionCheckpoint.ts
@@ -40,7 +40,7 @@ export async function prepareModifyDistributionCheckpoint(
   if (paymentDate <= now) {
     throw new PolymeshError({
       code: ErrorCode.UnmetPrerequisite,
-      message: 'Distribution is already in its payment period',
+      message: 'Cannot modify a Distribution checkpoint after the payment date',
     });
   }
 
@@ -48,16 +48,6 @@ export async function prepareModifyDistributionCheckpoint(
 
   if (!(checkpointValue instanceof Checkpoint)) {
     await assertDistributionDatesValid(checkpointValue, paymentDate, expiryDate);
-  }
-
-  if (expiryDate && expiryDate < now) {
-    throw new PolymeshError({
-      code: ErrorCode.UnmetPrerequisite,
-      message: 'Distribution has already expired',
-      data: {
-        expiryDate,
-      },
-    });
   }
 
   await this.addProcedure(modifyCaCheckpoint(), {


### PR DESCRIPTION
#### JIRA Link

https://polymath.atlassian.net/browse/MSDK-774

#### Changelog 

Removed the redundant expiry date check from `modifyDistributionCheckpoint` procedure and updated the validation message for paymentDate validation to _“Cannot modify a Distribution checkpoint after the payment date”_