### PR TITLE
feat: 🎸 Proper calculation of investor count with PUIS enabled

### DIFF
--- a/src/api/entities/Asset/index.ts
+++ b/src/api/entities/Asset/index.ts
@@ -491,8 +491,8 @@ export class Asset extends Entity<UniqueIdentifiers, string> {
     if (boolToBoolean(iuDisabled)) {
       const balanceEntries = await balanceOf.entries(rawTicker);
 
-      const assetBalances = balanceEntries.filter(([, balance]) =>
-        balanceToBigNumber(balance).gt(new BigNumber(0))
+      const assetBalances = balanceEntries.filter(
+        ([, balance]) => !balanceToBigNumber(balance).isZero()
       );
 
       return new BigNumber(assetBalances.length);
@@ -512,13 +512,11 @@ export class Asset extends Entity<UniqueIdentifiers, string> {
         },
         balance,
       ]) => {
-        if (balanceToBigNumber(balance).gt(new BigNumber(0))) {
+        if (!balanceToBigNumber(balance).isZero()) {
           assetHolders.add(scopeIdToString(scopeId));
         }
       }
     );
-
-    assetHolders.forEach(x => console.log(x.toString()));
 
     return new BigNumber(assetHolders.size);
   }

--- a/src/api/entities/Asset/index.ts
+++ b/src/api/entities/Asset/index.ts
@@ -500,12 +500,12 @@ export class Asset extends Entity<UniqueIdentifiers, string> {
 
     const scopeIdEntries = await scopeIdOf.entries(rawTicker);
 
-    const balanceEntries = await Promise.all(
+    const scopeBalanceEntries = await Promise.all(
       scopeIdEntries.map(([, scopeId]) => balanceOfAtScope.entries(scopeId))
     );
 
     const assetHolders = new Set<string>();
-    flatten(balanceEntries).forEach(
+    flatten(scopeBalanceEntries).forEach(
       ([
         {
           args: [scopeId],

--- a/src/api/entities/Asset/index.ts
+++ b/src/api/entities/Asset/index.ts
@@ -1,6 +1,8 @@
 import { bool, Option, StorageKey } from '@polkadot/types';
+import { Balance } from '@polkadot/types/interfaces';
 import { BlockNumber, Hash } from '@polkadot/types/interfaces/runtime';
 import BigNumber from 'bignumber.js';
+import { flatten } from 'lodash';
 import {
   AgentGroup,
   AssetName,
@@ -55,7 +57,6 @@ import {
   stringToTicker,
   textToString,
   tickerToDid,
-  u64ToBigNumber,
 } from '~/utils/conversion';
 import { createProcedureMethod, optionize, padString } from '~/utils/internal';
 
@@ -469,20 +470,14 @@ export class Asset extends Entity<UniqueIdentifiers, string> {
    * @note this takes into account the Scope ID of Investor Uniqueness Claims. If an investor holds balances
    *   of this Asset in two or more different Identities, but they all have Investor Uniqueness Claims with the same
    *   Scope ID, then they will only be counted once for the purposes of this result
-   *
-   * @note can be subscribed to
    */
-  public investorCount(): Promise<BigNumber>;
-  public investorCount(callback: SubCallback<BigNumber>): Promise<UnsubCallback>;
-
-  // eslint-disable-next-line require-jsdoc
-  public async investorCount(
-    callback?: SubCallback<BigNumber>
-  ): Promise<BigNumber | UnsubCallback> {
+  public async investorCount(): Promise<BigNumber> {
     const {
       context: {
         polymeshApi: {
-          query: { statistics },
+          query: {
+            asset: { disableInvestorUniqueness, scopeIdOf, balanceOfAtScope, balanceOf },
+          },
         },
       },
       context,
@@ -491,16 +486,28 @@ export class Asset extends Entity<UniqueIdentifiers, string> {
 
     const rawTicker = stringToTicker(ticker, context);
 
-    if (callback) {
-      return statistics.investorCountPerAsset(rawTicker, count => {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises -- callback errors should be handled by the caller
-        callback(u64ToBigNumber(count));
-      });
+    const iuDisabled = await disableInvestorUniqueness(rawTicker);
+
+    const assembleResult = (balanceEntries: [StorageKey, Balance][]): BigNumber => {
+      const assetBalances = balanceEntries.filter(([, balance]) =>
+        balanceToBigNumber(balance).gt(new BigNumber(0))
+      );
+
+      return new BigNumber(assetBalances.length);
+    };
+
+    if (boolToBoolean(iuDisabled)) {
+      const balanceEntries = await balanceOf.entries(rawTicker);
+      return assembleResult(balanceEntries);
     }
 
-    const result = await statistics.investorCountPerAsset(stringToTicker(ticker, context));
+    const scopeIdEntries = await scopeIdOf.entries(rawTicker);
 
-    return u64ToBigNumber(result);
+    const balanceEntries = await Promise.all(
+      scopeIdEntries.map(([, scopeId]) => balanceOfAtScope.entries(scopeId))
+    );
+
+    return assembleResult(flatten(balanceEntries));
   }
 
   /**


### PR DESCRIPTION
### Description

This changes the logic for calculation of investor count for an asset. 
* If PUIS is disabled, `asset.balanceOf` is used to fetch count of identities with non-zero balances. 
* If PUIS is enabled, `asset.scopeIdOf` is used to lookup all ScopeIds for a ticker before the count of identities with non-zero balances is queried using `asset.balanceOfAtScope`.

### JIRA Link

DA-322

### Checklist

- [ ] Updated the Readme.md (if required) ?
