### PR TITLE
Da 323/country code enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "ISC",
   "scripts": {
     "start": "cross-env node scripts/generateTsconfigDev.js && cross-env webpack-dev-server --config=webpack.config.dev.js",
-    "generate:polkadot-types": "yarn fetch-metadata && yarn fetch-definitions && yarn generate:defs && yarn generate:meta && yarn generate:tags && yarn generate:post-process",
+    "generate:polkadot-types": "yarn fetch-metadata && yarn fetch-definitions && yarn generate:defs && yarn generate:meta && yarn generate:tags && yarn generate:country-codes && yarn generate:post-process",
     "generate:middleware-types": "graphql-codegen -r dotenv/config",
     "fetch-definitions": "cross-env node scripts/fetchDefinitions.js",
     "fetch-metadata": "sh scripts/fetchMetadata.sh",
@@ -16,6 +16,7 @@
     "generate:defs": "ts-node --skip-project node_modules/.bin/polkadot-types-from-defs --endpoint metadata.json --package polymesh-types --input ./src/polkadot/",
     "generate:meta": "ts-node --skip-project node_modules/.bin/polkadot-types-from-chain --endpoint metadata.json --package polymesh-types --output ./src/polkadot --strict",
     "generate:tags": "cross-env node scripts/generateTxTags.js",
+    "generate:country-codes": "cross-env node scripts/generateCountryCodes.js",
     "generate:post-process": "cross-env node scripts/postProcessTypes.js",
     "test": "jest --detectOpenHandles --coverage",
     "test:no-cov": "jest --detectOpenHandles",

--- a/scripts/generateCountryCodes.js
+++ b/scripts/generateCountryCodes.js
@@ -1,0 +1,78 @@
+/*
+ * Author: Jeremías Díaz (monitz87)
+ *
+ * This script generates the `CountryCode` enum and the related conversion utility functions
+ *   (`countryCodeToMeshCountryCode` and `meshCountryCodeToCountryCode`) from the chain metadata.
+ *
+ * NOTE: it is assumed that the metadata has been previously fetched by the `fetchMetadata.js` script, and stored
+ *   in `metadata.json`
+ */
+
+/* eslint-disable */
+const { Metadata } = require('@polkadot/types');
+const { TypeRegistry } = require('@polkadot/types/create');
+const fs = require('fs');
+const path = require('path');
+const { upperFirst, toLower, capitalize } = require('lodash');
+
+const metadataFile = fs.readFileSync('metadata.json').toString('utf8');
+
+const registry = new TypeRegistry();
+
+const metadata = new Metadata(registry, JSON.parse(metadataFile).result);
+const lookup = metadata.asLatest.lookup;
+
+const countryCodes = lookup.types.find(({ type: { path } }) => {
+  const typeName = path[2];
+  return typeName && typeName.toString() === 'CountryCode';
+}).type.def.asVariant.variants;
+
+const instanbulIgnore = '/* istanbul ignore file */';
+let typesFile = `${instanbulIgnore}
+
+`;
+let utilsFile = `${instanbulIgnore}
+
+import { CountryCode as MeshCountryCode } from 'polymesh-types/types';
+
+import { Context } from '~/internal';
+import { CountryCode } from '~/types';
+
+`;
+
+let countryCodeEnum = 'export enum CountryCode {';
+let countryCodeFunctions = `/**
+ * @hidden
+ */
+export function countryCodeToMeshCountryCode(countryCode: CountryCode, context: Context): MeshCountryCode {
+  return context.polymeshApi.createType('CountryCode', countryCode);
+}
+
+/**
+ * @hidden
+ */
+export function meshCountryCodeToCountryCode(meshCountryCode: MeshCountryCode): CountryCode {`;
+
+countryCodes.forEach((code, index) => {
+  const isLast = index === countryCodes.length - 1;
+  const pascalCaseCode = capitalize(code.name.toString());
+
+  countryCodeEnum = `${countryCodeEnum}\n  ${pascalCaseCode} = '${pascalCaseCode}',${
+    isLast ? '\n}' : ''
+  }`;
+
+  const returnStatement = `return CountryCode.${pascalCaseCode}`;
+  if (isLast) {
+    countryCodeFunctions = `${countryCodeFunctions}\n  ${returnStatement};\n}`;
+  } else {
+    countryCodeFunctions = `${countryCodeFunctions}\n  if (meshCountryCode.is${pascalCaseCode}) {\n    ${returnStatement};\n  }\n`;
+  }
+});
+
+typesFile = `${typesFile}${countryCodeEnum}\n`;
+utilsFile = `${utilsFile}${countryCodeFunctions}\n`;
+
+const generatedDir = path.resolve('src', 'generated');
+
+fs.writeFileSync(path.resolve(generatedDir, 'types.ts'), typesFile);
+fs.writeFileSync(path.resolve(generatedDir, 'utils.ts'), utilsFile);

--- a/scripts/generateTxTags.js
+++ b/scripts/generateTxTags.js
@@ -1,85 +1,77 @@
 /* eslint-disable */
 const { Metadata } = require('@polkadot/types');
-const { w3cwebsocket } = require('websocket');
 const { TypeRegistry } = require('@polkadot/types/create');
 const { stringCamelCase, stringUpperFirst } = require('@polkadot/util');
 const { forEach } = require('lodash');
 const fs = require('fs');
 const path = require('path');
 const rimraf = require('rimraf');
-const { NODE_URL, WS_PORT } = require('./consts');
 
-const websocket = new w3cwebsocket(`ws://${NODE_URL}:${WS_PORT}`);
-websocket.onopen = () => {
-  websocket.send('{"id":"1","jsonrpc":"2.0","method":"state_getMetadata","params":[]}');
-};
-websocket.onmessage = message => {
-  let namespaces = '';
-  let moduleNameEnum = 'export enum ModuleName {';
-  let modulePermissions = 'export type ModulePermissions =';
-  let txTag = 'export type TxTag =';
-  let txTags = 'export const TxTags = {\n';
+const metadataFile = fs.readFileSync('metadata.json').toString('utf8');
 
-  const jsonPath = path.resolve('scripts', 'transactions.json');
+let namespaces = '';
+let moduleNameEnum = 'export enum ModuleName {';
+let modulePermissions = 'export type ModulePermissions =';
+let txTag = 'export type TxTag =';
+let txTags = 'export const TxTags = {\n';
 
-  const transactionData = JSON.parse(fs.readFileSync(jsonPath));
+const jsonPath = path.resolve('scripts', 'transactions.json');
 
-  const registry = new TypeRegistry();
+const transactionData = JSON.parse(fs.readFileSync(jsonPath));
 
-  const metadata = new Metadata(registry, JSON.parse(message.data).result);
-  const modules = metadata.asLatest.pallets;
+const registry = new TypeRegistry();
 
-  // add new calls to historic ones
-  modules.forEach(({ name, calls }) => {
-    const allCalls = calls.unwrapOr(null);
-    const moduleName = name.toString();
+const metadata = new Metadata(registry, JSON.parse(metadataFile).result);
+const modules = metadata.asLatest.pallets;
 
-    if (allCalls && allCalls.length) {
-      const moduleCalls = (transactionData[moduleName] = transactionData[moduleName] || {});
+// add new calls to historic ones
+modules.forEach(({ name, calls }) => {
+  const allCalls = calls.unwrapOr(null);
+  const moduleName = name.toString();
 
-      allCalls.forEach(({ name: cName }) => {
-        const callName = cName.toString();
-        moduleCalls[callName] = callName;
-      });
-    }
-  });
+  if (allCalls && allCalls.length) {
+    const moduleCalls = (transactionData[moduleName] = transactionData[moduleName] || {});
 
-  forEach(transactionData, (calls, moduleName) => {
-    const moduleNameCamelCase = stringCamelCase(moduleName);
-    const moduleNamePascal = stringUpperFirst(moduleNameCamelCase);
-
-    moduleNameEnum = moduleNameEnum.concat(`\n  ${moduleNamePascal} = '${moduleNameCamelCase}',`);
-    modulePermissions = modulePermissions.concat(
-      `\n  | { moduleName: ModuleName.${moduleNamePascal}; permissions: SectionPermissions<${moduleNamePascal}Tx> }`
-    );
-    txTag = txTag.concat(`\n  | ${moduleNamePascal}Tx`);
-    txTags = txTags.concat(`  ${stringCamelCase(moduleName)}: ${moduleNamePascal}Tx,\n`);
-
-    namespaces = namespaces.concat(`export enum ${moduleNamePascal}Tx {\n`);
-
-    forEach(calls, callName => {
-      const nameCamelCase = stringCamelCase(callName);
-      const namePascal = stringUpperFirst(nameCamelCase);
-
-      namespaces = namespaces.concat(
-        `  ${namePascal} = '${moduleNameCamelCase}.${nameCamelCase}',\n`
-      );
+    allCalls.forEach(({ name: cName }) => {
+      const callName = cName.toString();
+      moduleCalls[callName] = callName;
     });
+  }
+});
 
-    namespaces = namespaces.concat('}\n\n');
+forEach(transactionData, (calls, moduleName) => {
+  const moduleNameCamelCase = stringCamelCase(moduleName);
+  const moduleNamePascal = stringUpperFirst(moduleNameCamelCase);
+
+  moduleNameEnum = moduleNameEnum.concat(`\n  ${moduleNamePascal} = '${moduleNameCamelCase}',`);
+  modulePermissions = modulePermissions.concat(
+    `\n  | { moduleName: ModuleName.${moduleNamePascal}; permissions: SectionPermissions<${moduleNamePascal}Tx> }`
+  );
+  txTag = txTag.concat(`\n  | ${moduleNamePascal}Tx`);
+  txTags = txTags.concat(`  ${stringCamelCase(moduleName)}: ${moduleNamePascal}Tx,\n`);
+
+  namespaces = namespaces.concat(`export enum ${moduleNamePascal}Tx {\n`);
+
+  forEach(calls, callName => {
+    const nameCamelCase = stringCamelCase(callName);
+    const namePascal = stringUpperFirst(nameCamelCase);
+
+    namespaces = namespaces.concat(
+      `  ${namePascal} = '${moduleNameCamelCase}.${nameCamelCase}',\n`
+    );
   });
 
-  moduleNameEnum = moduleNameEnum.concat('\n}');
-  modulePermissions = modulePermissions.concat(';');
-  txTag = txTag.concat(';');
-  txTags = txTags.concat('};');
+  namespaces = namespaces.concat('}\n\n');
+});
 
-  fs.appendFileSync(
-    path.resolve('src', 'polkadot', 'types.ts'),
-    '\n'.concat(namespaces).concat(`${moduleNameEnum}\n\n${txTag}\n\n${txTags}\n`)
-  );
-  rimraf.sync(jsonPath);
-  fs.writeFileSync(jsonPath, `${JSON.stringify(transactionData, null, 2)}\n`);
+moduleNameEnum = moduleNameEnum.concat('\n}');
+modulePermissions = modulePermissions.concat(';');
+txTag = txTag.concat(';');
+txTags = txTags.concat('};');
 
-  websocket.close();
-};
+fs.appendFileSync(
+  path.resolve('src', 'polkadot', 'types.ts'),
+  '\n'.concat(namespaces).concat(`${moduleNameEnum}\n\n${txTag}\n\n${txTags}\n`)
+);
+rimraf.sync(jsonPath);
+fs.writeFileSync(jsonPath, `${JSON.stringify(transactionData, null, 2)}\n`);


### PR DESCRIPTION
### Description

This PR moves generation of the `CountryCode` enum and its respective conversion utils to its own script, which uses the fetched metadata instead of the schema. 

It also modifies the script that generates TxTags to use the previously fetched metadata instead of fetching it again

### JIRA Link

https://polymath.atlassian.net/browse/DA-321

### Checklist

- [ ] Updated the Readme.md (if required) ?
