### PR TITLE
refactor: 💡 Rename `toJson` to `toHuman` in all entities

### DIFF
--- a/src/api/entities/Account.ts
+++ b/src/api/entities/Account.ts
@@ -588,7 +588,7 @@ export class Account extends Entity<UniqueIdentifiers, string> {
   /**
    * Return the Account's address
    */
-  public toJson(): string {
+  public toHuman(): string {
     return this.address;
   }
 }

--- a/src/api/entities/Asset/__tests__/index.ts
+++ b/src/api/entities/Asset/__tests__/index.ts
@@ -766,12 +766,12 @@ describe('Asset class', () => {
     });
   });
 
-  describe('method: toJson', () => {
+  describe('method: toHuman', () => {
     it('should return a human readable version of the entity', () => {
       const context = dsMockUtils.getContextInstance();
       const asset = new Asset({ ticker: 'SOME_TICKER' }, context);
 
-      expect(asset.toJson()).toBe('SOME_TICKER');
+      expect(asset.toHuman()).toBe('SOME_TICKER');
     });
   });
 });

--- a/src/api/entities/Asset/index.ts
+++ b/src/api/entities/Asset/index.ts
@@ -609,7 +609,7 @@ export class Asset extends Entity<UniqueIdentifiers, string> {
   /**
    * Return the Asset's ticker
    */
-  public toJson(): string {
+  public toHuman(): string {
     return this.ticker;
   }
 }

--- a/src/api/entities/AuthorizationRequest.ts
+++ b/src/api/entities/AuthorizationRequest.ts
@@ -211,7 +211,7 @@ export class AuthorizationRequest extends Entity<UniqueIdentifiers, HumanReadabl
   /**
    * Return the Authorization's static data
    */
-  public toJson(): HumanReadable {
+  public toHuman(): HumanReadable {
     const { data, issuer, target, expiry, authId } = this;
 
     return toHumanReadable({

--- a/src/api/entities/Checkpoint.ts
+++ b/src/api/entities/Checkpoint.ts
@@ -262,7 +262,7 @@ export class Checkpoint extends Entity<UniqueIdentifiers, HumanReadable> {
   /**
    * Return the Checkpoint's ticker and identifier
    */
-  public toJson(): HumanReadable {
+  public toHuman(): HumanReadable {
     const { asset, id } = this;
 
     return toHumanReadable({

--- a/src/api/entities/CheckpointSchedule/__tests__/index.ts
+++ b/src/api/entities/CheckpointSchedule/__tests__/index.ts
@@ -275,7 +275,7 @@ describe('CheckpointSchedule class', () => {
     });
   });
 
-  describe('method: toJson', () => {
+  describe('method: toHuman', () => {
     it('should return a human readable version of the entity', () => {
       const schedule = new CheckpointSchedule(
         {
@@ -288,7 +288,7 @@ describe('CheckpointSchedule class', () => {
         },
         context
       );
-      expect(schedule.toJson()).toEqual({
+      expect(schedule.toHuman()).toEqual({
         id: '1',
         ticker: 'SOME_TICKER',
         period: {

--- a/src/api/entities/CheckpointSchedule/index.ts
+++ b/src/api/entities/CheckpointSchedule/index.ts
@@ -208,7 +208,7 @@ export class CheckpointSchedule extends Entity<UniqueIdentifiers, HumanReadable>
   /**
    * Return the Schedule's static data
    */
-  public toJson(): HumanReadable {
+  public toHuman(): HumanReadable {
     const { asset, id, expiryDate, complexity, start, period } = this;
 
     return toHumanReadable({

--- a/src/api/entities/CorporateActionBase/__tests__/index.ts
+++ b/src/api/entities/CorporateActionBase/__tests__/index.ts
@@ -305,9 +305,9 @@ describe('CorporateAction class', () => {
     });
   });
 
-  describe('method: toJson', () => {
+  describe('method: toHuman', () => {
     it('should return a human readable version of the entity', () => {
-      expect(corporateAction.toJson()).toEqual({
+      expect(corporateAction.toHuman()).toEqual({
         id: '1',
         ticker: 'SOME_TICKER',
         declarationDate: '1987-10-14T00:00:00.000Z',

--- a/src/api/entities/CorporateActionBase/index.ts
+++ b/src/api/entities/CorporateActionBase/index.ts
@@ -252,7 +252,7 @@ export abstract class CorporateActionBase extends Entity<UniqueIdentifiers, unkn
   /**
    * Return the Corporate Action's static data
    */
-  public toJson(): HumanReadable {
+  public toHuman(): HumanReadable {
     const {
       asset,
       id,

--- a/src/api/entities/CustomPermissionGroup.ts
+++ b/src/api/entities/CustomPermissionGroup.ts
@@ -114,7 +114,7 @@ export class CustomPermissionGroup extends PermissionGroup {
   /**
    * Return the Group's static data
    */
-  public toJson(): HumanReadable {
+  public toHuman(): HumanReadable {
     const { id, asset } = this;
 
     return toHumanReadable({

--- a/src/api/entities/DividendDistribution/__tests__/index.ts
+++ b/src/api/entities/DividendDistribution/__tests__/index.ts
@@ -593,13 +593,13 @@ describe('DividendDistribution class', () => {
     });
   });
 
-  describe('method: toJson', () => {
+  describe('method: toHuman', () => {
     it('should return a human readable version of the entity', () => {
       dividendDistribution.targets = {
         treatment: TargetTreatment.Exclude,
         identities: [],
       };
-      expect(dividendDistribution.toJson()).toEqual({
+      expect(dividendDistribution.toHuman()).toEqual({
         id: '1',
         ticker: 'SOME_TICKER',
         declarationDate: '1987-10-14T00:00:00.000Z',

--- a/src/api/entities/DividendDistribution/index.ts
+++ b/src/api/entities/DividendDistribution/index.ts
@@ -578,10 +578,10 @@ export class DividendDistribution extends CorporateActionBase {
   /**
    * Return the Dividend Distribution's static data
    */
-  public override toJson(): HumanReadable {
+  public override toHuman(): HumanReadable {
     const { origin, currency, perShare, maxAmount, expiryDate, paymentDate } = this;
 
-    const parentReadable = super.toJson();
+    const parentReadable = super.toHuman();
 
     return {
       ...toHumanReadable({ origin, currency, perShare, maxAmount, expiryDate, paymentDate }),

--- a/src/api/entities/Entity.ts
+++ b/src/api/entities/Entity.ts
@@ -70,5 +70,5 @@ export abstract class Entity<UniqueIdentifiers, HumanReadable> {
   /**
    * Returns Entity data in a human readable (JSON) format
    */
-  public abstract toJson(): HumanReadable;
+  public abstract toHuman(): HumanReadable;
 }

--- a/src/api/entities/Identity/__tests__/index.ts
+++ b/src/api/entities/Identity/__tests__/index.ts
@@ -1282,10 +1282,10 @@ describe('Identity class', () => {
     });
   });
 
-  describe('method: toJson', () => {
+  describe('method: toHuman', () => {
     it('should return a human readable version of the entity', () => {
       const identity = new Identity({ did: 'someDid' }, context);
-      expect(identity.toJson()).toBe('someDid');
+      expect(identity.toHuman()).toBe('someDid');
     });
   });
 });

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -723,7 +723,7 @@ export class Identity extends Entity<UniqueIdentifiers, string> {
   /**
    * Return the Identity's DID
    */
-  public toJson(): string {
+  public toHuman(): string {
     return this.did;
   }
 }

--- a/src/api/entities/Instruction/__tests__/index.ts
+++ b/src/api/entities/Instruction/__tests__/index.ts
@@ -862,9 +862,9 @@ describe('Instruction class', () => {
     });
   });
 
-  describe('method: toJson', () => {
+  describe('method: toHuman', () => {
     it('should return a human readable version of the entity', () => {
-      expect(instruction.toJson()).toBe('1');
+      expect(instruction.toHuman()).toBe('1');
     });
   });
 });

--- a/src/api/entities/Instruction/index.ts
+++ b/src/api/entities/Instruction/index.ts
@@ -434,7 +434,7 @@ export class Instruction extends Entity<UniqueIdentifiers, string> {
   /**
    * Return the Instruction's ID
    */
-  public toJson(): string {
+  public toHuman(): string {
     return this.id.toString();
   }
 }

--- a/src/api/entities/KnownPermissionGroup.ts
+++ b/src/api/entities/KnownPermissionGroup.ts
@@ -94,7 +94,7 @@ export class KnownPermissionGroup extends PermissionGroup {
   /**
    * Return the KnownPermissionGroup's static data
    */
-  public toJson(): HumanReadable {
+  public toHuman(): HumanReadable {
     const { type, asset } = this;
 
     return toHumanReadable({

--- a/src/api/entities/Offering/__tests__/index.ts
+++ b/src/api/entities/Offering/__tests__/index.ts
@@ -440,11 +440,11 @@ describe('Offering class', () => {
     });
   });
 
-  describe('method: toJson', () => {
+  describe('method: toHuman', () => {
     it('should return a human readable version of the entity', () => {
       const offering = new Offering({ ticker: 'SOME_TICKER', id: new BigNumber(1) }, context);
 
-      expect(offering.toJson()).toEqual({
+      expect(offering.toHuman()).toEqual({
         id: '1',
         ticker: 'SOME_TICKER',
       });

--- a/src/api/entities/Offering/index.ts
+++ b/src/api/entities/Offering/index.ts
@@ -266,7 +266,7 @@ export class Offering extends Entity<UniqueIdentifiers, HumanReadable> {
   /**
    * Return the Offering's ID and Asset ticker
    */
-  public toJson(): HumanReadable {
+  public toHuman(): HumanReadable {
     const { asset, id } = this;
 
     return toHumanReadable({

--- a/src/api/entities/Portfolio/__tests__/index.ts
+++ b/src/api/entities/Portfolio/__tests__/index.ts
@@ -571,18 +571,18 @@ describe('Portfolio class', () => {
     });
   });
 
-  describe('method: toJson', () => {
+  describe('method: toHuman', () => {
     it('should return a human readable version of the entity', () => {
       let portfolio = new NonAbstract({ did: 'someDid', id: new BigNumber(1) }, context);
 
-      expect(portfolio.toJson()).toEqual({
+      expect(portfolio.toHuman()).toEqual({
         did: 'someDid',
         id: '1',
       });
 
       portfolio = new NonAbstract({ did: 'someDid' }, context);
 
-      expect(portfolio.toJson()).toEqual({
+      expect(portfolio.toHuman()).toEqual({
         did: 'someDid',
       });
     });

--- a/src/api/entities/Portfolio/index.ts
+++ b/src/api/entities/Portfolio/index.ts
@@ -381,7 +381,7 @@ export abstract class Portfolio extends Entity<UniqueIdentifiers, HumanReadable>
   /**
    * Return the Portfolio ID and owner DID
    */
-  public toJson(): HumanReadable {
+  public toHuman(): HumanReadable {
     const {
       _id: id,
       owner: { did },

--- a/src/api/entities/Subsidy/__tests__/index.ts
+++ b/src/api/entities/Subsidy/__tests__/index.ts
@@ -239,11 +239,11 @@ describe('Subsidy class', () => {
     });
   });
 
-  describe('method: toJson', () => {
+  describe('method: toHuman', () => {
     it('should return a human readable version of the entity', () => {
-      subsidy.beneficiary.toJson = sinon.stub().returns(beneficiary);
-      subsidy.subsidizer.toJson = sinon.stub().returns(subsidizer);
-      expect(subsidy.toJson()).toEqual({ beneficiary, subsidizer });
+      subsidy.beneficiary.toHuman = sinon.stub().returns(beneficiary);
+      subsidy.subsidizer.toHuman = sinon.stub().returns(subsidizer);
+      expect(subsidy.toHuman()).toEqual({ beneficiary, subsidizer });
     });
   });
 });

--- a/src/api/entities/Subsidy/index.ts
+++ b/src/api/entities/Subsidy/index.ts
@@ -199,7 +199,7 @@ export class Subsidy extends Entity<UniqueIdentifiers, HumanReadable> {
   /**
    * Return the Subsidy's static data
    */
-  public toJson(): HumanReadable {
+  public toHuman(): HumanReadable {
     const { beneficiary, subsidizer } = this;
 
     return toHumanReadable({

--- a/src/api/entities/TickerReservation/__tests__/index.ts
+++ b/src/api/entities/TickerReservation/__tests__/index.ts
@@ -302,12 +302,12 @@ describe('TickerReservation class', () => {
     });
   });
 
-  describe('method: toJson', () => {
+  describe('method: toHuman', () => {
     it('should return a human readable version of the entity', () => {
       const context = dsMockUtils.getContextInstance();
       const tickerRes = new TickerReservation({ ticker: 'SOME_TICKER' }, context);
 
-      expect(tickerRes.toJson()).toBe('SOME_TICKER');
+      expect(tickerRes.toHuman()).toBe('SOME_TICKER');
     });
   });
 });

--- a/src/api/entities/TickerReservation/index.ts
+++ b/src/api/entities/TickerReservation/index.ts
@@ -212,7 +212,7 @@ export class TickerReservation extends Entity<UniqueIdentifiers, string> {
   /**
    * Return the Reservation's ticker
    */
-  public toJson(): string {
+  public toHuman(): string {
     return this.ticker;
   }
 }

--- a/src/api/entities/Venue/__tests__/index.ts
+++ b/src/api/entities/Venue/__tests__/index.ts
@@ -352,11 +352,11 @@ describe('Venue class', () => {
     });
   });
 
-  describe('method: toJson', () => {
+  describe('method: toHuman', () => {
     it('should return a human readable version of the entity', () => {
       const venueEntity = new Venue({ id: new BigNumber(1) }, context);
 
-      expect(venueEntity.toJson()).toBe('1');
+      expect(venueEntity.toHuman()).toBe('1');
     });
   });
 });

--- a/src/api/entities/Venue/index.ts
+++ b/src/api/entities/Venue/index.ts
@@ -227,7 +227,7 @@ export class Venue extends Entity<UniqueIdentifiers, string> {
   /**
    * Return the Venue's ID
    */
-  public toJson(): string {
+  public toHuman(): string {
     return this.id.toString();
   }
 }

--- a/src/api/entities/__tests__/Account.ts
+++ b/src/api/entities/__tests__/Account.ts
@@ -383,9 +383,9 @@ describe('Account class', () => {
     });
   });
 
-  describe('method: toJson', () => {
+  describe('method: toHuman', () => {
     it('should return a human readable version of the entity', () => {
-      expect(account.toJson()).toBe(account.address);
+      expect(account.toHuman()).toBe(account.address);
     });
   });
 

--- a/src/api/entities/__tests__/AuthorizationRequest.ts
+++ b/src/api/entities/__tests__/AuthorizationRequest.ts
@@ -399,7 +399,7 @@ describe('AuthorizationRequest class', () => {
     });
   });
 
-  describe('method: toJson', () => {
+  describe('method: toHuman', () => {
     it('should return a human readable version of the entity', () => {
       const authorizationRequest = new AuthorizationRequest(
         {
@@ -411,7 +411,7 @@ describe('AuthorizationRequest class', () => {
         },
         context
       );
-      expect(authorizationRequest.toJson()).toEqual({
+      expect(authorizationRequest.toHuman()).toEqual({
         id: '1',
         expiry: '1987-10-14T00:00:00.000Z',
         target: {

--- a/src/api/entities/__tests__/Checkpoint.ts
+++ b/src/api/entities/__tests__/Checkpoint.ts
@@ -248,10 +248,10 @@ describe('Checkpoint class', () => {
     });
   });
 
-  describe('method: toJson', () => {
+  describe('method: toHuman', () => {
     it('should return a human readable version of the entity', () => {
       const checkpoint = new Checkpoint({ id: new BigNumber(1), ticker: 'SOME_TICKER' }, context);
-      expect(checkpoint.toJson()).toEqual({
+      expect(checkpoint.toHuman()).toEqual({
         id: '1',
         ticker: 'SOME_TICKER',
       });

--- a/src/api/entities/__tests__/CustomPermissionGroup.ts
+++ b/src/api/entities/__tests__/CustomPermissionGroup.ts
@@ -66,15 +66,15 @@ describe('CustomPermissionGroup class', () => {
     });
   });
 
-  describe('method: toJson', () => {
+  describe('method: toHuman', () => {
     it('should return a human readable version of the entity', () => {
       entityMockUtils.configureMocks({
         assetOptions: {
-          toJson: ticker,
+          toHuman: ticker,
         },
       });
       const customPermissionGroup = new CustomPermissionGroup({ id, ticker }, context);
-      expect(customPermissionGroup.toJson()).toEqual({
+      expect(customPermissionGroup.toHuman()).toEqual({
         id: id.toString(),
         ticker,
       });

--- a/src/api/entities/__tests__/Entity.ts
+++ b/src/api/entities/__tests__/Entity.ts
@@ -6,7 +6,7 @@ import * as utilsInternalModule from '~/utils/internal';
 // eslint-disable-next-line require-jsdoc
 class NonAbstract extends Entity<unknown, boolean> {
   // eslint-disable-next-line require-jsdoc
-  public toJson(): boolean {
+  public toHuman(): boolean {
     return true;
   }
 

--- a/src/api/entities/__tests__/KnownPermissionGroup.ts
+++ b/src/api/entities/__tests__/KnownPermissionGroup.ts
@@ -57,16 +57,16 @@ describe('KnownPermissionGroup class', () => {
     });
   });
 
-  describe('method: toJson', () => {
+  describe('method: toHuman', () => {
     it('should return a human readable version of the entity', () => {
       entityMockUtils.configureMocks({
         assetOptions: {
-          toJson: ticker,
+          toHuman: ticker,
         },
       });
       const type = PermissionGroupType.Full;
       const knownPermissionGroup = new KnownPermissionGroup({ type, ticker }, context);
-      expect(knownPermissionGroup.toJson()).toEqual({
+      expect(knownPermissionGroup.toHuman()).toEqual({
         type,
         ticker,
       });

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -98,7 +98,7 @@ export type MockKnownPermissionGroup = Mocked<KnownPermissionGroup>;
 interface EntityOptions {
   exists?: boolean;
   isEqual?: boolean;
-  toJson?: any;
+  toHuman?: any;
 }
 
 type EntityGetter<Result> = Partial<Result> | ((...args: any) => any) | sinon.SinonStub;
@@ -331,14 +331,14 @@ function createMockEntityClass<Options extends EntityOptions>(
     ({
       isEqual: true,
       exists: true,
-      toJson: 'DEFAULT_JSON_STRING_PLEASE_OVERRIDE',
+      toHuman: 'DEFAULT_JSON_STRING_PLEASE_OVERRIDE',
       ...defaultOptions(),
       ...options,
     } as Required<Options>);
   return class MockClass extends Class {
     isEqual = sinon.stub();
     exists = sinon.stub();
-    toJson = sinon.stub();
+    toHuman = sinon.stub();
 
     private static constructorStub = sinon.stub();
 
@@ -419,7 +419,7 @@ function createMockEntityClass<Options extends EntityOptions>(
 
       this.exists.returns(fullOpts.exists);
       this.isEqual.returns(fullOpts.isEqual);
-      this.toJson.returns(fullOpts.toJson);
+      this.toHuman.returns(fullOpts.toHuman);
     }
 
     /**
@@ -558,7 +558,7 @@ const MockIdentityClass = createMockEntityClass<IdentityOptions>(
     checkRoles: {
       result: true,
     },
-    toJson: 'someDid',
+    toHuman: 'someDid',
   }),
   ['Identity']
 );
@@ -644,7 +644,7 @@ const MockSubsidyClass = createMockEntityClass<SubsidyOptions>(
     beneficiary: 'beneficiary',
     subsidizer: 'subsidizer',
     getAllowance: new BigNumber(100),
-    toJson: {
+    toHuman: {
       beneficiary: 'beneficiary',
       subsidizer: 'subsidizer',
     },
@@ -820,7 +820,7 @@ const MockAssetClass = createMockEntityClass<AssetOptions>(
         nextCheckpointDate: new Date(new Date().getTime() + 1000 * 60 * 60),
       },
     },
-    toJson: 'SOME_TICKER',
+    toHuman: 'SOME_TICKER',
   }),
   ['Asset']
 );
@@ -995,7 +995,7 @@ const MockNumberedPortfolioClass = createMockEntityClass<NumberedPortfolioOption
     did: 'someDid',
     getCustodian: getIdentityInstance(),
     isCustodiedBy: true,
-    toJson: {
+    toHuman: {
       did: 'someDid',
       id: '1',
     },
@@ -1044,7 +1044,7 @@ const MockDefaultPortfolioClass = createMockEntityClass<DefaultPortfolioOptions>
     did: 'someDid',
     getCustodian: getIdentityInstance(),
     isCustodiedBy: true,
-    toJson: {
+    toHuman: {
       did: 'someDid',
     },
   }),

--- a/src/types/utils/index.ts
+++ b/src/types/utils/index.ts
@@ -21,7 +21,7 @@ export type ArgsType<T> = T extends (...args: infer A) => unknown ? A : never;
 
 /**
  * Recursively traverse a type and transform its Entity properties into their
- *   human readable version (as if `.toJson` had been called on all of them)
+ *   human readable version (as if `.toHuman` had been called on all of them)
  */
 export type HumanReadableType<T> = T extends Entity<unknown, infer H>
   ? HumanReadableType<H>

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -708,13 +708,13 @@ export function isModuleOrTagMatch(a: TxTag | ModuleName, b: TxTag | ModuleName)
  * @hidden
  *
  * Recursively convert a value into a human readable (JSON compliant) version:
- *   - Entities are converted via their `.toJson` method
+ *   - Entities are converted via their `.toHuman` method
  *   - Dates are converted to ISO strings
  *   - BigNumbers are converted to numerical strings
  */
 export function toHumanReadable<T>(obj: T): HumanReadableType<T> {
   if (isEntity<unknown, HumanReadableType<T>>(obj)) {
-    return obj.toJson();
+    return obj.toHuman();
   }
 
   if (obj instanceof BigNumber) {


### PR DESCRIPTION
### Description
All entities had a `toJson` method to convert the Entity properties into their human readable version. That method in all the entities has been renamed to `toHuman`.

### Breaking Changes
🧨 `toJson` method within all entities has been renamed to `toHuman`

### JIRA Link
DA-157

### Checklist
- [ ] Updated the Readme.md (if required) ?