### PR TITLE
feat: 🎸 Add `getOne` method in `IdentityAuthorizations`

### DIFF
--- a/src/api/entities/Identity/__tests__/IdentityAuthorizations.ts
+++ b/src/api/entities/Identity/__tests__/IdentityAuthorizations.ts
@@ -154,7 +154,7 @@ describe('IdentityAuthorizations class', () => {
       sinon.stub(utilsConversionModule, 'bigNumberToU64');
     });
 
-    it('should return the requested Authorization Request issued by the signing Identity', async () => {
+    it('should return the requested Authorization Request issued by the parent Identity', async () => {
       const did = 'someDid';
       const targetDid = 'alice';
       const context = dsMockUtils.getContextInstance({ did });
@@ -195,7 +195,7 @@ describe('IdentityAuthorizations class', () => {
       expect(result.issuer.did).toEqual(did);
     });
 
-    it('should return the requested Authorization Request targeted by the signing Identity', async () => {
+    it('should return the requested Authorization Request targeting the parent Identity', async () => {
       const did = 'someDid';
       const issuerDid = 'alice';
       const context = dsMockUtils.getContextInstance({ did });

--- a/src/api/entities/common/namespaces/__tests__/Authorizations.ts
+++ b/src/api/entities/common/namespaces/__tests__/Authorizations.ts
@@ -70,8 +70,6 @@ describe('Authorizations class', () => {
       const rawSignatory = dsMockUtils.createMockSignatory();
       const rawAuthorizationType = dsMockUtils.createMockAuthorizationType(filter);
 
-      /* eslint-disable @typescript-eslint/naming-convention */
-
       const authParams = [
         {
           authId: new BigNumber(1),
@@ -89,6 +87,7 @@ describe('Authorizations class', () => {
         } as const,
       ];
 
+      /* eslint-disable @typescript-eslint/naming-convention */
       const fakeAuthorizations = authParams.map(({ authId, expiry, issuer, data }) =>
         dsMockUtils.createMockAuthorization({
           auth_id: dsMockUtils.createMockU64(authId),
@@ -101,6 +100,7 @@ describe('Authorizations class', () => {
           authorized_by: dsMockUtils.createMockIdentityId(issuer.did),
         })
       );
+      /* eslint-enable @typescript-eslint/naming-convention */
 
       signerValueToSignatoryStub.returns(rawSignatory);
       booleanToBoolStub.withArgs(true, context).returns(dsMockUtils.createMockBool(true));
@@ -154,11 +154,10 @@ describe('Authorizations class', () => {
       const authsNamespace = new Authorizations(identity, context);
       const id = new BigNumber(1);
 
-      /* eslint-disable @typescript-eslint/naming-convention */
-
       const authId = new BigNumber(1);
       const data = { type: AuthorizationType.TransferAssetOwnership, value: 'myTicker' } as const;
 
+      /* eslint-disable @typescript-eslint/naming-convention */
       dsMockUtils.createQueryStub('identity', 'authorizations', {
         returnValue: dsMockUtils.createMockOption(
           dsMockUtils.createMockAuthorization({
@@ -171,6 +170,7 @@ describe('Authorizations class', () => {
           })
         ),
       });
+      /* eslint-enable @typescript-eslint/naming-convention */
 
       const result = await authsNamespace.getOne({ id });
 
@@ -188,26 +188,9 @@ describe('Authorizations class', () => {
       const authsNamespace = new Authorizations(identity, context);
       const id = new BigNumber(1);
 
-      /* eslint-disable @typescript-eslint/naming-convention */
-
-      const authId = new BigNumber(1);
-      const data = { type: AuthorizationType.TransferAssetOwnership, value: 'myTicker' } as const;
-      const target = identity;
-      const issuer = entityMockUtils.getIdentityInstance({ did: 'alice' });
-
-      const authParams = {
-        authId,
-        expiry: null,
-        data,
-        target,
-        issuer,
-      };
-
       dsMockUtils.createQueryStub('identity', 'authorizations', {
         returnValue: dsMockUtils.createMockOption(),
       });
-
-      entityMockUtils.getAuthorizationRequestInstance(authParams);
 
       return expect(authsNamespace.getOne({ id })).rejects.toThrow(
         'The Authorization Request does not exist'

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -1445,7 +1445,7 @@ const createMockEnum = (enumValue?: string | Record<string, Codec | Codec[]>): E
     codec[`as${upperFirst(key)}`] = enumValue[key];
   }
 
-  return createMockCodec(codec, false) as Enum;
+  return createMockCodec(codec, !enumValue) as Enum;
 };
 
 /**

--- a/src/testUtils/types/index.ts
+++ b/src/testUtils/types/index.ts
@@ -1,6 +1,5 @@
 import { SinonStub } from 'sinon';
 
-export type Mocked<T> = T &
-  {
-    [K in keyof T]: T[K] extends (...args: infer Args) => unknown ? T[K] & SinonStub<Args> : T[K];
-  };
+export type Mocked<T> = T & {
+  [K in keyof T]: T[K] extends (...args: infer Args) => unknown ? T[K] & SinonStub<Args> : T[K];
+};


### PR DESCRIPTION
#### JIRA Link

https://polymath.atlassian.net/browse/DA-252

#### Changelog

`IdentityAuthorizations.getOne` - This method overrides the `getOne` method from base class `Authorizations` and will fetch Authorization Request, targeting or issued by the parent Identity, by its ID