### PR TITLE
fix: 🐛 DA-290 Replace signing identity with account identity while fetching account permissions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-## Description
+### Description
 
 <!-- Describe your changes in detail -->
 
@@ -8,7 +8,7 @@
 
 ### JIRA Link
 
-<!-- Insert JIRA url here   -->
+<!-- Insert JIRA issue here. Example: DA-40  -->
 
 ### Checklist
 

--- a/src/api/entities/__tests__/Account.ts
+++ b/src/api/entities/__tests__/Account.ts
@@ -401,13 +401,13 @@ describe('Account class', () => {
 
       account = new Account({ address }, context);
 
-      const spy = jest.spyOn(account, 'getIdentity').mockResolvedValue(null);
+      const getIdentitySpy = jest.spyOn(account, 'getIdentity').mockResolvedValue(null);
 
       await expect(() => account.getPermissions()).rejects.toThrowError(
         'There is no Identity associated with this Account'
       );
 
-      spy.mockRestore();
+      getIdentitySpy.mockRestore();
     });
 
     it('should return full permissions if the Account is the primary Account', async () => {
@@ -419,7 +419,7 @@ describe('Account class', () => {
 
       account = new Account({ address }, context);
 
-      const spy = jest.spyOn(account, 'getIdentity').mockResolvedValue(identity);
+      const getIdentitySpy = jest.spyOn(account, 'getIdentity').mockResolvedValue(identity);
 
       const result = await account.getPermissions();
 
@@ -430,7 +430,7 @@ describe('Account class', () => {
         portfolios: null,
       });
 
-      spy.mockRestore();
+      getIdentitySpy.mockRestore();
     });
 
     it("should return the Account's permissions if it is a secondary Account", async () => {
@@ -461,29 +461,19 @@ describe('Account class', () => {
 
       account = new Account({ address }, context);
 
-      const spy = jest.spyOn(account, 'getIdentity').mockResolvedValue(identity);
+      const getIdentitySpy = jest.spyOn(account, 'getIdentity').mockResolvedValue(identity);
 
       const result = await account.getPermissions();
 
       expect(result).toEqual(permissions);
 
-      spy.mockRestore();
+      getIdentitySpy.mockRestore();
     });
   });
 
   describe('method: checkPermissions', () => {
     it('should return whether the Account has the passed permissions', async () => {
-      context = dsMockUtils.getContextInstance({
-        primaryAccount: address,
-      });
-
-      account = new Account({ address }, context);
-
-      let result = await account.checkPermissions({ assets: [], portfolios: [], transactions: [] });
-
-      expect(result).toEqual({
-        result: true,
-      });
+      const getPermissionsSpy = jest.spyOn(account, 'getPermissions');
 
       let permissions: Permissions = {
         assets: null,
@@ -491,19 +481,10 @@ describe('Account class', () => {
         transactionGroups: [],
         portfolios: null,
       };
-      const secondaryAccountAddress = 'secondaryAccount';
-      const secondaryAccount = entityMockUtils.getAccountInstance({
-        address: secondaryAccountAddress,
-      });
 
-      context = dsMockUtils.getContextInstance({
-        primaryAccount: address,
-        secondaryAccounts: [{ account: secondaryAccount, permissions }],
-      });
+      getPermissionsSpy.mockResolvedValue(permissions);
 
-      account = new Account({ address: secondaryAccountAddress }, context);
-
-      result = await account.checkPermissions({
+      let result = await account.checkPermissions({
         assets: null,
         portfolios: null,
         transactions: null,
@@ -522,12 +503,8 @@ describe('Account class', () => {
           type: PermissionType.Include,
         },
       };
-      context = dsMockUtils.getContextInstance({
-        primaryAccount: address,
-        secondaryAccounts: [{ account: secondaryAccount, permissions }],
-      });
 
-      account = new Account({ address: secondaryAccountAddress }, context);
+      getPermissionsSpy.mockResolvedValue(permissions);
 
       const portfolio = entityMockUtils.getDefaultPortfolioInstance({ did: 'otherDid' });
 
@@ -553,12 +530,8 @@ describe('Account class', () => {
           type: PermissionType.Exclude,
         },
       };
-      context = dsMockUtils.getContextInstance({
-        primaryAccount: address,
-        secondaryAccounts: [{ account: secondaryAccount, permissions }],
-      });
 
-      account = new Account({ address: secondaryAccountAddress }, context);
+      getPermissionsSpy.mockResolvedValue(permissions);
 
       result = await account.checkPermissions({
         assets: [asset],
@@ -618,12 +591,8 @@ describe('Account class', () => {
           type: PermissionType.Exclude,
         },
       };
-      context = dsMockUtils.getContextInstance({
-        primaryAccount: address,
-        secondaryAccounts: [{ account: secondaryAccount, permissions }],
-      });
 
-      account = new Account({ address: secondaryAccountAddress }, context);
+      getPermissionsSpy.mockResolvedValue(permissions);
 
       result = await account.checkPermissions({
         assets: [],
@@ -652,12 +621,8 @@ describe('Account class', () => {
           type: PermissionType.Exclude,
         },
       };
-      context = dsMockUtils.getContextInstance({
-        primaryAccount: address,
-        secondaryAccounts: [{ account: secondaryAccount, permissions }],
-      });
 
-      account = new Account({ address: secondaryAccountAddress }, context);
+      getPermissionsSpy.mockResolvedValue(permissions);
 
       result = await account.checkPermissions({
         assets: [],
@@ -672,14 +637,20 @@ describe('Account class', () => {
           transactions: [TxTags.identity.AddClaim],
         },
       });
+      getPermissionsSpy.mockRestore();
     });
 
     it('should exempt certain transactions from requiring permissions', async () => {
-      context = dsMockUtils.getContextInstance({
-        primaryAccount: address,
-      });
+      const permissions: Permissions = {
+        assets: null,
+        transactions: null,
+        transactionGroups: [],
+        portfolios: null,
+      };
 
-      account = new Account({ address }, context);
+      const getPermissionsSpy = jest
+        .spyOn(account, 'getPermissions')
+        .mockResolvedValue(permissions);
 
       const result = await account.checkPermissions({
         assets: [],
@@ -696,21 +667,20 @@ describe('Account class', () => {
       expect(result).toEqual({
         result: true,
       });
+      getPermissionsSpy.mockRestore();
     });
   });
 
   describe('method: hasPermissions', () => {
     it('should return whether the Account has the passed permissions', async () => {
-      const mockAccount = entityMockUtils.getAccountInstance({ address });
-      context = dsMockUtils.getContextInstance({
-        primaryAccount: address,
-      });
-
-      account = new Account(mockAccount, context);
+      const checkPermissionsSpy = jest
+        .spyOn(account, 'checkPermissions')
+        .mockResolvedValue({ result: true });
 
       const result = await account.hasPermissions({ assets: [], portfolios: [], transactions: [] });
 
       expect(result).toEqual(true);
+      checkPermissionsSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
### Description

Currently the signing Identity was used to get the permissions that an Account had as a Permissioned Account. This change replaces the use of `signingIdentity` with the corresponding identity associated with the Account and then uses that to fetch the permissions. Also, throws an error if the Account is not associated with any Identity

### Breaking Changes

🧨 `account.getPermissions` can throw if there is no Identity associated with the Account

### JIRA Link

DA-290

### Checklist

❌  Updated the Readme.md (if required) ?