### PR TITLE
fix: 🐛 Pin polkadot dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@graphql-codegen/typescript": "1.22.1",
     "@open-wc/webpack-import-meta-loader": "^0.4.7",
     "@ovos-media/ts-transform-paths": "^1.7.18-1",
-    "@polkadot/typegen": "^8.0.2",
+    "@polkadot/typegen": "8.0.2",
     "@polymathnetwork/signing-manager-types": "^1.0.3",
     "@polymathnetwork/local-signing-manager": "^1.0.3",
     "@semantic-release/changelog": "^6.0.1",
@@ -108,9 +108,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@polkadot/api": "^8.0.2",
-    "@polkadot/util": "^9.0.1",
-    "@polkadot/util-crypto": "^9.0.1",
+    "@polkadot/api": "8.0.2",
+    "@polkadot/util": "9.0.1",
+    "@polkadot/util-crypto": "9.0.1",
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",
     "apollo-link": "^1.2.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3264,7 +3264,7 @@
     "@polkadot/util-crypto" "^9.0.1"
     rxjs "^7.5.5"
 
-"@polkadot/api@8.0.2", "@polkadot/api@^8.0.2":
+"@polkadot/api@8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-8.0.2.tgz#3411ec0beea33160b71455da7f6cad0461819cae"
   integrity sha512-/cE6rCrLvSQ9EEfSULctDn/VzfgD/wB9yfd7T0pfqeAXbA2QKYykq2QI77tsi1kfF3+cWScoj7hCYsgAFhRVRw==
@@ -3347,7 +3347,7 @@
     mock-socket "^9.1.2"
     nock "^13.2.4"
 
-"@polkadot/typegen@^8.0.2":
+"@polkadot/typegen@8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@polkadot/typegen/-/typegen-8.0.2.tgz#7f9fe8c1adbd3a18e94f5c4124dcc99e3eba5bd5"
   integrity sha512-3ScODNXPjmGAsavoqXhWQo/20SwAMebfnMI0GC7H755F2FsWTU+AZQ28cZPzYmJeOJTbfzwW1oXjqtgGsyz6CQ==


### PR DESCRIPTION
### Description
polkadot api introduced breaking changes with their BTreeSet around
8.3.1. We need to pin our dependencies so consumers get a working
version

### Breaking Changes

### JIRA Link

Issue discovered when working on [DA-348](https://polymath.atlassian.net/browse/DA-348)

### Checklist

- [ ] Updated the Readme.md (if required) ?
