### PR TITLE
feat: 🎸 Return type change for `getPrimaryKey`

### DIFF
--- a/src/api/entities/Account.ts
+++ b/src/api/entities/Account.ts
@@ -304,9 +304,9 @@ export class Account extends Entity<UniqueIdentifiers, string> {
       return false;
     }
 
-    const primaryKey = await identity.getPrimaryKey();
+    const { signer } = await identity.getPrimaryKey();
 
-    if (address === primaryKey.address) {
+    if (address === signerToString(signer)) {
       return false;
     }
 
@@ -321,12 +321,12 @@ export class Account extends Entity<UniqueIdentifiers, string> {
 
     const currentIdentity = await context.getCurrentIdentity();
 
-    const [primaryKey, secondaryKeys] = await Promise.all([
+    const [{ signer: primaryKeySigner }, secondaryKeys] = await Promise.all([
       currentIdentity.getPrimaryKey(),
       currentIdentity.getSecondaryKeys(),
     ]);
 
-    if (address === primaryKey.address) {
+    if (address === signerToString(primaryKeySigner)) {
       return {
         tokens: null,
         transactions: null,

--- a/src/api/procedures/__tests__/leaveIdentity.ts
+++ b/src/api/procedures/__tests__/leaveIdentity.ts
@@ -9,7 +9,7 @@ import {
 import { Context } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
-import { SecondaryKey } from '~/types';
+import { SigningKey } from '~/types';
 
 jest.mock(
   '~/api/entities/SecurityToken',
@@ -86,7 +86,7 @@ describe('modifyCaCheckpoint procedure', () => {
         getSecondaryKeys: [
           ({
             signer: entityMockUtils.getAccountInstance({ address }),
-          } as unknown) as SecondaryKey,
+          } as unknown) as SigningKey,
         ],
       }),
     });

--- a/src/api/procedures/__tests__/modifySignerPermissions.ts
+++ b/src/api/procedures/__tests__/modifySignerPermissions.ts
@@ -8,7 +8,7 @@ import {
 import { Account, Context, Identity } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
-import { PermissionType, SecondaryKey, Signer, SignerType, SignerValue } from '~/types';
+import { PermissionType, Signer, SignerType, SignerValue, SigningKey } from '~/types';
 import * as utilsConversionModule from '~/utils/conversion';
 
 describe('modifySignerPermissions procedure', () => {
@@ -78,7 +78,7 @@ describe('modifySignerPermissions procedure', () => {
   });
 
   test('should add a batch of Set Permission To Signer transactions to the queue', async () => {
-    let secondaryKeys: SecondaryKey[] = [
+    let secondaryKeys: SigningKey[] = [
       {
         signer: account,
         permissions: {

--- a/src/api/procedures/__tests__/registerIdentity.ts
+++ b/src/api/procedures/__tests__/registerIdentity.ts
@@ -10,7 +10,7 @@ import {
 import { Context, Identity, PostTransactionValue, RegisterIdentityParams } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
-import { SecondaryKey } from '~/types';
+import { SigningKey } from '~/types';
 import { PolymeshTx } from '~/types/internal';
 import * as utilsConversionModule from '~/utils/conversion';
 import * as utilsInternalModule from '~/utils/internal';
@@ -18,10 +18,7 @@ import * as utilsInternalModule from '~/utils/internal';
 describe('registerIdentity procedure', () => {
   let mockContext: Mocked<Context>;
   let stringToAccountIdStub: sinon.SinonStub<[string, Context], AccountId>;
-  let secondaryKeyToMeshSecondaryKeyStub: sinon.SinonStub<
-    [SecondaryKey, Context],
-    MeshSecondaryKey
-  >;
+  let secondaryKeyToMeshSecondaryKeyStub: sinon.SinonStub<[SigningKey, Context], MeshSecondaryKey>;
   let addTransactionStub: sinon.SinonStub;
   let registerIdentityTransaction: PolymeshTx<unknown[]>;
   let identity: PostTransactionValue<Identity>;

--- a/src/api/procedures/registerIdentity.ts
+++ b/src/api/procedures/registerIdentity.ts
@@ -2,7 +2,7 @@ import { ISubmittableResult } from '@polkadot/types/types';
 import { TxTags } from 'polymesh-types/types';
 
 import { Account, Context, Identity, PostTransactionValue, Procedure } from '~/internal';
-import { PermissionsLike, RoleType, SecondaryKey } from '~/types';
+import { PermissionsLike, RoleType, SigningKey } from '~/types';
 import { Modify } from '~/types/utils';
 import {
   identityIdToString,
@@ -15,7 +15,7 @@ import { filterEventRecords } from '~/utils/internal';
 
 export interface RegisterIdentityParams {
   targetAccount: string | Account;
-  secondaryKeys?: Modify<SecondaryKey, { permissions: PermissionsLike }>[];
+  secondaryKeys?: Modify<SigningKey, { permissions: PermissionsLike }>[];
 }
 
 /**

--- a/src/api/procedures/removeSecondaryKeys.ts
+++ b/src/api/procedures/removeSecondaryKeys.ts
@@ -3,7 +3,7 @@ import { find } from 'lodash';
 import { assertSecondaryKeys } from '~/api/procedures/utils';
 import { PolymeshError, Procedure } from '~/internal';
 import { ErrorCode, Signer, TxTags } from '~/types';
-import { signerToSignerValue, signerValueToSignatory } from '~/utils/conversion';
+import { signerToSignerValue, signerToString, signerValueToSignatory } from '~/utils/conversion';
 
 export interface RemoveSecondaryKeysParams {
   signers: Signer[];
@@ -27,13 +27,15 @@ export async function prepareRemoveSecondaryKeys(
 
   const identity = await context.getCurrentIdentity();
 
-  const [primaryKey, secondaryKeys] = await Promise.all([
+  const [{ signer: primaryKeySigner }, secondaryKeys] = await Promise.all([
     identity.getPrimaryKey(),
     identity.getSecondaryKeys(),
   ]);
 
   const signerValues = signers.map(signer => signerToSignerValue(signer));
-  const isPrimaryKeyPresent = find(signerValues, ({ value }) => value === primaryKey.address);
+  const primaryKeySignerValue = signerToString(primaryKeySigner);
+
+  const isPrimaryKeyPresent = find(signerValues, ({ value }) => value === primaryKeySignerValue);
 
   if (isPrimaryKeyPresent) {
     throw new PolymeshError({

--- a/src/api/procedures/utils.ts
+++ b/src/api/procedures/utils.ts
@@ -31,9 +31,9 @@ import {
   InstructionStatus,
   InstructionType,
   PermissionGroupType,
-  SecondaryKey,
   Signer,
   SignerValue,
+  SigningKey,
   TickerReservationStatus,
 } from '~/types';
 import { MaybePostTransactionValue, PortfolioId } from '~/types/internal';
@@ -135,7 +135,7 @@ export async function assertPortfolioExists(
  */
 export function assertSecondaryKeys(
   signerValues: SignerValue[],
-  secondaryKeys: SecondaryKey[]
+  secondaryKeys: SigningKey[]
 ): void {
   const notInTheList: string[] = [];
   signerValues.forEach(({ value: itemValue }) => {

--- a/src/base/PolymeshTransactionBase.ts
+++ b/src/base/PolymeshTransactionBase.ts
@@ -11,6 +11,7 @@ import { BaseTransactionSpec, PolymeshTx, PostTransactionValueArray } from '~/ty
 import {
   balanceToBigNumber,
   hashToString,
+  signerToString,
   transactionToTxTag,
   u32ToBigNumber,
 } from '~/utils/conversion';
@@ -304,10 +305,10 @@ export abstract class PolymeshTransactionBase<
     const { paidForBy, context, tag } = this;
 
     if (paidForBy) {
-      const primaryKey = await paidForBy.getPrimaryKey();
+      const { signer } = await paidForBy.getPrimaryKey();
 
       return {
-        account: primaryKey,
+        account: new Account({ address: signerToString(signer) }, context),
         allowance: null,
       };
     }

--- a/src/base/__tests__/PolymeshTransactionBase.ts
+++ b/src/base/__tests__/PolymeshTransactionBase.ts
@@ -11,6 +11,7 @@ import { Mocked } from '~/testUtils/types';
 import { TransactionStatus } from '~/types';
 import { PostTransactionValueArray } from '~/types/internal';
 import { tuple } from '~/types/utils';
+import { DUMMY_ACCOUNT_ID } from '~/utils/constants';
 import * as utilsConversionModule from '~/utils/conversion';
 
 describe('Polymesh Transaction Base class', () => {
@@ -501,9 +502,17 @@ describe('Polymesh Transaction Base class', () => {
 
     test('should return a null allowance if the transaction is paid for a fixed third party', async () => {
       const tx = dsMockUtils.createTxStub('asset', 'registerTicker');
-      const account = entityMockUtils.getAccountInstance();
+      const account = entityMockUtils.getAccountInstance({ address: DUMMY_ACCOUNT_ID });
       const paidForBy = entityMockUtils.getIdentityInstance({
-        getPrimaryKey: account,
+        getPrimaryKey: {
+          signer: account,
+          permissions: {
+            tokens: null,
+            portfolios: null,
+            transactions: null,
+            transactionGroups: [],
+          },
+        },
       });
 
       const args = tuple('SOMETHING');
@@ -520,7 +529,7 @@ describe('Polymesh Transaction Base class', () => {
 
       const result = await transaction.getPayingAccount();
 
-      expect(result?.account).toEqual(account);
+      expect(result?.account.address).toEqual(account.address);
       expect(result?.allowance).toBeNull();
     });
 

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -155,8 +155,8 @@ import {
   ExtrinsicData,
   KeyringPair,
   ResultSet,
-  SecondaryKey,
   SignerType,
+  SigningKey,
   Subsidy,
 } from '~/types';
 import { Consts, Extrinsics, GraphqlQuery, PolymeshTx, Queries } from '~/types/internal';
@@ -317,8 +317,8 @@ interface ContextOptions {
   getIdentity?: Identity;
   getIdentityClaimsFromChain?: ClaimData[];
   getIdentityClaimsFromMiddleware?: ResultSet<ClaimData>;
-  primaryKey?: string;
-  secondaryKeys?: SecondaryKey[];
+  primaryKey?: SigningKey;
+  secondaryKeys?: SigningKey[];
   transactionHistory?: ResultSet<ExtrinsicData>;
   latestBlock?: BigNumber;
   middlewareEnabled?: boolean;
@@ -584,7 +584,15 @@ const defaultContextOptions: ContextOptions = {
     next: 1,
     count: 1,
   },
-  primaryKey: 'primaryKey',
+  primaryKey: {
+    signer: ('primaryKey' as unknown) as Account,
+    permissions: {
+      tokens: null,
+      transactions: null,
+      transactionGroups: [],
+      portfolios: null,
+    },
+  },
   secondaryKeys: [],
   transactionHistory: {
     data: [],

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -58,9 +58,9 @@ import {
   ResultSet,
   ScheduleDetails,
   ScheduleWithDetails,
-  SecondaryKey,
   SecurityTokenDetails,
   SignerType,
+  SigningKey,
   StoBalanceStatus,
   StoDetails,
   StoSaleStatus,
@@ -127,7 +127,7 @@ interface IdentityOptions {
   tokenPermissionsCheckPermissions?: CheckPermissionsResult<SignerType.Identity>;
   hasValidCdd?: boolean;
   isCddProvider?: boolean;
-  getPrimaryKey?: Account;
+  getPrimaryKey?: SigningKey;
   authorizations?: {
     getReceived?: AuthorizationRequest[];
     getSent?: ResultSet<AuthorizationRequest>;
@@ -135,7 +135,7 @@ interface IdentityOptions {
   getVenues?: Venue[];
   getScopeId?: string;
   getTokenBalance?: BigNumber;
-  getSecondaryKeys?: SecondaryKey[];
+  getSecondaryKeys?: SigningKey[];
   areScondaryKeysFrozen?: boolean;
   isEqual?: boolean;
   tokenPermissionsGetGroup?: CustomPermissionGroup | KnownPermissionGroup;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1167,7 +1167,7 @@ export interface CheckpointWithData {
   totalSupply: BigNumber;
 }
 
-export interface SecondaryKey {
+export interface SigningKey {
   signer: Signer;
   permissions: Permissions;
 }

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -164,11 +164,11 @@ import {
   RequirementCompliance,
   Scope,
   ScopeType,
-  SecondaryKey,
   SectionPermissions,
   Signer,
   SignerType,
   SignerValue,
+  SigningKey,
   SingleClaimCondition,
   StoBalanceStatus,
   StoDetails,
@@ -2613,7 +2613,7 @@ export function transactionToTxTag<Args extends unknown[]>(tx: PolymeshTx<Args>)
  * @hidden
  */
 export function secondaryKeyToMeshSecondaryKey(
-  secondaryKey: SecondaryKey,
+  secondaryKey: SigningKey,
   context: Context
 ): MeshSecondaryKey {
   const { polymeshApi } = context;


### PR DESCRIPTION
JIRA Link - https://polymath.atlassian.net/browse/MSDK-760

BREAKING CHANGE: 🧨
* `SecondaryKey` interface has been renamed to `SigningKey`
* `identity.getPrimaryKey` now returns interface of type `SigningKey` instead of `Account`