### PR TITLE
feat: 🎸 Always return `TickerReservation` from `assets.getTickerReservation`

### DIFF
--- a/src/Assets.ts
+++ b/src/Assets.ts
@@ -11,14 +11,8 @@ import {
   ReserveTickerParams,
   TickerReservation,
 } from '~/internal';
-import {
-  ErrorCode,
-  ProcedureMethod,
-  SubCallback,
-  TickerReservationStatus,
-  UnsubCallback,
-} from '~/types';
-import { stringToIdentityId, stringToTicker, tickerToString } from '~/utils/conversion';
+import { ErrorCode, ProcedureMethod } from '~/types';
+import { stringToIdentityId, tickerToString } from '~/utils/conversion';
 import { createProcedureMethod, getDid, isPrintableAscii } from '~/utils/internal';
 
 /**
@@ -77,35 +71,6 @@ export class Assets {
   public createAsset: ProcedureMethod<CreateAssetWithTickerParams, Asset>;
 
   /**
-   * Check if a ticker hasn't been reserved
-   *
-   * @note can be subscribed to
-   */
-  public isTickerAvailable(args: { ticker: string }): Promise<boolean>;
-  public isTickerAvailable(
-    args: { ticker: string },
-    callback: SubCallback<boolean>
-  ): Promise<UnsubCallback>;
-
-  // eslint-disable-next-line require-jsdoc
-  public async isTickerAvailable(
-    args: { ticker: string },
-    callback?: SubCallback<boolean>
-  ): Promise<boolean | UnsubCallback> {
-    const reservation = new TickerReservation(args, this.context);
-
-    if (callback) {
-      return reservation.details(({ status: reservationStatus }) => {
-        // eslint-disable-next-line node/no-callback-literal, @typescript-eslint/no-floating-promises -- callback errors should be handled by the caller
-        callback(reservationStatus === TickerReservationStatus.Free);
-      });
-    }
-    const { status } = await reservation.details();
-
-    return status === TickerReservationStatus.Free;
-  }
-
-  /**
    * Retrieve all the ticker reservations currently owned by an Identity. This doesn't include Assets that
    *   have already been launched
    *
@@ -149,32 +114,9 @@ export class Assets {
    */
   public async getTickerReservation(args: { ticker: string }): Promise<TickerReservation> {
     const { ticker } = args;
-    const {
-      context: {
-        polymeshApi: {
-          query: { asset },
-        },
-      },
-      context,
-    } = this;
+    const { context } = this;
 
-    const { owner, expiry } = await asset.tickers(stringToTicker(ticker, context));
-
-    if (!owner.isEmpty) {
-      if (!expiry.isNone) {
-        return new TickerReservation({ ticker }, context);
-      }
-
-      throw new PolymeshError({
-        code: ErrorCode.UnmetPrerequisite,
-        message: `${ticker} Asset has been created`,
-      });
-    }
-
-    throw new PolymeshError({
-      code: ErrorCode.UnmetPrerequisite,
-      message: `There is no reservation for ${ticker} ticker`,
-    });
+    return new TickerReservation({ ticker }, context);
   }
 
   /**

--- a/src/Assets.ts
+++ b/src/Assets.ts
@@ -112,7 +112,7 @@ export class Assets {
    *
    * @param args.ticker - Asset ticker
    */
-  public async getTickerReservation(args: { ticker: string }): Promise<TickerReservation> {
+  public getTickerReservation(args: { ticker: string }): TickerReservation {
     const { ticker } = args;
     const { context } = this;
 

--- a/src/__tests__/Assets.ts
+++ b/src/__tests__/Assets.ts
@@ -5,7 +5,7 @@ import { Assets } from '~/Assets';
 import { Asset, Context, TickerReservation, TransactionQueue } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
-import { KnownAssetType, SecurityIdentifierType, TickerReservationStatus } from '~/types';
+import { KnownAssetType, SecurityIdentifierType } from '~/types';
 import { tuple } from '~/types/utils';
 import * as utilsConversionModule from '~/utils/conversion';
 
@@ -118,68 +118,6 @@ describe('Assets Class', () => {
     });
   });
 
-  describe('method: isTickerAvailable', () => {
-    afterEach(() => {
-      entityMockUtils.reset();
-    });
-
-    it('should return true if ticker is available to reserve it', async () => {
-      entityMockUtils.configureMocks({
-        tickerReservationOptions: {
-          details: {
-            owner: entityMockUtils.getIdentityInstance(),
-            expiryDate: new Date(),
-            status: TickerReservationStatus.Free,
-          },
-        },
-      });
-
-      const isTickerAvailable = await assets.isTickerAvailable({ ticker: 'SOME_TICKER' });
-
-      expect(isTickerAvailable).toBeTruthy();
-    });
-
-    it('should return false if ticker is not available to reserve it', async () => {
-      entityMockUtils.configureMocks({
-        tickerReservationOptions: {
-          details: {
-            owner: entityMockUtils.getIdentityInstance(),
-            expiryDate: new Date(),
-            status: TickerReservationStatus.Reserved,
-          },
-        },
-      });
-
-      const isTickerAvailable = await assets.isTickerAvailable({ ticker: 'someTicker' });
-
-      expect(isTickerAvailable).toBeFalsy();
-    });
-
-    it('should allow subscription', async () => {
-      const unsubCallback = 'unsubCallBack';
-
-      entityMockUtils.configureMocks({
-        tickerReservationOptions: {
-          details: async cbFunc => {
-            cbFunc({
-              owner: entityMockUtils.getIdentityInstance(),
-              expiryDate: new Date(),
-              status: TickerReservationStatus.Free,
-            });
-
-            return unsubCallback;
-          },
-        },
-      });
-
-      const callback = sinon.stub();
-      const result = await assets.isTickerAvailable({ ticker: 'someTicker' }, callback);
-
-      expect(result).toBe(unsubCallback);
-      sinon.assert.calledWithExactly(callback, true);
-    });
-  });
-
   describe('method: getTickerReservations', () => {
     beforeAll(() => {
       sinon.stub(utilsConversionModule, 'signerValueToSignatory');
@@ -263,51 +201,10 @@ describe('Assets Class', () => {
   });
 
   describe('method: getTickerReservation', () => {
-    it('should return a specific ticker reservation owned by the Identity', async () => {
+    it('should return a Ticker Reservation', async () => {
       const ticker = 'TEST';
-      const expiry = new Date();
-
-      dsMockUtils.createQueryStub('asset', 'tickers', {
-        returnValue: dsMockUtils.createMockTickerRegistration({
-          owner: dsMockUtils.createMockIdentityId('someDid'),
-          expiry: dsMockUtils.createMockOption(
-            dsMockUtils.createMockMoment(new BigNumber(expiry.getTime()))
-          ),
-        }),
-      });
-
       const tickerReservation = await assets.getTickerReservation({ ticker });
       expect(tickerReservation.ticker).toBe(ticker);
-    });
-
-    it('should throw if ticker reservation does not exist', async () => {
-      const ticker = 'TEST';
-
-      dsMockUtils.createQueryStub('asset', 'tickers', {
-        returnValue: dsMockUtils.createMockTickerRegistration({
-          owner: dsMockUtils.createMockIdentityId(),
-          expiry: dsMockUtils.createMockOption(),
-        }),
-      });
-
-      return expect(assets.getTickerReservation({ ticker })).rejects.toThrow(
-        `There is no reservation for ${ticker} ticker`
-      );
-    });
-
-    it('should throw if ticker is already an Asset', async () => {
-      const ticker = 'TEST';
-
-      dsMockUtils.createQueryStub('asset', 'tickers', {
-        returnValue: dsMockUtils.createMockTickerRegistration({
-          owner: dsMockUtils.createMockIdentityId('someDid'),
-          expiry: dsMockUtils.createMockOption(),
-        }),
-      });
-
-      return expect(assets.getTickerReservation({ ticker })).rejects.toThrow(
-        `${ticker} Asset has been created`
-      );
     });
   });
 

--- a/src/__tests__/Assets.ts
+++ b/src/__tests__/Assets.ts
@@ -201,9 +201,9 @@ describe('Assets Class', () => {
   });
 
   describe('method: getTickerReservation', () => {
-    it('should return a Ticker Reservation', async () => {
+    it('should return a Ticker Reservation', () => {
       const ticker = 'TEST';
-      const tickerReservation = await assets.getTickerReservation({ ticker });
+      const tickerReservation = assets.getTickerReservation({ ticker });
       expect(tickerReservation.ticker).toBe(ticker);
     });
   });

--- a/src/api/entities/TickerReservation/__tests__/index.ts
+++ b/src/api/entities/TickerReservation/__tests__/index.ts
@@ -1,9 +1,11 @@
 import BigNumber from 'bignumber.js';
 import sinon from 'sinon';
 
-import { Asset, Entity, TickerReservation, TransactionQueue } from '~/internal';
+import { Asset, Context, Entity, TickerReservation, TransactionQueue } from '~/internal';
 import { dsMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { Mocked } from '~/testUtils/types';
 import { KnownAssetType, SecurityIdentifierType, TickerReservationStatus } from '~/types';
+import * as utilsInternalModule from '~/utils/internal';
 
 jest.mock(
   '~/base/Procedure',
@@ -11,16 +13,20 @@ jest.mock(
 );
 
 describe('TickerReservation class', () => {
-  const ticker = 'FAKETICKER';
+  const ticker = 'FAKE_TICKER';
+  let assertTickerValidStub: sinon.SinonStub;
+  let context: Mocked<Context>;
 
   beforeAll(() => {
     dsMockUtils.initMocks();
     procedureMockUtils.initMocks();
+    assertTickerValidStub = sinon.stub(utilsInternalModule, 'assertTickerValid');
   });
 
   afterEach(() => {
     dsMockUtils.reset();
     procedureMockUtils.reset();
+    context = dsMockUtils.getContextInstance();
   });
 
   afterAll(() => {
@@ -33,8 +39,15 @@ describe('TickerReservation class', () => {
   });
 
   describe('constructor', () => {
+    it('should throw an error if the supplied ticker is invalid', () => {
+      assertTickerValidStub.throws();
+
+      expect(() => new TickerReservation({ ticker: 'some_ticker' }, context)).toThrow();
+
+      sinon.reset();
+    });
+
     it('should assign ticker to instance', () => {
-      const context = dsMockUtils.getContextInstance();
       const tickerReservation = new TickerReservation({ ticker }, context);
 
       expect(tickerReservation.ticker).toBe(ticker);
@@ -59,7 +72,6 @@ describe('TickerReservation class', () => {
     });
 
     it('should return details for a free ticker', async () => {
-      const context = dsMockUtils.getContextInstance();
       const tickerReservation = new TickerReservation({ ticker }, context);
 
       queryMultiStub.resolves([
@@ -79,7 +91,7 @@ describe('TickerReservation class', () => {
     it('should return details for a reserved ticker', async () => {
       const ownerDid = 'someDid';
       const expiryDate = new Date(new Date().getTime() + 100000);
-      const context = dsMockUtils.getContextInstance();
+
       const tickerReservation = new TickerReservation({ ticker }, context);
 
       queryMultiStub.resolves([
@@ -104,7 +116,7 @@ describe('TickerReservation class', () => {
     it('should return details for a permanently reserved ticker', async () => {
       const ownerDid = 'someDid';
       const expiryDate = null;
-      const context = dsMockUtils.getContextInstance();
+
       const tickerReservation = new TickerReservation({ ticker }, context);
 
       queryMultiStub.resolves([
@@ -127,7 +139,7 @@ describe('TickerReservation class', () => {
     it('should return details for a ticker for which a reservation expired', async () => {
       const ownerDid = 'someDid';
       const expiryDate = new Date(new Date().getTime() - 100000);
-      const context = dsMockUtils.getContextInstance();
+
       const tickerReservation = new TickerReservation({ ticker }, context);
 
       queryMultiStub.resolves([
@@ -152,7 +164,7 @@ describe('TickerReservation class', () => {
     it('should return details for a ticker for which an Asset has already been created', async () => {
       const ownerDid = 'someDid';
       const expiryDate = null;
-      const context = dsMockUtils.getContextInstance();
+
       const tickerReservation = new TickerReservation({ ticker }, context);
 
       queryMultiStub.resolves([
@@ -180,7 +192,6 @@ describe('TickerReservation class', () => {
     });
 
     it('should allow subscription', async () => {
-      const context = dsMockUtils.getContextInstance();
       const tickerReservation = new TickerReservation({ ticker }, context);
 
       const unsubCallback = 'unsubCallback';
@@ -204,7 +215,6 @@ describe('TickerReservation class', () => {
 
   describe('method: extend', () => {
     it('should prepare the procedure with the correct arguments and context, and return the resulting transaction queue', async () => {
-      const context = dsMockUtils.getContextInstance();
       const tickerReservation = new TickerReservation({ ticker }, context);
 
       const args = {
@@ -227,7 +237,6 @@ describe('TickerReservation class', () => {
 
   describe('method: createAsset', () => {
     it('should prepare the procedure with the correct arguments and context, and return the resulting transaction queue', async () => {
-      const context = dsMockUtils.getContextInstance();
       const tickerReservation = new TickerReservation({ ticker }, context);
 
       const args = {
@@ -257,7 +266,6 @@ describe('TickerReservation class', () => {
 
   describe('method: transferOwnership', () => {
     it('should prepare the procedure with the correct arguments and context, and return the resulting transaction queue', async () => {
-      const context = dsMockUtils.getContextInstance();
       const tickerReservation = new TickerReservation({ ticker }, context);
       const target = 'someOtherDid';
       const expiry = new Date('10/10/2022');
@@ -283,7 +291,6 @@ describe('TickerReservation class', () => {
 
   describe('method: exists', () => {
     it('should return whether the Reservation exists', async () => {
-      const context = dsMockUtils.getContextInstance();
       const tickerRes = new TickerReservation({ ticker: 'SOME_TICKER' }, context);
 
       dsMockUtils.createQueryStub('asset', 'tickers', {
@@ -304,7 +311,6 @@ describe('TickerReservation class', () => {
 
   describe('method: toJson', () => {
     it('should return a human readable version of the entity', () => {
-      const context = dsMockUtils.getContextInstance();
       const tickerRes = new TickerReservation({ ticker: 'SOME_TICKER' }, context);
 
       expect(tickerRes.toJson()).toBe('SOME_TICKER');

--- a/src/api/entities/TickerReservation/index.ts
+++ b/src/api/entities/TickerReservation/index.ts
@@ -16,7 +16,7 @@ import {
 import { NoArgsProcedureMethod, ProcedureMethod, SubCallback, UnsubCallback } from '~/types';
 import { QueryReturnType } from '~/types/utils';
 import { identityIdToString, momentToDate, stringToTicker } from '~/utils/conversion';
-import { createProcedureMethod } from '~/utils/internal';
+import { assertTickerValid, createProcedureMethod } from '~/utils/internal';
 
 import { TickerReservationDetails, TickerReservationStatus } from './types';
 
@@ -55,6 +55,8 @@ export class TickerReservation extends Entity<UniqueIdentifiers, string> {
     super(identifiers, context);
 
     const { ticker } = identifiers;
+
+    assertTickerValid(ticker);
 
     this.ticker = ticker;
 

--- a/src/utils/__tests__/conversion.ts
+++ b/src/utils/__tests__/conversion.ts
@@ -550,42 +550,6 @@ describe('stringToTicker and tickerToString', () => {
 
       expect(result).toBe(fakeResult);
     });
-
-    it('should throw an error if the string is empty', () => {
-      const value = '';
-      const context = dsMockUtils.getContextInstance();
-
-      expect(() => stringToTicker(value, context)).toThrow(
-        `Ticker length must be between 1 and ${MAX_TICKER_LENGTH} character`
-      );
-    });
-
-    it('should throw an error if the string length exceeds the max ticker length', () => {
-      const value = 'veryLongTicker';
-      const context = dsMockUtils.getContextInstance();
-
-      expect(() => stringToTicker(value, context)).toThrow(
-        `Ticker length must be between 1 and ${MAX_TICKER_LENGTH} character`
-      );
-    });
-
-    it('should throw an error if the string contains unreadable characters', () => {
-      const value = `Illegal ${String.fromCharCode(65533)}`;
-      const context = dsMockUtils.getContextInstance();
-
-      expect(() => stringToTicker(value, context)).toThrow(
-        'Only printable ASCII is allowed as ticker name'
-      );
-    });
-
-    it('should throw an error if the string is not in upper case', () => {
-      const value = 'FakeTicker';
-      const context = dsMockUtils.getContextInstance();
-
-      expect(() => stringToTicker(value, context)).toThrow(
-        'Ticker cannot contain lower case letters'
-      );
-    });
   });
 
   describe('tickerToString', () => {

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -18,12 +18,14 @@ import {
   TxTags,
 } from '~/types';
 import { tuple } from '~/types/utils';
+import { MAX_TICKER_LENGTH } from '~/utils/constants';
 
 import {
   assertAddressValid,
   assertExpectedChainVersion,
   assertIsInteger,
   assertIsPositive,
+  assertTickerValid,
   asTicker,
   calculateNextKey,
   createClaim,
@@ -947,5 +949,43 @@ describe('assertExpectedChainVersion', () => {
     });
     client.triggerError(new Error('could not connect'));
     return expect(signal).rejects.toThrowError(expectedError);
+  });
+});
+
+describe('assertTickerValid', () => {
+  it('should throw an error if the string is empty', () => {
+    const ticker = '';
+
+    expect(() => assertTickerValid(ticker)).toThrow(
+      `Ticker length must be between 1 and ${MAX_TICKER_LENGTH} character`
+    );
+  });
+
+  it('should throw an error if the string length exceeds the max ticker length', () => {
+    const ticker = 'VERY_LONG_TICKER';
+
+    expect(() => assertTickerValid(ticker)).toThrow(
+      `Ticker length must be between 1 and ${MAX_TICKER_LENGTH} character`
+    );
+  });
+
+  it('should throw an error if the string contains unreadable characters', () => {
+    const ticker = `ILLEGAL_${String.fromCharCode(65533)}`;
+
+    expect(() => assertTickerValid(ticker)).toThrow(
+      'Only printable ASCII is allowed as ticker name'
+    );
+  });
+
+  it('should throw an error if the string is not in upper case', () => {
+    const ticker = 'FakeTicker';
+
+    expect(() => assertTickerValid(ticker)).toThrow('Ticker cannot contain lower case letters');
+  });
+
+  it('should not throw an error', () => {
+    const ticker = 'FAKE_TICKER';
+
+    assertTickerValid(ticker);
   });
 });

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -211,11 +211,11 @@ import {
   assertAddressValid,
   assertIsInteger,
   assertIsPositive,
+  assertTickerValid,
   asTicker,
   conditionsAreEqual,
   createClaim,
   isModuleOrTagMatch,
-  isPrintableAscii,
   optionize,
   padString,
   removePadding,
@@ -283,26 +283,7 @@ export function bytesToString(bytes: Bytes): string {
  * @hidden
  */
 export function stringToTicker(ticker: string, context: Context): Ticker {
-  if (!ticker.length || ticker.length > MAX_TICKER_LENGTH) {
-    throw new PolymeshError({
-      code: ErrorCode.ValidationError,
-      message: `Ticker length must be between 1 and ${MAX_TICKER_LENGTH} characters`,
-    });
-  }
-
-  if (!isPrintableAscii(ticker)) {
-    throw new PolymeshError({
-      code: ErrorCode.ValidationError,
-      message: 'Only printable ASCII is allowed as ticker name',
-    });
-  }
-
-  if (ticker !== ticker.toUpperCase()) {
-    throw new PolymeshError({
-      code: ErrorCode.ValidationError,
-      message: 'Ticker cannot contain lower case letters',
-    });
-  }
+  assertTickerValid(ticker);
 
   return context.createType('Ticker', padString(ticker, MAX_TICKER_LENGTH));
 }

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -61,6 +61,7 @@ import {
 import { HumanReadableType, ProcedureFunc, UnionOfProcedureFuncs } from '~/types/utils';
 import {
   DEFAULT_GQL_PAGE_SIZE,
+  MAX_TICKER_LENGTH,
   SUPPORTED_VERSION_RANGE,
   SYSTEM_VERSION_RPC_CALL,
 } from '~/utils/constants';
@@ -1032,4 +1033,32 @@ export function assertExpectedChainVersion(nodeUrl: string): Promise<void> {
       reject(err);
     };
   });
+}
+
+/**
+ * @hidden
+ *
+ * Validates a ticker value
+ */
+export function assertTickerValid(ticker: string) {
+  if (!ticker.length || ticker.length > MAX_TICKER_LENGTH) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: `Ticker length must be between 1 and ${MAX_TICKER_LENGTH} characters`,
+    });
+  }
+
+  if (!isPrintableAscii(ticker)) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'Only printable ASCII is allowed as ticker name',
+    });
+  }
+
+  if (ticker !== ticker.toUpperCase()) {
+    throw new PolymeshError({
+      code: ErrorCode.ValidationError,
+      message: 'Ticker cannot contain lower case letters',
+    });
+  }
 }

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -1040,7 +1040,7 @@ export function assertExpectedChainVersion(nodeUrl: string): Promise<void> {
  *
  * Validates a ticker value
  */
-export function assertTickerValid(ticker: string) {
+export function assertTickerValid(ticker: string): void {
   if (!ticker.length || ticker.length > MAX_TICKER_LENGTH) {
     throw new PolymeshError({
       code: ErrorCode.ValidationError,


### PR DESCRIPTION
### Description

Regardless of the state, `assets.getReservation` now returns a `TickerReservation` instance.

### Breaking Changes

🧨 `assets.isTickerAvailable` has been removed. 
To check ticker availability, directly get the `TickerReservation` instance and use `details.status` to check the availability

### JIRA Link

DA-142

### Checklist

- [ ] Updated the Readme.md (if required) ?
