### PR TITLE
fix: 🐛 Add missing validations in `controllerTransfer` proc

### DIFF
--- a/src/api/procedures/__tests__/controllerTransfer.ts
+++ b/src/api/procedures/__tests__/controllerTransfer.ts
@@ -59,7 +59,7 @@ describe('controllerTransfer procedure', () => {
     stringToTickerStub = sinon.stub(utilsConversionModule, 'stringToTicker');
     ticker = 'SOME_TICKER';
     rawTicker = dsMockUtils.createMockTicker(ticker);
-    did = 'someDid';
+    did = 'fakeDid';
     rawPortfolioId = dsMockUtils.createMockPortfolioId({
       did: dsMockUtils.createMockIdentityId(did),
       kind: dsMockUtils.createMockPortfolioKind('Default'),
@@ -92,6 +92,22 @@ describe('controllerTransfer procedure', () => {
   afterAll(() => {
     procedureMockUtils.cleanup();
     dsMockUtils.cleanup();
+  });
+
+  it('should throw an error in case of self Transfer', () => {
+    const selfPortfolio = entityMockUtils.getDefaultPortfolioInstance({
+      did: 'someDid',
+      getAssetBalances: [{ free: new BigNumber(90) }] as PortfolioBalance[],
+    });
+    const proc = procedureMockUtils.getInstance<Params, void>(mockContext);
+
+    return expect(
+      prepareControllerTransfer.call(proc, {
+        ticker,
+        originPortfolio: selfPortfolio,
+        amount: new BigNumber(1000),
+      })
+    ).rejects.toThrow('Transfers to self are not allowed');
   });
 
   it('should throw an error if the Portfolio does not have enough balance to transfer', () => {

--- a/src/api/procedures/controllerTransfer.ts
+++ b/src/api/procedures/controllerTransfer.ts
@@ -46,6 +46,15 @@ export async function prepareControllerTransfer(
 
   const originPortfolioId = portfolioLikeToPortfolioId(originPortfolio);
 
+  const { did } = await context.getSigningIdentity();
+
+  if (did === originPortfolioId.did) {
+    throw new PolymeshError({
+      code: ErrorCode.UnmetPrerequisite,
+      message: 'Transfers to self are not allowed',
+    });
+  }
+
   const fromPortfolio = portfolioIdToPortfolio(originPortfolioId, context);
 
   const [{ free }] = await fromPortfolio.getAssetBalances({

--- a/src/api/procedures/controllerTransfer.ts
+++ b/src/api/procedures/controllerTransfer.ts
@@ -22,6 +22,10 @@ export interface ControllerTransferParams {
   amount: BigNumber;
 }
 
+export interface Storage {
+  did: string;
+}
+
 /**
  * @hidden
  */
@@ -31,13 +35,14 @@ export type Params = { ticker: string } & ControllerTransferParams;
  * @hidden
  */
 export async function prepareControllerTransfer(
-  this: Procedure<Params, void>,
+  this: Procedure<Params, void, Storage>,
   args: Params
 ): Promise<void> {
   const {
     context: {
       polymeshApi: { tx },
     },
+    storage: { did },
     context,
   } = this;
   const { ticker, originPortfolio, amount } = args;
@@ -46,12 +51,10 @@ export async function prepareControllerTransfer(
 
   const originPortfolioId = portfolioLikeToPortfolioId(originPortfolio);
 
-  const { did } = await context.getSigningIdentity();
-
   if (did === originPortfolioId.did) {
     throw new PolymeshError({
       code: ErrorCode.UnmetPrerequisite,
-      message: 'Transfers to self are not allowed',
+      message: 'Controller transfers to self are not allowed',
     });
   }
 
@@ -83,14 +86,16 @@ export async function prepareControllerTransfer(
  * @hidden
  */
 export async function getAuthorization(
-  this: Procedure<Params, void>,
+  this: Procedure<Params, void, Storage>,
   { ticker }: Params
 ): Promise<ProcedureAuthorization> {
-  const { context } = this;
+  const {
+    context,
+    storage: { did },
+  } = this;
 
   const asset = new Asset({ ticker }, context);
 
-  const { did } = await context.getSigningIdentity();
   const portfolioId = { did };
 
   return {
@@ -106,5 +111,18 @@ export async function getAuthorization(
 /**
  * @hidden
  */
-export const controllerTransfer = (): Procedure<Params, void> =>
-  new Procedure(prepareControllerTransfer, getAuthorization);
+export async function prepareStorage(this: Procedure<Params, void, Storage>): Promise<Storage> {
+  const { context } = this;
+
+  const { did } = await context.getSigningIdentity();
+
+  return {
+    did,
+  };
+}
+
+/**
+ * @hidden
+ */
+export const controllerTransfer = (): Procedure<Params, void, Storage> =>
+  new Procedure(prepareControllerTransfer, getAuthorization, prepareStorage);


### PR DESCRIPTION
### Description

`controllerTransfer` procedure used to throw the following error when trying to transfer the Asset to a self Portfolio - 
```
asset.SenderSameAsReceiver:  Transfers to self are not allowed
```
This PR add the missing validation -> checks if the originPortfolio DID is same as the signingIdentity DID, it throws `ErrorCode.UnmetPrerequisite` with apt message

### JIRA Link

DA-304

### Checklist

- [ ] Updated the Readme.md (if required) ?
