### PR TITLE
feat: 🎸 Use nonce: -1 for signAndSend

### DIFF
--- a/src/base/PolymeshTransactionBase.ts
+++ b/src/base/PolymeshTransactionBase.ts
@@ -164,7 +164,7 @@ export abstract class PolymeshTransactionBase<Values extends unknown[] = unknown
       const txWithArgs = this.composeTx();
       let settingBlockData = Promise.resolve();
 
-      // nonce: -1 takes pending transactions into consideration. D
+      // nonce: -1 takes pending transactions into consideration.
       // More information can be found at: https://polkadot.js.org/docs/api/cookbook/tx/#how-do-i-take-the-pending-tx-pool-into-account-in-my-nonce
       const gettingUnsub = txWithArgs.signAndSend(this.signer, { nonce: -1 }, receipt => {
         const { status } = receipt;

--- a/src/base/PolymeshTransactionBase.ts
+++ b/src/base/PolymeshTransactionBase.ts
@@ -164,7 +164,9 @@ export abstract class PolymeshTransactionBase<Values extends unknown[] = unknown
       const txWithArgs = this.composeTx();
       let settingBlockData = Promise.resolve();
 
-      const gettingUnsub = txWithArgs.signAndSend(this.signer, receipt => {
+      // nonce: -1 takes pending transactions into consideration. D
+      // More information can be found at: https://polkadot.js.org/docs/api/cookbook/tx/#how-do-i-take-the-pending-tx-pool-into-account-in-my-nonce
+      const gettingUnsub = txWithArgs.signAndSend(this.signer, { nonce: -1 }, receipt => {
         const { status } = receipt;
         let unsubscribe = false;
 

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -1064,7 +1064,7 @@ export function createTxStub<
   const transaction = sinon.stub().returns({
     method: tx, // should be a `Call` object, but this is enough for testing
     hash: tx,
-    signAndSend: sinon.stub().callsFake((_, cb: StatusCallback) => {
+    signAndSend: sinon.stub().callsFake((_, __, cb: StatusCallback) => {
       if (autoResolve === MockTxStatus.Rejected) {
         return Promise.reject(new Error('Cancelled'));
       }


### PR DESCRIPTION
Using this option will account for pending transactions when auto
incrementing the account nonce. This allows for a better experience when
submitting multiple transactions for a single account. Each transaction
needs time to end up in the transaction pool, so some wait time may
still be needed.