### PR TITLE
docs: ✏️ Add note about enabling skipLibCheck in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Here is an overview of the parameters passed to the `connect` function:
 
 **NOTE:** if using the SDK on a browser environment \(i.e. with the Polymesh wallet browser extension\), there is no need to provide the account seed. Instead, you pass a Keyring object that contains the address, and a signer for that address (which you would typically get from the wallet extension)
 
+**NOTE** if using TypeScript the compiler option "skipLibCheck" should be set to true in your tsconfig.json file
+
 ```typescript
 import { Polymesh, Keyring } from '@polymathnetwork/polymesh-sdk';
 


### PR DESCRIPTION
Without this option enabled, a project importing the SDK will fail type checking

[Slack convo](https://polymathnetwork.slack.com/archives/C026L2FKT25/p1643920406272279?thread_ts=1643918647.591449&cid=C026L2FKT25)